### PR TITLE
Android: Prefer external storage

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="0.5.99" android:versionCode="1" package="org.openorienteering.mapper" android:installLocation="auto">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="0.5.99" android:versionCode="1" package="org.openorienteering.mapper" android:installLocation="preferExternal">
     <application android:name="org.qtproject.qt5.android.bindings.QtApplication" android:label="@string/app_name" android:icon="@drawable/icon">
         <activity android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|locale|fontScale|keyboard|keyboardHidden|navigation"
                   android:name="org.openorienteering.mapper.MapperActivity"


### PR DESCRIPTION
Currently App Install Location is set to Auto this results in that Mapper first will be installed to the system storage, then the user can move the app to external storage if they wish to do so. If Mapper instead preferred external storage the app would be installed and downloaded to the external storage if such is available. The user would still be able to move the app to the system storage after the installation.

(Short story: for most users system storage is more valued then external storage.)

Example of an user benefiting from this approach: 

Currently the user has a lot of space available on his/her SD card but the system storage is almost full, this results in that the he/she can't download the app because it would first be downloaded to the system storage. If it would first be downloaded to the SD card this issue would never have happen.

