### PR TITLE
Added MIME types of *.omap and *.xmap files

### DIFF
--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -457,12 +457,25 @@ if(UNIX AND NOT APPLE)
 	install(
 	  FILES "debian/Mapper.desktop"
 	  DESTINATION "share/applications")
+	install(
+	  FILES "debian/openorienteering-mapper.xml"
+	  DESTINATION "share/mime/packages")
 	# Cf. http://standards.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html#directory_layout
 	foreach(_size 16 24 32 48 96 128 256 512)
 		install(
 		  FILES "${PROJECT_SOURCE_DIR}/images/mapper-icon/Mapper-${_size}.png"
 		  DESTINATION "share/icons/hicolor/${_size}x${_size}/apps"
 		  RENAME Mapper.png
+		)
+		install(
+		  FILES "${PROJECT_SOURCE_DIR}/images/mapper-icon/Mapper-${_size}.png"
+		  DESTINATION "share/icons/hicolor/${_size}x${_size}/mimetypes"
+		  RENAME application-x-openorienteering-omap.png
+		)
+		install(
+		  FILES "${PROJECT_SOURCE_DIR}/images/mapper-icon/Mapper-${_size}.png"
+		  DESTINATION "share/icons/hicolor/${_size}x${_size}/mimetypes"
+		  RENAME application-x-openorienteering-xmap.png
 		)
 	endforeach()
 endif()

--- a/packaging/debian/Mapper.desktop
+++ b/packaging/debian/Mapper.desktop
@@ -8,3 +8,4 @@ Exec=Mapper %F
 Icon=Mapper
 Terminal=false
 Categories=Graphics;Qt;
+MimeType=application/x-openorienteering-omap;application/x-openorienteering-xmap;

--- a/packaging/debian/openorienteering-mapper.xml
+++ b/packaging/debian/openorienteering-mapper.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+   <mime-type type="application/x-openorienteering-omap">
+     <comment>Orienteering map</comment>
+     <comment xml:lang="ru">Спортивная карта</comment>
+     <glob pattern="*.omap"/>
+   </mime-type>
+   <mime-type type="application/x-openorienteering-xmap">
+     <comment>Orienteering map</comment>
+     <comment xml:lang="ru">Спортивная карта</comment>
+     <glob pattern="*.xmap"/>
+   </mime-type>
+</mime-info>

--- a/packaging/debian/openorienteering-mapper.xml
+++ b/packaging/debian/openorienteering-mapper.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
    <mime-type type="application/x-openorienteering-omap">
+     <sub-class-of type="text/xml"/>
      <comment>Orienteering map</comment>
      <comment xml:lang="ru">Спортивная карта</comment>
      <glob pattern="*.omap"/>
    </mime-type>
    <mime-type type="application/x-openorienteering-xmap">
+     <sub-class-of type="text/xml"/>
      <comment>Orienteering map</comment>
      <comment xml:lang="ru">Спортивная карта</comment>
      <glob pattern="*.xmap"/>


### PR DESCRIPTION
Added MIME types:

- application/x-openorienteering-omap for *.omap files;
- application/x-openorienteering-xmap for *.xmap files.
Associated these MIME types with OOMapper.

Tested in Xununtu 14.04 with Thunar and Nautilus.

Issue #756 