### PR TITLE
Fix CRT symbol mapping when symbol has a minor number

### DIFF
--- a/src/gui/symbols/replace_symbol_set_dialog.cpp
+++ b/src/gui/symbols/replace_symbol_set_dialog.cpp
@@ -438,7 +438,7 @@ bool ReplaceSymbolSetDialog::showDialogForCRT(QWidget* parent, const Map* base_m
 					{
 						auto layerized_symbol = object_symbol->duplicate();
 						layerized_symbol->setNumberComponent(0, symbol->getNumberComponent(0));
-						layerized_symbol->setNumberComponent(1, symbol->getNumberComponent(2));
+						layerized_symbol->setNumberComponent(1, symbol->getNumberComponent(1));
 						layerized_symbol->setNumberComponent(2, symbol->getNumberComponent(2));
 						layerized_symbol->setName(layer);
 						imported_map->addSymbol(layerized_symbol, imported_map->getNumSymbols());


### PR DESCRIPTION
Currently the code won't match up symbols correctly if the target symbol has a minor number due to a typo.