### PR TITLE
Set QT_SELECT=5 instead of QT_SELECT=qt5 env variable for Assistant

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -282,7 +282,7 @@ void showHelp(QWidget* dialog_parent, QString filename)
 		
 #if defined(Q_OS_LINUX)
 		auto env = QProcessEnvironment::systemEnvironment();
-		env.insert(QLatin1String("QT_SELECT"), QLatin1String("qt5")); // #541
+		env.insert(QLatin1String("QT_SELECT"), QLatin1String("5")); // #541
 		assistant_process.setProcessEnvironment(env);
 #endif
 		


### PR DESCRIPTION
The problem is that I couldn't open the manual (just nothing happened, no error messages).
After looking at `strace ./Mapper` output, I discovered the follow error:
`assistant: could not find a Qt installation of 'qt5'`
Ther reason is that on ArchLinux/LFS:
```
> qtchooser -list-versions
4
5
default

```
But #541 works for Debian/Ubuntu, where both qt5 and 5 exist.