### PR TITLE
Add missing qtbase5-private-dev package in INSTALL.md for Linux build

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -74,7 +74,7 @@ PROJ.4 library and of CUPS are installed. For a Ubuntu or Debian system, install
 
 For using the Qt libraries provided by the repositories, the following packages
 need to be installed:
-`qt5-default` (>= 5.2), `qttools5-dev`, `qttools5-dev-tools`, `libqt5sql5-sqlite`
+`qt5-default` (>= 5.2), `qtbase5-private-dev`, `qttools5-dev`, `qttools5-dev-tools`, `libqt5sql5-sqlite`
 
 Open a terminal, and create a build directory, e.g. as subdirectory build in
 the source directory, and change to that directory. From the build directory,


### PR DESCRIPTION
I also removed commas so that one can copy the whole line directly to the terminal.