### PR TITLE
Area symbol: Prepare alternatives to pattern clipping

### DIFF
--- a/src/core/symbols/area_symbol.cpp
+++ b/src/core/symbols/area_symbol.cpp
@@ -215,6 +215,13 @@ void AreaSymbol::FillPattern::setRotatable(bool value)
 
 
 
+void AreaSymbol::FillPattern::setClipping(Options clipping)
+{
+	flags = (flags & ~Option::AlternativeToClipping) | (clipping & Option::AlternativeToClipping);
+}
+
+
+
 void AreaSymbol::FillPattern::colorDeleted(const MapColor* color)
 {
 	switch (type)

--- a/src/core/symbols/area_symbol.cpp
+++ b/src/core/symbols/area_symbol.cpp
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 
+#include <QtMath>
 #include <QIODevice>
 #include <QXmlStreamReader>
 #include <QXmlStreamWriter>
@@ -168,7 +169,7 @@ bool AreaSymbol::FillPattern::equals(const AreaSymbol::FillPattern& other, Qt::C
 {
 	if (type != other.type)
 		return false;
-	if (qAbs(angle - other.angle) > 1e-05)
+	if (qAbs(angle - other.angle) > 1e-05f)
 		return false;
 	if (flags != other.flags)
 		return false;
@@ -311,8 +312,8 @@ void AreaSymbol::FillPattern::createRenderables(QRectF extent, float delta_rotat
 	extent = QRectF(extent.topLeft() - fill_extent.bottomRight(), extent.bottomRight() - fill_extent.topLeft());
 	
 	// Fill
-	float delta_line_offset = 0;
-	float delta_along_line_offset = 0;
+	qreal delta_line_offset = 0;
+	qreal delta_along_line_offset = 0;
 	if (rotatable())
 	{
 		MapCoordF line_normal(0, -1);
@@ -326,7 +327,7 @@ void AreaSymbol::FillPattern::createRenderables(QRectF extent, float delta_rotat
 		delta_along_line_offset = MapCoordF::dotProduct(line_tangent, MapCoordF(pattern_origin));
 	}
 	
-	const float offset = 0.001f * line_offset + delta_line_offset;
+	const auto offset = 0.001 * line_offset + delta_line_offset;
 	if (qAbs(rotation - M_PI/2) < 0.0001)
 	{
 		// Special case: vertical lines
@@ -357,23 +358,23 @@ void AreaSymbol::FillPattern::createRenderables(QRectF extent, float delta_rotat
 		if (rotation < M_PI / 2)
 			delta_along_line_offset = -delta_along_line_offset;
 		
-		float xfactor = 1.0f / sin(rotation);
-		float yfactor = 1.0f / cos(rotation);
+		auto xfactor = 1.0 / sin(rotation);
+		auto yfactor = 1.0 / cos(rotation);
 		
-		float dist_x = xfactor * line_spacing_f;
-		float dist_y = yfactor * line_spacing_f;
-		float offset_x = xfactor * offset;
-		float offset_y = yfactor * offset;
+		auto dist_x = xfactor * line_spacing_f;
+		auto dist_y = yfactor * line_spacing_f;
+		auto offset_x = xfactor * offset;
+		auto offset_y = yfactor * offset;
 		
 		if (rotation < M_PI/2)
 		{
 			// Start with the upper left corner
 			offset_x += (-extent.top()) / tan(rotation);
 			offset_y -= extent.left() * tan(rotation);
-			float start_x = offset_x + ceil((extent.x() - offset_x) / dist_x) * dist_x;
-			float start_y = extent.top();
-			float end_x = extent.left();
-			float end_y = offset_y + ceil((extent.y() - offset_y) / dist_y) * dist_y;
+			auto start_x = offset_x + ceil((extent.x() - offset_x) / dist_x) * dist_x;
+			auto start_y = extent.top();
+			auto end_x = extent.left();
+			auto end_y = offset_y + ceil((extent.y() - offset_y) / dist_y) * dist_y;
 			
 			do
 			{
@@ -407,10 +408,10 @@ void AreaSymbol::FillPattern::createRenderables(QRectF extent, float delta_rotat
 			// Start with left lower corner
 			offset_x += (-extent.bottom()) / tan(rotation);
 			offset_y -= extent.x() * tan(rotation);
-			float start_x = offset_x + ceil((extent.x() - offset_x) / dist_x) * dist_x;
-			float start_y = extent.bottom();
-			float end_x = extent.x();
-			float end_y = offset_y + ceil((extent.bottom() - offset_y) / dist_y) * dist_y;
+			auto start_x = offset_x + ceil((extent.x() - offset_x) / dist_x) * dist_x;
+			auto start_y = extent.bottom();
+			auto end_x = extent.x();
+			auto end_y = offset_y + ceil((extent.bottom() - offset_y) / dist_y) * dist_y;
 			
 			do
 			{
@@ -442,7 +443,7 @@ void AreaSymbol::FillPattern::createRenderables(QRectF extent, float delta_rotat
 	}
 }
 
-void AreaSymbol::FillPattern::createLine(MapCoordF first, MapCoordF second, float delta_offset, LineSymbol* line, float rotation, ObjectRenderables& output) const
+void AreaSymbol::FillPattern::createLine(MapCoordF first, MapCoordF second, qreal delta_offset, LineSymbol* line, float rotation, ObjectRenderables& output) const
 {
 	if (type == LinePattern)
 	{
@@ -593,7 +594,7 @@ void AreaSymbol::createHatchingRenderables(
 		area_symbol.setNumFillPatterns(1);
 		AreaSymbol::FillPattern& pattern = area_symbol.getFillPattern(0);
 		pattern.type = AreaSymbol::FillPattern::LinePattern;
-		pattern.angle = 45 * M_PI / 180.0f;
+		pattern.angle = qDegreesToRadians(45.0f);
 		pattern.line_spacing = 1000;
 		pattern.line_offset = 0;
 		pattern.line_color = color;

--- a/src/core/symbols/area_symbol.cpp
+++ b/src/core/symbols/area_symbol.cpp
@@ -291,27 +291,26 @@ void AreaSymbol::FillPattern::createRenderables(QRectF extent, float delta_rotat
 	
 	MapCoordF first, second;
 	
-	// Determine real extent to fill
-	QRectF fill_extent;
-	if (type == LinePattern)
+	// Adjust extent wrt fill pattern size
+	switch (type)
 	{
-		
-		if (qAbs(rotation - M_PI/2) < 0.0001)
-			fill_extent = QRectF(-0.5 * line_width_f, 0, line_width_f, 0);	// horizontal lines
-		else if (qAbs(rotation - 0) < 0.0001)
-			fill_extent = QRectF(0, -0.5 * line_width_f, 0, line_width_f);	// verticallines
-		else
-			fill_extent = QRectF(-0.5 * line_width_f, -0.5 * line_width_f, line_width_f, line_width_f);	// not the 100% optimum but the performance gain is surely neglegible
+	case LinePattern:
+		{
+			auto margin = line_width_f / 2;
+			extent.adjust(-margin, -margin, margin, margin);
+		}
+		break;
+	case PointPattern:
+		if (point)
+		{
+			PointObject point_object(point);
+			point_object.setRotation(delta_rotation);
+			point_object.update();
+			auto point_extent = point_object.getExtent();
+			extent.adjust(-point_extent.right(), -point_extent.bottom(), -point_extent.left(), -point_extent.top());
+		}
+		break;
 	}
-	else if (point)
-	{
-		// TODO: Ugly method to get the point's extent
-		PointObject point_object(point);
-		point_object.setRotation(delta_rotation);
-		point_object.update();
-		fill_extent = point_object.getExtent();
-	}
-	extent = QRectF(extent.topLeft() - fill_extent.bottomRight(), extent.bottomRight() - fill_extent.topLeft());
 	
 	// Fill
 	qreal delta_line_offset = 0;

--- a/src/core/symbols/area_symbol.cpp
+++ b/src/core/symbols/area_symbol.cpp
@@ -108,6 +108,8 @@ void AreaSymbol::FillPattern::save(QXmlStreamWriter& xml, const Map& map) const
 	XmlElementWriter element { xml, QLatin1String("pattern") };
 	element.writeAttribute(QLatin1String("type"), type);
 	element.writeAttribute(QLatin1String("angle"), angle);
+	if (auto no_clipping = int(flags & Option::AlternativeToClipping))
+		element.writeAttribute(QLatin1String("no_clipping"), no_clipping);
 	if (rotatable())
 		element.writeAttribute(QLatin1String("rotatable"), true);
 	element.writeAttribute(QLatin1String("line_spacing"), line_spacing);
@@ -134,10 +136,10 @@ void AreaSymbol::FillPattern::load(QXmlStreamReader& xml, const Map& map, Symbol
 {
 	Q_ASSERT (xml.name() == QLatin1String("pattern"));
 	
-	flags = Option::Default;
 	XmlElementReader element { xml };
 	type = element.attribute<Type>(QLatin1String("type"));
 	angle = element.attribute<float>(QLatin1String("angle"));
+	flags = Options{element.attribute<int>(QLatin1String("no_clipping")) & Option::AlternativeToClipping};
 	if (element.attribute<bool>(QLatin1String("rotatable")))
 		flags |= Option::Rotatable;
 	line_spacing = element.attribute<int>(QLatin1String("line_spacing"));

--- a/src/core/symbols/area_symbol.cpp
+++ b/src/core/symbols/area_symbol.cpp
@@ -742,9 +742,13 @@ bool AreaSymbol::equalsImpl(const Symbol* other, Qt::CaseSensitivity case_sensit
 	if (minimum_area != area->minimum_area)
 		return false;
 	
-	// TODO: Fill patterns are only compared in order
 	if (patterns.size() != area->patterns.size())
 		return false;
+	
+	// std::is_permutation would identify equal sets of patterns.
+	// However, guessDominantColor() depends on pattern order if there is no
+	// AreaSymbol::color (or after the AreaSymbol::color is set to nullptr).
+	// So equalsImpl cannot be changed unless guessDominantColor is changed.
 	return std::equal(begin(patterns), end(patterns), begin(area->patterns), [case_sensitivity](auto& lhs, auto& rhs){
 		return lhs.equals(rhs, case_sensitivity);
 	});

--- a/src/core/symbols/area_symbol.h
+++ b/src/core/symbols/area_symbol.h
@@ -24,6 +24,7 @@
 
 #include "symbol.h"
 
+class AreaRenderable;
 class PointObject;
 
 
@@ -140,14 +141,14 @@ public:
 		
 		
 		/**
-		 * Creates renderables for this pattern in the area given by extent.
-		 * @param extent Rectangular area to create renderables for.
+		 * Creates renderables for this pattern to fill the area surrounded by the outline.
+		 * @param outline A renderable giving the extent and outline.
 		 * @param delta_rotation Rotation offest which is added to the pattern angle.
 		 * @param pattern_origin Origin point for line / point placement.
 		 * @param output Created renderables will be inserted here.
 		 */
 		void createRenderables(
-			QRectF extent,
+			const AreaRenderable& outline,
 			float delta_rotation,
 			const MapCoord& pattern_origin,
 			ObjectRenderables& output

--- a/src/core/symbols/area_symbol.h
+++ b/src/core/symbols/area_symbol.h
@@ -160,6 +160,8 @@ public:
 			qreal delta_offset,
 			LineSymbol* line,
 			float rotation,
+			const AreaRenderable& outline,
+			QRectF point_extent,
 			ObjectRenderables& output
 		) const;
 		

--- a/src/core/symbols/area_symbol.h
+++ b/src/core/symbols/area_symbol.h
@@ -125,6 +125,17 @@ public:
 		
 		
 		/**
+		 * Returns the flags which control drawing at boundary.
+		 */
+		Options clipping() const;
+		
+		/**
+		 * Sets the flags which control drawing at boundary.
+		 */
+		void setClipping(Options clipping);
+		
+		
+		/**
 		 * Removes the pattern's references to the deleted color.
 		 */
 		void colorDeleted(const MapColor* color);
@@ -267,6 +278,12 @@ inline
 bool AreaSymbol::FillPattern::rotatable() const
 {
 	return flags.testFlag(Option::Rotatable);
+}
+
+inline
+AreaSymbol::FillPattern::Options AreaSymbol::FillPattern::clipping() const
+{
+	return flags & Option::AlternativeToClipping;
 }
 
 

--- a/src/core/symbols/area_symbol.h
+++ b/src/core/symbols/area_symbol.h
@@ -91,7 +91,7 @@ public:
 		
 		
 		/** Creates a default fill pattern */
-		FillPattern();
+		FillPattern() noexcept;
 		/** Loads the pattern in the old "native" format */
 		bool load(QIODevice* file, int version, Map* map);
 		/** Saves the pattern in xml format */
@@ -160,7 +160,7 @@ public:
 	
 	AreaSymbol();
 	virtual ~AreaSymbol();
-	Symbol* duplicate(const MapColorMap* color_map = NULL) const override;
+	Symbol* duplicate(const MapColorMap* color_map = nullptr) const override;
 	
 	void createRenderables(
 	        const Object *object,

--- a/src/core/symbols/area_symbol.h
+++ b/src/core/symbols/area_symbol.h
@@ -117,6 +117,22 @@ public:
 		
 		
 		/**
+		 * Removes the pattern's references to the deleted color.
+		 */
+		void colorDeleted(const MapColor* color);
+		                  
+		/**
+		 * Tests if the pattern contains the given color.
+		 */
+		bool containsColor(const MapColor* color) const;
+		
+		/**
+		 * Returns the patterns primary color.
+		 */
+		const MapColor* guessDominantColor() const;
+		
+		
+		/**
 		 * Creates renderables for this pattern in the area given by extent.
 		 * @param extent Rectangular area to create renderables for.
 		 * @param delta_rotation Rotation offest which is added to the pattern angle.

--- a/src/core/symbols/area_symbol.h
+++ b/src/core/symbols/area_symbol.h
@@ -63,7 +63,10 @@ public:
 		Type type;
 		/** Basic properties of the pattern. */
 		Options flags;
-		/** Rotation angle in radians */
+		/** Rotation angle in radians
+		 * 
+		 * \todo Switch to qreal when legacy native file format is dropped.
+		 */
 		float angle;
 		/** Distance between parallel lines, as usual in 0.001mm */
 		int line_spacing;
@@ -149,11 +152,12 @@ public:
 		/** Creates one line of renderables, called by createRenderables(). */
 		void createLine(
 			MapCoordF first, MapCoordF second,
-			float delta_offset,
+			qreal delta_offset,
 			LineSymbol* line,
 			float rotation,
 			ObjectRenderables& output
 		) const;
+		
 		/** Spatially scales the pattern settings by the given factor. */
 		void scale(double factor);
 	};
@@ -198,10 +202,10 @@ public:
 	inline const MapColor* getColor() const {return color;}
 	inline void setColor(const MapColor* color) {this->color = color;}
 	inline int getMinimumArea() const {return minimum_area; }
-	inline int getNumFillPatterns() const {return (int)patterns.size();}
-	inline void setNumFillPatterns(int count) {patterns.resize(count);}
-	inline FillPattern& getFillPattern(int i) {return patterns[i];}
-	inline const FillPattern& getFillPattern(int i) const {return patterns[i];}
+	inline int getNumFillPatterns() const {return int(patterns.size());}
+	inline void setNumFillPatterns(int count) {patterns.resize(std::size_t(count));}
+	inline FillPattern& getFillPattern(int i) {return patterns[std::size_t(i)];}
+	inline const FillPattern& getFillPattern(int i) const {return patterns[std::size_t(i)];}
 	bool hasRotatableFillPattern() const;
 	SymbolPropertiesWidget* createPropertiesWidget(SymbolSettingDialog* dialog) override;
 	

--- a/src/core/symbols/area_symbol.h
+++ b/src/core/symbols/area_symbol.h
@@ -185,7 +185,6 @@ public:
 			LineSymbol* line,
 			float rotation,
 			const AreaRenderable& outline,
-			QRectF point_extent,
 			ObjectRenderables& output
 		) const;
 		
@@ -195,7 +194,6 @@ public:
 			qreal delta_offset,
 			float rotation,
 			const AreaRenderable& outline,
-			QRectF point_extent,
 			ObjectRenderables& output
 		) const;
 		

--- a/src/core/symbols/area_symbol.h
+++ b/src/core/symbols/area_symbol.h
@@ -211,6 +211,12 @@ protected:
 #endif
 	void saveImpl(QXmlStreamWriter& xml, const Map& map) const override;
 	bool loadImpl(QXmlStreamReader& xml, const Map& map, SymbolDictionary& symbol_dict) override;
+	
+	/**
+	 * Compares AreaSymbol objects for equality.
+	 * 
+	 * Fill patterns are only compared in order.
+	 */
 	bool equalsImpl(const Symbol* other, Qt::CaseSensitivity case_sensitivity) const override;
 	
 	const MapColor* color;

--- a/src/core/symbols/area_symbol.h
+++ b/src/core/symbols/area_symbol.h
@@ -154,7 +154,20 @@ public:
 			ObjectRenderables& output
 		) const;
 		
+		/** Does the heavy-lifting in loops over lines. */
+		template <int type>
+		void createRenderables(
+			const AreaRenderable& outline,
+			float delta_rotation,
+			const MapCoord& pattern_origin,
+			QRectF point_extent,
+			LineSymbol* line,
+			qreal rotation,
+			ObjectRenderables& output
+		) const;
+		
 		/** Creates one line of renderables, called by createRenderables(). */
+		template <int type>
 		void createLine(
 			MapCoordF first, MapCoordF second,
 			qreal delta_offset,

--- a/src/core/symbols/area_symbol.h
+++ b/src/core/symbols/area_symbol.h
@@ -165,6 +165,17 @@ public:
 			ObjectRenderables& output
 		) const;
 		
+		/** Creates a single line of renderables for a PointPattern. */
+		void createPointPatternLine(
+			MapCoordF first, MapCoordF second,
+			qreal delta_offset,
+			float rotation,
+			const AreaRenderable& outline,
+			QRectF point_extent,
+			ObjectRenderables& output
+		) const;
+		
+		
 		/** Spatially scales the pattern settings by the given factor. */
 		void scale(double factor);
 	};

--- a/src/core/symbols/area_symbol.h
+++ b/src/core/symbols/area_symbol.h
@@ -55,6 +55,10 @@ public:
 		enum Option
 		{
 			Default                      = 0x00,
+			NoClippingIfCompletelyInside = 0x01,
+			NoClippingIfCenterInside     = 0x02,
+			NoClippingIfPartiallyInside  = 0x03,
+			AlternativeToClipping        = 0x03, ///< Bitmask for NoClipping* options
 			Rotatable                    = 0x10, ///< Pattern is rotatable per-object
 		};
 		Q_DECLARE_FLAGS(Options, Option)

--- a/src/core/symbols/area_symbol.h
+++ b/src/core/symbols/area_symbol.h
@@ -49,12 +49,22 @@ public:
 			PointPattern = 2
 		};
 		
+		/**
+		 * Flags for pattern properties.
+		 */
+		enum Option
+		{
+			Default                      = 0x00,
+			Rotatable                    = 0x10, ///< Pattern is rotatable per-object
+		};
+		Q_DECLARE_FLAGS(Options, Option)
+		
 		/** Type of the pattern */
 		Type type;
+		/** Basic properties of the pattern. */
+		Options flags;
 		/** Rotation angle in radians */
 		float angle;
-		/** True if the pattern is rotatable per-object. */
-		bool rotatable;
 		/** Distance between parallel lines, as usual in 0.001mm */
 		int line_spacing;
 		/** Offset of the first line from the origin */
@@ -93,6 +103,18 @@ public:
 		 * TODO: should the transient name really be compared?!
 		 */
 		bool equals(const FillPattern& other, Qt::CaseSensitivity case_sensitivity) const;
+		
+		
+		/**
+		 * Returns true if the pattern is rotatable per object.
+		 */
+		bool rotatable() const;
+		
+		/**
+		 * Controls whether the pattern is rotatable per object.
+		 */
+		void setRotatable(bool value);
+		
 		
 		/**
 		 * Creates renderables for this pattern in the area given by extent.
@@ -179,5 +201,16 @@ protected:
 	int minimum_area;	// in mm^2 // FIXME: unit (factor) wrong
 	std::vector<FillPattern> patterns;
 };
+
+
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(AreaSymbol::FillPattern::Options)
+
+inline
+bool AreaSymbol::FillPattern::rotatable() const
+{
+	return flags.testFlag(Option::Rotatable);
+}
+
 
 #endif

--- a/src/core/symbols/point_symbol.h
+++ b/src/core/symbols/point_symbol.h
@@ -23,6 +23,7 @@
 #define OPENORIENTEERING_POINT_SYMBOL_H
 
 #include "symbol.h"
+#include "area_symbol.h"
 
 
 /**
@@ -54,6 +55,10 @@ public:
 	        RenderableOptions options ) const override;
 	
 	void createRenderablesScaled(MapCoordF coord, float rotation, ObjectRenderables& output, float coord_scale = 1.0f) const;
+	
+	void createRenderablesIfCenterInside(MapCoordF point_coord, qreal rotation, const QPainterPath* outline, ObjectRenderables& output) const;
+	void createRenderablesIfCompletelyInside(MapCoordF point_coord, qreal rotation, const QPainterPath* outline, ObjectRenderables& output) const;
+	void createRenderablesIfPartiallyInside(MapCoordF point_coord, qreal rotation, const QPainterPath* outline, ObjectRenderables& output) const;
 	
 	void colorDeleted(const MapColor* color) override;
 	bool containsColor(const MapColor* color) const override;

--- a/src/fileformats/ocad8_file_format.cpp
+++ b/src/fileformats/ocad8_file_format.cpp
@@ -670,7 +670,7 @@ Symbol *OCAD8FileImport::importAreaSymbol(const OCADAreaSymbol *ocad_symbol)
         int n = symbol->patterns.size(); symbol->patterns.resize(n + 1); pat = &(symbol->patterns[n]);
         pat->type = AreaSymbol::FillPattern::LinePattern;
         pat->angle = convertRotation(ocad_symbol->hangle1);
-        pat->rotatable = true;
+        pat->flags = AreaSymbol::FillPattern::Option::Rotatable;
         pat->line_spacing = convertSize(ocad_symbol->hdist + ocad_symbol->hwidth);
         pat->line_offset = 0;
         pat->line_color = convertColor(ocad_symbol->hcolor);
@@ -693,7 +693,7 @@ Symbol *OCAD8FileImport::importAreaSymbol(const OCADAreaSymbol *ocad_symbol)
         int n = symbol->patterns.size(); symbol->patterns.resize(n + 1); pat = &(symbol->patterns[n]);
         pat->type = AreaSymbol::FillPattern::PointPattern;
         pat->angle = convertRotation(ocad_symbol->pangle);
-        pat->rotatable = true;
+        pat->flags = AreaSymbol::FillPattern::Option::Rotatable;
         pat->point_distance = convertSize(ocad_symbol->pwidth);
         pat->line_spacing = spacing;
         pat->line_offset = 0;
@@ -706,7 +706,7 @@ Symbol *OCAD8FileImport::importAreaSymbol(const OCADAreaSymbol *ocad_symbol)
             int n = symbol->patterns.size(); symbol->patterns.resize(n + 1); pat = &(symbol->patterns[n]);
             pat->type = AreaSymbol::FillPattern::PointPattern;
             pat->angle = convertRotation(ocad_symbol->pangle);
-            pat->rotatable = true;
+            pat->flags = AreaSymbol::FillPattern::Option::Rotatable;
             pat->point_distance = convertSize(ocad_symbol->pwidth);
             pat->line_spacing = spacing;
             pat->line_offset = pat->line_spacing / 2;
@@ -2219,7 +2219,7 @@ s16 OCAD8FileExport::exportAreaSymbol(const AreaSymbol* area)
 				continue;
 			}
 			
-			if (pattern.rotatable)
+			if (pattern.rotatable())
 				ocad_symbol->base_flags |= 1;
 			
 			++ocad_symbol->hmode;
@@ -2246,7 +2246,7 @@ s16 OCAD8FileExport::exportAreaSymbol(const AreaSymbol* area)
 		const AreaSymbol::FillPattern& pattern = area->getFillPattern(i);
 		if (pattern.type == AreaSymbol::FillPattern::PointPattern)
 		{
-			if (pattern.rotatable)
+			if (pattern.rotatable())
 				ocad_symbol->base_flags |= 1;
 			
 			++ocad_symbol->pmode;

--- a/src/fileformats/ocd_file_import.cpp
+++ b/src/fileformats/ocd_file_import.cpp
@@ -1317,7 +1317,7 @@ void OcdFileImport::setupAreaSymbolCommon(OcdImportedAreaSymbol* symbol, bool fi
 		AreaSymbol::FillPattern pattern;
 		pattern.type = AreaSymbol::FillPattern::LinePattern;
 		pattern.angle = convertAngle(ocd_symbol.hatch_angle_1);
-		pattern.rotatable = true;
+		pattern.setRotatable(true);
 		pattern.line_spacing = convertLength(ocd_symbol.hatch_dist);
 		pattern.line_offset = 0;
 		pattern.line_color = convertColor(ocd_symbol.hatch_color);
@@ -1341,7 +1341,7 @@ void OcdFileImport::setupAreaSymbolCommon(OcdImportedAreaSymbol* symbol, bool fi
 		AreaSymbol::FillPattern pattern;
 		pattern.type = AreaSymbol::FillPattern::PointPattern;
 		pattern.angle = convertAngle(ocd_symbol.structure_angle);
-		pattern.rotatable = true;
+		pattern.setRotatable(true);
 		pattern.point_distance = convertLength(ocd_symbol.structure_width);
 		pattern.line_spacing = convertLength(ocd_symbol.structure_height);
 		pattern.line_offset = 0;

--- a/src/gui/symbols/area_symbol_settings.cpp
+++ b/src/gui/symbols/area_symbol_settings.cpp
@@ -314,7 +314,7 @@ void AreaSymbolSettings::updatePatternWidgets()
 	
 	pattern_angle_edit->setValue(pattern->angle * 180.0 / M_PI);
 	pattern_angle_edit->setEnabled(pattern_active);
-	pattern_rotatable_check->setChecked(pattern->rotatable);
+	pattern_rotatable_check->setChecked(pattern->rotatable());
 	pattern_rotatable_check->setEnabled(pattern_active);
 	pattern_spacing_edit->setValue(0.001 * pattern->line_spacing);
 	pattern_spacing_edit->setEnabled(pattern_active);
@@ -461,7 +461,7 @@ void AreaSymbolSettings::patternAngleChanged(double value)
 
 void AreaSymbolSettings::patternRotatableClicked(bool checked)
 {
-	active_pattern->rotatable = checked;
+	active_pattern->setRotatable(checked);
 	emit propertiesModified();
 }
 

--- a/src/gui/symbols/area_symbol_settings.cpp
+++ b/src/gui/symbols/area_symbol_settings.cpp
@@ -21,6 +21,7 @@
 
 #include "area_symbol_settings.h"
 
+#include <QtMath>
 #include <QDialogButtonBox>
 #include <QFormLayout>
 #include <QLabel>
@@ -36,6 +37,8 @@
 #include "gui/symbols/symbol_setting_dialog.h"
 #include "gui/widgets/color_dropdown.h"
 #include "gui/util_gui.h"
+#include "util/backports.h"
+#include "util/scoped_signals_blocker.h"
 
 
 // ### AreaSymbol ###
@@ -104,34 +107,34 @@ AreaSymbolSettings::AreaSymbolSettings(AreaSymbol* symbol, SymbolSettingDialog* 
 	
 	/* From here, stacked widgets are used to unify the layout of pattern type dependant fields. */
 	QStackedWidget* single_line_headline = new QStackedWidget();
-	connect(this, SIGNAL(switchPatternEdits(int)), single_line_headline, SLOT(setCurrentIndex(int)));
+	connect(this, &AreaSymbolSettings::switchPatternEdits, single_line_headline, &QStackedWidget::setCurrentIndex);
 	fill_pattern_layout->addRow(single_line_headline);
 	
 	QStackedWidget* single_line_label1 = new QStackedWidget();
-	connect(this, SIGNAL(switchPatternEdits(int)), single_line_label1, SLOT(setCurrentIndex(int)));
+	connect(this, &AreaSymbolSettings::switchPatternEdits, single_line_label1, &QStackedWidget::setCurrentIndex);
 	QStackedWidget* single_line_edit1  = new QStackedWidget();
-	connect(this, SIGNAL(switchPatternEdits(int)), single_line_edit1, SLOT(setCurrentIndex(int)));
+	connect(this, &AreaSymbolSettings::switchPatternEdits, single_line_edit1, &QStackedWidget::setCurrentIndex);
 	fill_pattern_layout->addRow(single_line_label1, single_line_edit1);
 	
 	QStackedWidget* single_line_label2 = new QStackedWidget();
-	connect(this, SIGNAL(switchPatternEdits(int)), single_line_label2, SLOT(setCurrentIndex(int)));
+	connect(this, &AreaSymbolSettings::switchPatternEdits, single_line_label2, &QStackedWidget::setCurrentIndex);
 	QStackedWidget* single_line_edit2  = new QStackedWidget();
-	connect(this, SIGNAL(switchPatternEdits(int)), single_line_edit2, SLOT(setCurrentIndex(int)));
+	connect(this, &AreaSymbolSettings::switchPatternEdits, single_line_edit2, &QStackedWidget::setCurrentIndex);
 	fill_pattern_layout->addRow(single_line_label2, single_line_edit2);
 	
 	QStackedWidget* single_line_label3 = new QStackedWidget();
-	connect(this, SIGNAL(switchPatternEdits(int)), single_line_label3, SLOT(setCurrentIndex(int)));
+	connect(this, &AreaSymbolSettings::switchPatternEdits, single_line_label3, &QStackedWidget::setCurrentIndex);
 	pattern_line_offset_edit = Util::SpinBox::create(3, -999999.9, 999999.9, tr("mm"));
 	fill_pattern_layout->addRow(single_line_label3, pattern_line_offset_edit);
 	
 	fill_pattern_layout->addItem(Util::SpacerItem::create(this));
 	
 	QStackedWidget* parallel_lines_headline = new QStackedWidget();
-	connect(this, SIGNAL(switchPatternEdits(int)), parallel_lines_headline, SLOT(setCurrentIndex(int)));
+	connect(this, &AreaSymbolSettings::switchPatternEdits, parallel_lines_headline, &QStackedWidget::setCurrentIndex);
 	fill_pattern_layout->addRow(parallel_lines_headline);
 	
 	QStackedWidget* parallel_lines_label1 = new QStackedWidget();
-	connect(this, SIGNAL(switchPatternEdits(int)), parallel_lines_label1, SLOT(setCurrentIndex(int)));
+	connect(this, &AreaSymbolSettings::switchPatternEdits, parallel_lines_label1, &QStackedWidget::setCurrentIndex);
 	pattern_spacing_edit = Util::SpinBox::create(3, 0.0, 999999.9, tr("mm"));
 	fill_pattern_layout->addRow(parallel_lines_label1, pattern_spacing_edit);
 	
@@ -200,24 +203,32 @@ AreaSymbolSettings::AreaSymbolSettings(AreaSymbol* symbol, SymbolSettingDialog* 
 	area_tab->setLayout(layout);
 	addPropertiesGroup(tr("Area settings"), area_tab);
 	
-	connect(color_edit, SIGNAL(currentIndexChanged(int)), this, SLOT(colorChanged()));
-	connect(minimum_size_edit, SIGNAL(valueChanged(double)), this, SLOT(minimumSizeChanged(double)));
-	connect(del_pattern_button, SIGNAL(clicked(bool)), this, SLOT(deleteActivePattern()));
-	connect(pattern_list, SIGNAL(currentRowChanged(int)), this, SLOT(selectPattern(int)));
-	connect(pattern_angle_edit, SIGNAL(valueChanged(double)), this, SLOT(patternAngleChanged(double)));
-	connect(pattern_rotatable_check, SIGNAL(clicked(bool)), this, SLOT(patternRotatableClicked(bool)));
-	connect(pattern_spacing_edit, SIGNAL(valueChanged(double)), this, SLOT(patternSpacingChanged(double)));
-	connect(pattern_line_offset_edit, SIGNAL(valueChanged(double)), this, SLOT(patternLineOffsetChanged(double)));
-	connect(pattern_offset_along_line_edit, SIGNAL(valueChanged(double)), this, SLOT(patternOffsetAlongLineChanged(double)));
+	connect(color_edit, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &AreaSymbolSettings::colorChanged);
+	connect(minimum_size_edit, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &AreaSymbolSettings::minimumSizeChanged);
+	connect(del_pattern_button, &QAbstractButton::clicked, this, &AreaSymbolSettings::deleteActivePattern);
+	connect(pattern_list, &QListWidget::currentRowChanged, this, &AreaSymbolSettings::selectPattern);
+	connect(pattern_angle_edit, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &AreaSymbolSettings::patternAngleChanged);
+	connect(pattern_rotatable_check, &QAbstractButton::clicked, this, &AreaSymbolSettings::patternRotatableClicked);
+	connect(pattern_spacing_edit, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &AreaSymbolSettings::patternSpacingChanged);
+	connect(pattern_line_offset_edit, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &AreaSymbolSettings::patternLineOffsetChanged);
+	connect(pattern_offset_along_line_edit, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &AreaSymbolSettings::patternOffsetAlongLineChanged);
 	
-	connect(pattern_color_edit, SIGNAL(currentIndexChanged(int)), this, SLOT(patternColorChanged()));
-	connect(pattern_linewidth_edit, SIGNAL(valueChanged(double)), this, SLOT(patternLineWidthChanged(double)));
-	connect(pattern_pointdist_edit, SIGNAL(valueChanged(double)), this, SLOT(patternPointDistChanged(double)));
+	connect(pattern_color_edit, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &AreaSymbolSettings::patternColorChanged);
+	connect(pattern_linewidth_edit, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &AreaSymbolSettings::patternLineWidthChanged);
+	connect(pattern_pointdist_edit, QOverload<double>::of(&QDoubleSpinBox::valueChanged), this, &AreaSymbolSettings::patternPointDistChanged);
 	
 	updateAreaGeneral();
 	updatePatternWidgets();
 	loadPatterns();
 }
+
+
+AreaSymbolSettings::~AreaSymbolSettings()
+{
+	// nothing, not inlined
+}
+
+
 
 void AreaSymbolSettings::reset(Symbol* symbol)
 {
@@ -232,68 +243,71 @@ void AreaSymbolSettings::reset(Symbol* symbol)
 	loadPatterns();
 }
 
+
 void AreaSymbolSettings::updateAreaGeneral()
 {
-	color_edit->blockSignals(true);
+	ScopedMultiSignalsBlocker block(color_edit, minimum_size_edit);
 	color_edit->setColor(symbol->getColor());
-	color_edit->blockSignals(false);
-	minimum_size_edit->blockSignals(true);
 	minimum_size_edit->setValue(0.001 * symbol->minimum_area);
-	minimum_size_edit->blockSignals(false);
 }
+
 
 void AreaSymbolSettings::clearPatterns()
 {
 	pattern_list->clear();
-	for (int i = 0; i < (int)this->symbol->patterns.size(); ++i)
+	for (const auto& pattern : symbol->patterns)
 	{
-		if (this->symbol->patterns[i].type == AreaSymbol::FillPattern::PointPattern)
+		if (pattern.type == AreaSymbol::FillPattern::PointPattern)
 			removePropertiesGroup(2);
 	}
 }
+
 
 void AreaSymbolSettings::loadPatterns()
 {
 	Q_ASSERT(pattern_list->count() == 0);
 	Q_ASSERT(count() == 2); // General + Area tab
 	
-	for (int i = 0; i < symbol->getNumFillPatterns(); ++i)
+	for (const auto& pattern : symbol->patterns)
 	{
-		pattern_list->addItem(symbol->patterns[i].name);
-		if (symbol->getFillPattern(i).type == AreaSymbol::FillPattern::PointPattern)
+		pattern_list->addItem(pattern.name);
+		if (pattern.type == AreaSymbol::FillPattern::PointPattern)
 		{
-			PointSymbolEditorWidget* editor = new PointSymbolEditorWidget(controller, symbol->getFillPattern(i).point, 16);
-			connect(editor, SIGNAL(symbolEdited()), this, SIGNAL(propertiesModified()) );
-			addPropertiesGroup(symbol->patterns[i].name, editor);
+			PointSymbolEditorWidget* editor = new PointSymbolEditorWidget(controller, pattern.point, 16);
+			connect(editor, &PointSymbolEditorWidget::symbolEdited, this, &SymbolPropertiesWidget::propertiesModified );
+			addPropertiesGroup(pattern.name, editor);
 		}
 	}
 	updatePatternNames();
 	pattern_list->setCurrentRow(0);
 }
 
+
 void AreaSymbolSettings::updatePatternNames()
 {
-	int line_pattern_num = 0, point_pattern_num = 0;
-	for (int i = 0; i < (int)symbol->patterns.size(); ++i)
+	int i = 0, line_pattern_num = 0, point_pattern_num = 0;
+	for (auto& pattern : symbol->patterns)
 	{
-		if (symbol->patterns[i].type == AreaSymbol::FillPattern::PointPattern)
+		if (pattern.type == AreaSymbol::FillPattern::PointPattern)
 		{
-			point_pattern_num++;
+			++point_pattern_num;
 			QString name = tr("Pattern fill %1").arg(point_pattern_num);
-			symbol->patterns[i].name = name;
-			symbol->patterns[i].point->setName(name);
+			pattern.name = name;
+			pattern.point->setName(name);
 			pattern_list->item(i)->setText(name);
 			renamePropertiesGroup(point_pattern_num + 1, name);
 		}
 		else
 		{
-			line_pattern_num++;
+			++line_pattern_num;
 			QString name = tr("Line fill %1").arg(line_pattern_num);
-			symbol->patterns[i].name = name;
-			pattern_list->item(i)->setText(symbol->patterns[i].name);
+			pattern.name = name;
+			pattern_list->item(i)->setText(pattern.name);
 		}
+		++i;
 	}
 }
+
 
 void AreaSymbolSettings::updatePatternWidgets()
 {
@@ -307,73 +321,71 @@ void AreaSymbolSettings::updatePatternWidgets()
 	AreaSymbol::FillPattern* pattern = pattern_active ? &*active_pattern : new AreaSymbol::FillPattern();
 	pattern_name_edit->setText(pattern_active ? (QLatin1String("<b>") + active_pattern->name + QLatin1String("</b>")) : tr("No fill selected"));
 	
-	pattern_angle_edit->blockSignals(true);
-	pattern_rotatable_check->blockSignals(true);
-	pattern_spacing_edit->blockSignals(true);
-	pattern_line_offset_edit->blockSignals(true);
-	
-	pattern_angle_edit->setValue(pattern->angle * 180.0 / M_PI);
-	pattern_angle_edit->setEnabled(pattern_active);
-	pattern_rotatable_check->setChecked(pattern->rotatable());
-	pattern_rotatable_check->setEnabled(pattern_active);
-	pattern_spacing_edit->setValue(0.001 * pattern->line_spacing);
-	pattern_spacing_edit->setEnabled(pattern_active);
-	pattern_line_offset_edit->setValue(0.001 * pattern->line_offset);
-	pattern_line_offset_edit->setEnabled(pattern_active);
-	
-	pattern_angle_edit->blockSignals(false);
-	pattern_rotatable_check->blockSignals(false);
-	pattern_spacing_edit->blockSignals(false);
-	pattern_line_offset_edit->blockSignals(false);
-	
-	if (pattern->type == AreaSymbol::FillPattern::LinePattern)
 	{
-		emit switchPatternEdits(0);
-		
-		pattern_linewidth_edit->blockSignals(true);
-		pattern_linewidth_edit->setValue(0.001 * pattern->line_width);
-		pattern_linewidth_edit->setEnabled(pattern_active);
-		pattern_linewidth_edit->blockSignals(false);
-		
-		pattern_color_edit->blockSignals(true);
-		pattern_color_edit->setColor(pattern->line_color);
-		pattern_color_edit->setEnabled(pattern_active);
-		pattern_color_edit->blockSignals(false);
+		ScopedMultiSignalsBlocker block(
+		  pattern_angle_edit,
+		  pattern_rotatable_check,
+		  pattern_spacing_edit,
+		  pattern_line_offset_edit
+		);
+		pattern_angle_edit->setValue(qRadiansToDegrees(pattern->angle));
+		pattern_angle_edit->setEnabled(pattern_active);
+		pattern_rotatable_check->setChecked(pattern->rotatable());
+		pattern_rotatable_check->setEnabled(pattern_active);
+		pattern_spacing_edit->setValue(0.001 * pattern->line_spacing);
+		pattern_spacing_edit->setEnabled(pattern_active);
+		pattern_line_offset_edit->setValue(0.001 * pattern->line_offset);
+		pattern_line_offset_edit->setEnabled(pattern_active);
 	}
-	else
+	
+	switch (pattern->type)
 	{
-		emit switchPatternEdits(1);
-		
-		pattern_offset_along_line_edit->blockSignals(true);
-		pattern_offset_along_line_edit->setValue(0.001 * pattern->offset_along_line);
-		pattern_offset_along_line_edit->setEnabled(pattern_active);
-		pattern_offset_along_line_edit->blockSignals(false);
-		
-		pattern_pointdist_edit->blockSignals(true);
-		pattern_pointdist_edit->setValue(0.001 * pattern->point_distance);
-		pattern_pointdist_edit->setEnabled(pattern_active);
-		pattern_pointdist_edit->blockSignals(false);
+	case AreaSymbol::FillPattern::LinePattern:
+		{
+			emit switchPatternEdits(0);
+			
+			ScopedMultiSignalsBlocker block(pattern_linewidth_edit, pattern_color_edit);
+			pattern_linewidth_edit->setValue(0.001 * pattern->line_width);
+			pattern_linewidth_edit->setEnabled(pattern_active);
+			pattern_color_edit->setColor(pattern->line_color);
+			pattern_color_edit->setEnabled(pattern_active);
+			break;
+		}
+	case AreaSymbol::FillPattern::PointPattern:
+		{
+			emit switchPatternEdits(1);
+			
+			ScopedMultiSignalsBlocker block(pattern_offset_along_line_edit, pattern_pointdist_edit);
+			pattern_offset_along_line_edit->setValue(0.001 * pattern->offset_along_line);
+			pattern_offset_along_line_edit->setEnabled(pattern_active);
+			pattern_pointdist_edit->setValue(0.001 * pattern->point_distance);
+			pattern_pointdist_edit->setEnabled(pattern_active);
+			break;
+		}
 	}
 	
 	if (!pattern_active)
 		delete pattern;
 }
 
+
 void AreaSymbolSettings::addLinePattern()
 {
 	addPattern(AreaSymbol::FillPattern::LinePattern);
 }
+
 
 void AreaSymbolSettings::addPointPattern()
 {
 	addPattern(AreaSymbol::FillPattern::PointPattern);
 }
 
+
 void AreaSymbolSettings::addPattern(AreaSymbol::FillPattern::Type type)
 {
 	int index = pattern_list->currentRow() + 1;
 	if (index < 0)
-		index = symbol->patterns.size();
+		index = int(symbol->patterns.size());
 	
 	active_pattern = symbol->patterns.insert(symbol->patterns.begin() + index, AreaSymbol::FillPattern());
 	auto temp_name = QString::fromLatin1("new");
@@ -386,7 +398,7 @@ void AreaSymbolSettings::addPattern(AreaSymbol::FillPattern::Type type)
 		active_pattern->point = new PointSymbol();
 		active_pattern->point->setRotatable(true);
 		PointSymbolEditorWidget* editor = new PointSymbolEditorWidget(controller, active_pattern->point, 16);
-		connect(editor, SIGNAL(symbolEdited()), this, SIGNAL(propertiesModified()) );
+		connect(editor, &PointSymbolEditorWidget::symbolEdited, this, &SymbolPropertiesWidget::propertiesModified );
 		if (pattern_list->currentRow() == int(symbol->patterns.size()) - 1)
 		{
 			addPropertiesGroup(temp_name, editor);
@@ -408,6 +420,7 @@ void AreaSymbolSettings::addPattern(AreaSymbol::FillPattern::Type type)
 	pattern_list->setCurrentRow(index);
 }
 
+
 void AreaSymbolSettings::deleteActivePattern()
 {
 	int index = pattern_list->currentRow();
@@ -421,7 +434,7 @@ void AreaSymbolSettings::deleteActivePattern()
 	{
 		removePropertiesGroup(active_pattern->name);
 		delete active_pattern->point;
-		active_pattern->point = NULL;
+		active_pattern->point = nullptr;
 	}
 	symbol->patterns.erase(active_pattern);
 	
@@ -435,11 +448,14 @@ void AreaSymbolSettings::deleteActivePattern()
 	selectPattern(index);
 }
 
+
 void AreaSymbolSettings::selectPattern(int index)
 {
 	active_pattern = symbol->patterns.begin() + index;
 	updatePatternWidgets();
 }
+
+
 
 void AreaSymbolSettings::colorChanged()
 {
@@ -455,7 +471,7 @@ void AreaSymbolSettings::minimumSizeChanged(double value)
 
 void AreaSymbolSettings::patternAngleChanged(double value)
 {
-	active_pattern->angle = value * M_PI / 180.0;
+	active_pattern->angle = qDegreesToRadians(value);
 	emit propertiesModified();
 }
 

--- a/src/gui/symbols/area_symbol_settings.h
+++ b/src/gui/symbols/area_symbol_settings.h
@@ -28,6 +28,7 @@
 
 QT_BEGIN_NAMESPACE
 class QCheckBox;
+class QComboBox;
 class QDoubleSpinBox;
 class QLabel;
 class QListWidget;
@@ -117,6 +118,8 @@ private:
 	ColorDropDown*  pattern_color_edit;
 	QDoubleSpinBox* pattern_linewidth_edit;
 	QDoubleSpinBox* pattern_pointdist_edit;
+	
+	QComboBox*      pattern_clipping_edit;
 };
 
 #endif

--- a/src/gui/symbols/area_symbol_settings.h
+++ b/src/gui/symbols/area_symbol_settings.h
@@ -55,7 +55,10 @@ Q_OBJECT
 public:
 	AreaSymbolSettings(AreaSymbol* symbol, SymbolSettingDialog* dialog);
 	
-	virtual void reset(Symbol* symbol);
+	~AreaSymbolSettings() override;
+	
+	
+	void reset(Symbol* symbol) override;
 	
 	/**
 	 * Updates the general area fields (not related to patterns)

--- a/src/gui/symbols/symbol_setting_dialog.cpp
+++ b/src/gui/symbols/symbol_setting_dialog.cpp
@@ -399,14 +399,15 @@ void SymbolSettingDialog::createPreviewMap()
 	}
 	else if (symbol->getType() == Symbol::Area)
 	{
-		const float half_radius = 8;
-		const float offset_y = 0;
+		const qreal half_radius = 8;
+		const qreal offset_y = 0;
 		
 		PathObject* path = new PathObject(symbol);
 		path->addCoordinate(0, { -half_radius, -half_radius + offset_y });
-		path->addCoordinate(1, { half_radius,  -half_radius + offset_y });
-		path->addCoordinate(2, { half_radius,  half_radius + offset_y });
-		path->addCoordinate(3, { -half_radius, half_radius + offset_y });
+		path->addCoordinate(1, {  0.0,         -half_radius + offset_y });
+		path->addCoordinate(2, {  half_radius,                offset_y });
+		path->addCoordinate(3, {  half_radius,  half_radius + offset_y });
+		path->addCoordinate(4, { -half_radius,  half_radius + offset_y });
 		preview_map->addObject(path);
 		
 		preview_objects.push_back(path);


### PR DESCRIPTION
Alternatives added in last commit (272e0b3).
Includes cleanup and modernization of this AreaSymbol and AreaSymbol::FillPattern.