### PR TITLE
Fix broken Swedish translation for zoom factor

### DIFF
--- a/translations/OpenOrienteering_sv.ts
+++ b/translations/OpenOrienteering_sv.ts
@@ -4523,7 +4523,7 @@ valda</translation>
         <location filename="../src/map_widget.cpp" line="542"/>
         <source>%1x</source>
         <comment>Zoom factor</comment>
-        <translation>Zoom faktor</translation>
+        <translation>%1x</translation>
     </message>
     <message>
         <location filename="../src/map_widget.cpp" line="563"/>


### PR DESCRIPTION
This was caused by the earlier update to the translations but first discovered now.