### PR TITLE
Elaborate and leverage ObjectQuery and CRT file support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,6 +64,7 @@ set(Mapper_Common_SRCS
   core/objects/boolean_tool.cpp
   core/objects/object.cpp
   core/objects/object_query.cpp
+  core/objects/symbol_rule_set.cpp
   core/objects/text_object.cpp
   
   core/renderables/renderable.cpp

--- a/src/core/map.h
+++ b/src/core/map.h
@@ -31,6 +31,7 @@
 #include <QScopedPointer>
 #include <QSharedData>
 #include <QString>
+#include <QTransform>
 
 #include "global.h"
 #include "map_coord.h"
@@ -194,6 +195,26 @@ public:
 	        bool merge_duplicate_symbols = true,
 	        QHash<const Symbol*, Symbol*>* out_symbol_map = nullptr
 	);
+	
+	/**
+	 * Imports another map into this map with the following strategy:
+	 *  - If the other map contains objects, import all objects with the
+	 *    minimum amount of colors and symbols needed to display them.
+	 *  - If the other map does not contain objects, import all symbols
+	 *    with the minimum amount of colors needed to display them.
+	 *  - If the other map does neither contain objects nor symbols,
+	 *    import all colors.
+	 * The transform is applied to all imported objects.
+	 */
+	QHash<const Symbol*, Symbol*> importMap(
+	        const Map& imported_map,
+	        ImportMode mode,
+	        std::vector<bool>* symbol_filter = nullptr,
+	        int symbol_insert_pos = -1,
+	        bool merge_duplicate_symbols = true,
+	        const QTransform& transform = {}
+	);
+	
 	
 	/**
 	 * Serializes the map directly into the given IO device in a known format.

--- a/src/core/map.h
+++ b/src/core/map.h
@@ -1396,17 +1396,22 @@ private:
 		void adjustColorPriorities(int first, int last);
 	};
 	
-	/// Imports the other symbol set into this set, only importing the symbols for which filter[color_index] == true and
-	/// returning the map from symbol indices in other to imported indices. Imported symbols are placed after the existing symbols.
-	void importSymbols(
-	        const Map* other,
+	
+	/** 
+	 * Imports the other symbol set into this map's symbols.
+	 * 
+	 * If a filter is given, imports only the symbols for which filter[color_index] == true.
+	 * Imported symbols are placed at insert_pos (if positive), or after the existing symbols.
+	 * Returns a mapping from original symbols (in other) to imported symbols.
+	 */
+	QHash<const Symbol*, Symbol*> importSymbols(
+	        const Map& other,
 	        const MapColorMap& color_map,
 	        int insert_pos = -1,
 	        bool merge_duplicates = true,
-	        std::vector<bool>* filter = nullptr,
-	        QHash<int, int>* out_indexmap = nullptr,
-	        QHash<const Symbol*, Symbol*>* out_pointermap = nullptr
+	        const std::vector<bool>& filter = {}
 	);
+	
 	
 	void addSelectionRenderables(const Object* object);
 	void updateSelectionRenderables(const Object* object);

--- a/src/core/objects/object_query.cpp
+++ b/src/core/objects/object_query.cpp
@@ -254,6 +254,39 @@ void ObjectQuery::selectMatchingObjects(Map* map, MapEditorController* controlle
 
 
 
+const ObjectQuery::LogicalOperands* ObjectQuery::logicalOperands() const
+{
+	const LogicalOperands* result = nullptr;
+	if (op >= 1 && op <= 2)
+	{
+		result = &subqueries;
+	}
+	else
+	{
+		Q_ASSERT(op >= 1);
+		Q_ASSERT(op <= 2);
+	}
+	return result;
+}
+
+
+const ObjectQuery::TagOperands* ObjectQuery::tagOperands() const
+{
+	const TagOperands* result = nullptr;
+	if (op >= 16 && op <= 18)
+	{
+		result = &tags;
+	}
+	else
+	{
+		Q_ASSERT(op >= 16);
+		Q_ASSERT(op <= 18);
+	}
+	return result;
+}
+
+
+
 void ObjectQuery::reset()
 {
 	if (op == ObjectQuery::OperatorInvalid)

--- a/src/core/objects/object_query.cpp
+++ b/src/core/objects/object_query.cpp
@@ -419,7 +419,8 @@ bool operator==(const ObjectQuery& lhs, const ObjectQuery& rhs)
 		
 	case ObjectQuery::OperatorAnd:
 	case ObjectQuery::OperatorOr:
-		return *lhs.subqueries.first == *rhs.subqueries.second;
+		return *lhs.subqueries.first == *rhs.subqueries.first
+		       && *lhs.subqueries.second == *rhs.subqueries.second;
 		
 	case ObjectQuery::OperatorSymbol:
 		return lhs.symbol == rhs.symbol;

--- a/src/core/objects/object_query.cpp
+++ b/src/core/objects/object_query.cpp
@@ -397,3 +397,36 @@ void ObjectQuery::consume(ObjectQuery&& other)
 	other.op = ObjectQuery::OperatorInvalid;
 }
 
+
+
+bool operator==(const ObjectQuery::TagOperands& lhs, const ObjectQuery::TagOperands& rhs)
+{
+	return lhs.key == rhs.key && lhs.value == rhs.value;
+}
+
+bool operator==(const ObjectQuery& lhs, const ObjectQuery& rhs)
+{
+	if (lhs.op != rhs.op)
+		return false;
+	
+	switch(lhs.op)
+	{
+	case ObjectQuery::OperatorIs:
+	case ObjectQuery::OperatorIsNot:
+	case ObjectQuery::OperatorContains:
+	case ObjectQuery::OperatorSearch:
+		return lhs.tags == rhs.tags;
+		
+	case ObjectQuery::OperatorAnd:
+	case ObjectQuery::OperatorOr:
+		return *lhs.subqueries.first == *rhs.subqueries.second;
+		
+	case ObjectQuery::OperatorSymbol:
+		return lhs.symbol == rhs.symbol;
+		
+	case ObjectQuery::OperatorInvalid:
+		return false;
+	}
+	
+	Q_UNREACHABLE();
+}

--- a/src/core/objects/object_query.h
+++ b/src/core/objects/object_query.h
@@ -138,6 +138,17 @@ public:
 	void selectMatchingObjects(Map* map, MapEditorController* controller) const;
 	
 	
+	/**
+	 * Returns the operands of logical query operations.
+	 */
+	const LogicalOperands* logicalOperands() const;
+	
+	/**
+	 * Returns the operands of logical query operations.
+	 */
+	const TagOperands* tagOperands() const;
+	
+	
 private:
 	/**
 	 * Resets the query to the OperatorInvalid state.

--- a/src/core/objects/object_query.h
+++ b/src/core/objects/object_query.h
@@ -30,6 +30,7 @@
 class Map;
 class MapEditorController;
 class Object;
+class Symbol;
 
 
 /**
@@ -58,6 +59,9 @@ public:
 		OperatorIs       = 16, ///< Tests an existing tag for equality with the given value
 		OperatorIsNot    = 17, ///< Tests an existing tag for inequality with the given value
 		OperatorContains = 18, ///< Tests an existing tag for containing the given value
+		
+		// More operators, 32 ..
+		OperatorSymbol   = 32, ///< Test the symbol for equality.
 		
 		OperatorInvalid  = 0   ///< Marks an invalid query
 	};
@@ -113,6 +117,11 @@ public:
 	 */
 	ObjectQuery(ObjectQuery&& first, Operator op, ObjectQuery&& second) noexcept;
 	
+	/**
+	 * Constructs a query for a particular symbol.
+	 */
+	ObjectQuery(const Symbol* symbol) noexcept;
+	
 	
 	/**
 	 * Returns the underlying operator.
@@ -148,6 +157,11 @@ public:
 	 */
 	const TagOperands* tagOperands() const;
 	
+	/**
+	 * Returns the operand of symbol operations.
+	 */
+	const Symbol* symbolOperand() const;
+	
 	
 private:
 	/**
@@ -163,12 +177,15 @@ private:
 	 */
 	void consume(ObjectQuery&& other);
 	
+	using SymbolOperand = const Symbol*;
+	
 	Operator op;
 	
 	union
 	{
 		LogicalOperands subqueries;
 		TagOperands     tags;
+		SymbolOperand   symbol;
 	};
 	
 };

--- a/src/core/objects/object_query.h
+++ b/src/core/objects/object_query.h
@@ -220,6 +220,54 @@ bool operator!=(const ObjectQuery::TagOperands& lhs, const ObjectQuery::TagOpera
 
 
 
+/**
+ * Utility to contruct object queries from text.
+ * 
+ * The text shall be in the formal language generate by ObjectQuery::toString().
+ */
+class ObjectQueryParser
+{
+public:
+	/**
+	 * Returns an ObjectQuery for the given text.
+	 * 
+	 * The return query has ObjectQuery::OperatorInvalid in case of error.
+	 */
+	ObjectQuery parse(const QString& text);
+	
+	/**
+	 * In case of error, returns the approximate position where parsing the
+	 * text failed.
+	 */
+	int errorPos() const;
+	
+	enum TokenType
+	{
+		TokenUnknown = 0,
+		TokenNothing,
+		TokenString,
+		TokenWord,
+		TokenTextOperator,
+		TokenOr,
+		TokenAnd,
+		TokenLeftParen,
+		TokenRightParen,
+	};
+	
+private:
+	void getToken();
+	
+	QString tokenAsString() const;
+	
+	QStringRef input;
+	QStringRef token_text;
+	TokenType token;
+	int token_start;
+	int pos;
+};
+
+
+
 inline
 bool operator!=(const ObjectQuery& lhs, const ObjectQuery& rhs)
 {

--- a/src/core/objects/object_query.h
+++ b/src/core/objects/object_query.h
@@ -56,9 +56,10 @@ public:
 		OperatorOr       = 2,  ///< Or-chains two object queries
 		
 		// Operators 16 .. 18 operate on object tags
-		OperatorIs       = 16, ///< Tests an existing tag for equality with the given value
-		OperatorIsNot    = 17, ///< Tests an existing tag for inequality with the given value
-		OperatorContains = 18, ///< Tests an existing tag for containing the given value
+		OperatorIs       = 16, ///< Tests an existing tag for equality with the given value (case-sensitive)
+		OperatorIsNot    = 17, ///< Tests an existing tag for inequality with the given value (case-sensitive)
+		OperatorContains = 18, ///< Tests an existing tag for containing the given value (case-sensitive)
+		OperatorSearch   = 19, ///< Tests if the symbol name, a tag key or a tag value contains the given value (case-insensitive)
 		
 		// More operators, 32 ..
 		OperatorSymbol   = 32, ///< Test the symbol for equality.
@@ -104,6 +105,13 @@ public:
 	 * Constructs a query for a key and value.
 	 */
 	ObjectQuery(const QString& key, Operator op, const QString& value);
+	
+	/**
+	 * Constructs a query for a value.
+	 * 
+	 * Valid for OperatorSearch.
+	 */
+	ObjectQuery(Operator op, const QString& value);
 	
 	/**
 	 * Constructs a query which connects two sub-queries.

--- a/src/core/objects/object_query.h
+++ b/src/core/objects/object_query.h
@@ -171,6 +171,8 @@ public:
 	const Symbol* symbolOperand() const;
 	
 	
+	friend bool operator==(const ObjectQuery& lhs, const ObjectQuery& rhs);
+	
 private:
 	/**
 	 * Resets the query to the OperatorInvalid state.
@@ -199,5 +201,27 @@ private:
 };
 
 Q_DECLARE_METATYPE(ObjectQuery::Operator)
+
+bool operator==(const ObjectQuery& lhs, const ObjectQuery& rhs);
+
+bool operator!=(const ObjectQuery& lhs, const ObjectQuery& rhs);
+
+bool operator==(const ObjectQuery::TagOperands& lhs, const ObjectQuery::TagOperands& rhs);
+
+bool operator!=(const ObjectQuery::TagOperands& lhs, const ObjectQuery::TagOperands& rhs);
+
+
+
+inline
+bool operator!=(const ObjectQuery& lhs, const ObjectQuery& rhs)
+{
+	return !(lhs==rhs);
+}
+
+inline
+bool operator!=(const ObjectQuery::TagOperands& lhs, const ObjectQuery::TagOperands& rhs)
+{
+	return !(lhs==rhs);
+}
 
 #endif

--- a/src/core/objects/object_query.h
+++ b/src/core/objects/object_query.h
@@ -171,6 +171,14 @@ public:
 	const Symbol* symbolOperand() const;
 	
 	
+	/**
+	 * Pretty print the query.
+	 * 
+	 * The output is meant to be formal language, for possible parsing.
+	 */
+	QString toString() const;
+	
+	
 	friend bool operator==(const ObjectQuery& lhs, const ObjectQuery& rhs);
 	
 private:

--- a/src/core/objects/symbol_rule_set.cpp
+++ b/src/core/objects/symbol_rule_set.cpp
@@ -1,0 +1,394 @@
+/*
+ *    Copyright 2017 Kai Pastor
+ *
+ *    This file is part of OpenOrienteering.
+ *
+ *    OpenOrienteering is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OpenOrienteering is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "symbol_rule_set.h"
+
+#include <unordered_set>
+
+#include <QTextStream>
+
+#include "core/map.h"
+#include "core/objects/object.h"
+#include "core/symbols/symbol.h"
+#include "undo/undo_manager.h"
+
+
+// The SymbolRule member "query" may throw on copying.
+Q_STATIC_ASSERT(std::is_nothrow_constructible<SymbolRule>::value);
+Q_STATIC_ASSERT(std::is_nothrow_default_constructible<SymbolRule>::value);
+Q_STATIC_ASSERT(std::is_copy_constructible<SymbolRule>::value);
+Q_STATIC_ASSERT(std::is_nothrow_move_constructible<SymbolRule>::value);
+Q_STATIC_ASSERT(std::is_nothrow_destructible<SymbolRule>::value);
+Q_STATIC_ASSERT(std::is_copy_assignable<SymbolRule>::value);
+Q_STATIC_ASSERT(std::is_nothrow_move_assignable<SymbolRule>::value);
+
+// Analogously for SymbolRuleSet
+Q_STATIC_ASSERT(std::is_nothrow_constructible<SymbolRuleSet>::value);
+Q_STATIC_ASSERT(std::is_nothrow_default_constructible<SymbolRuleSet>::value);
+Q_STATIC_ASSERT(std::is_copy_constructible<SymbolRuleSet>::value);
+Q_STATIC_ASSERT(std::is_nothrow_move_constructible<SymbolRuleSet>::value);
+Q_STATIC_ASSERT(std::is_nothrow_destructible<SymbolRuleSet>::value);
+Q_STATIC_ASSERT(std::is_copy_assignable<SymbolRuleSet>::value);
+Q_STATIC_ASSERT(std::is_nothrow_move_assignable<SymbolRuleSet>::value);
+
+
+// static
+SymbolRuleSet SymbolRuleSet::forOriginalSymbols(const Map& map)
+{
+	SymbolRuleSet list;
+	list.reserve(std::size_t(map.getNumSymbols()));
+	for (int i = 0; i < map.getNumSymbols(); ++i)
+	{
+		auto original = map.getSymbol(i);
+		list.push_back({{original}, nullptr, SymbolRule::NoAssignment});
+	}
+	list.sortByQueryKeyAndValue();
+	return list;
+}
+
+
+SymbolRuleSet SymbolRuleSet::squeezed() const
+{
+	SymbolRuleSet list;
+	list.reserve(this->size());
+	std::copy_if(begin(), end(), std::back_inserter(list), [](auto item) {
+		return item.type != SymbolRule::NoAssignment;
+	});
+	return list;
+}
+
+
+
+void SymbolRuleSet::sortByQuerySymbol()
+{
+	auto last = std::remove_if(begin(), end(), [](auto item) {
+		return item.query.getOperator() != ObjectQuery::OperatorSymbol
+		       || !item.query.symbolOperand();
+	});
+	std::sort(begin(), last, [](auto lhs, auto rhs) {
+		auto lhs_op = lhs.query.symbolOperand();
+		auto rhs_op = rhs.query.symbolOperand();
+		return (lhs_op->getNumberAsString() < rhs_op->getNumberAsString()
+		        && lhs_op->getName() < rhs_op->getName());
+	});
+}
+
+
+void SymbolRuleSet::sortByQueryKeyAndValue()
+{
+	auto last = std::remove_if(begin(), end(), [](auto item) {
+		const auto op = item.query.getOperator();
+		return (op != ObjectQuery::OperatorIs
+		        && op != ObjectQuery::OperatorIsNot
+		        && op != ObjectQuery::OperatorContains)
+		       || !item.query.tagOperands();
+	});
+	std::sort(begin(), last, [](auto lhs, auto rhs) {
+		auto lhs_op = lhs.query.tagOperands();
+		auto rhs_op = rhs.query.tagOperands();
+		return (lhs_op->key < rhs_op->key)
+		       && (lhs_op->value < rhs_op->value);
+	});
+}
+
+
+
+void SymbolRuleSet::matchQuerySymbolName(const Map& other_map)
+{
+	auto findMatchingSymbol = [&other_map](const Symbol* original)->const Symbol*
+	{
+		for (int k = 0; k < other_map.getNumSymbols(); ++k)
+		{
+			auto other_symbol = other_map.getSymbol(k);
+			if (original->getName() == other_symbol->getName()
+			    && Symbol::areTypesCompatible(original->getType(), other_symbol->getType()))
+			{
+				return other_symbol;
+			}
+		}
+		return nullptr;
+	};
+	
+	for (auto& item : *this)
+	{
+		if (item.query.getOperator() != ObjectQuery::OperatorSymbol)
+			continue;
+		
+		auto original = item.query.symbolOperand();
+		if (!original)
+			continue;
+		
+		auto candidate = findMatchingSymbol(original);
+		if (!candidate)
+		{
+			candidate = findMatchingSymbol(original);
+		}
+		if (candidate != item.symbol)
+		{
+			if (candidate)
+			{
+				item.symbol = candidate;
+				item.type = SymbolRule::AutomaticAssignment;
+			}
+			else 
+			{
+				item.type = SymbolRule::NoAssignment;
+			}
+		}
+	}
+}
+
+
+void SymbolRuleSet::matchQuerySymbolNumber(const Map& other_map)
+{
+	auto findMatchingSymbol = [&other_map](const Symbol* original, bool ignore_trailing_zeros)->const Symbol*
+	{
+		for (int k = 0; k < other_map.getNumSymbols(); ++k)
+		{
+			auto other_symbol = other_map.getSymbol(k);
+			if (original->numberEquals(other_symbol, ignore_trailing_zeros)
+				&& Symbol::areTypesCompatible(original->getType(), other_symbol->getType()))
+			{
+				return other_symbol;
+			}
+		}
+		return nullptr;
+	};
+	
+	for (auto& item : *this)
+	{
+		if (item.query.getOperator() != ObjectQuery::OperatorSymbol)
+			continue;
+		
+		auto original = item.query.symbolOperand();
+		if (!original)
+			continue;
+		
+		auto candidate = findMatchingSymbol(original, false);
+		if (!candidate)
+		{
+			candidate = findMatchingSymbol(original, true);
+		}
+		if (candidate != item.symbol)
+		{
+			if (candidate)
+			{
+				item.symbol = candidate;
+				item.type = SymbolRule::AutomaticAssignment;
+			}
+			else 
+			{
+				item.type = SymbolRule::NoAssignment;
+			}
+		}
+	}
+}
+
+
+
+// static
+SymbolRuleSet SymbolRuleSet::loadCrt(QTextStream& stream, const Map& replacement_map)
+{
+	auto list = SymbolRuleSet{};
+	stream.setIntegerBase(10); // No autodectection; 001 is 1.
+	while (!stream.atEnd())
+	{
+		QString replacement_key;
+		stream >> replacement_key;
+		auto pattern = stream.readLine().trimmed();
+		if (stream.status() == QTextStream::Ok
+		    && !replacement_key.startsWith(QLatin1Char{'#'}))
+		{
+			list.push_back({{ObjectQuery::OperatorSearch, pattern}, nullptr, SymbolRule::NoAssignment});
+			for (int k = 0; k < replacement_map.getNumSymbols(); ++k)
+			{
+				auto symbol = replacement_map.getSymbol(k);
+				if (symbol->getNumberAsString() == replacement_key)
+				{
+					list.back().symbol = symbol;
+					list.back().type = SymbolRule::DefinedAssignment;
+					break;
+				}
+			}
+		}
+	}
+	return list;
+}
+
+
+void SymbolRuleSet::writeCrt(QTextStream& stream) const
+{
+	for (const auto& item : *this)
+	{
+		if (item.type != SymbolRule::NoAssignment
+		    && item.symbol)
+		{
+			const auto& query = item.query;
+			auto second_field = QString{};
+			switch (query.getOperator())
+			{
+			case ObjectQuery::OperatorSearch:
+				if (query.tagOperands())
+					second_field = query.tagOperands()->value;
+				break;
+				
+			case ObjectQuery::OperatorSymbol:
+				if (query.symbolOperand())
+					second_field = query.symbolOperand()->getNumberAsString();
+				break;
+				
+			case ObjectQuery::OperatorIs:
+				if (query.tagOperands()
+				    && query.tagOperands()->key == QLatin1String("Layer"))
+				{
+					second_field = query.tagOperands()->value;
+					break;
+				}
+				// fall through
+			case ObjectQuery::OperatorIsNot:
+			case ObjectQuery::OperatorContains:
+				if (query.tagOperands())
+					second_field = query.tagOperands()->key + QLatin1Char(' ')
+					               + query.labelFor(query.getOperator()) + QLatin1String(" \"")
+					               + query.tagOperands()->value + QLatin1Char('"');
+				break;
+				
+			default:
+				qDebug("Unsupported query in SymbolRuleSet::writeCrt");
+			}
+
+			if (!second_field.isEmpty())
+			{
+				auto first_field = item.symbol->getNumberAsString();
+				auto whitespace = QString(qMax(1, 10-first_field.length()), QLatin1Char{' '});
+				stream <<  first_field << whitespace << second_field << endl;
+			}
+		}
+	}
+}
+
+
+
+bool SymbolRuleSet::operator()(Object* object, MapPart*, int) const
+{
+	for (const auto& item : *this)
+	{
+		if (item.symbol && item.query(object))
+		{
+			object->setSymbol(item.symbol, false);
+			break;
+		}
+	}
+	return true;
+}
+
+
+void SymbolRuleSet::apply(Map& object_map, const Map& symbol_set, Options options)
+{
+	std::unordered_set<const Symbol*> old_symbols;
+	
+	// Import new symbols if needed
+	if (&object_map != &symbol_set)
+	{
+		if (!options.testFlag(KeepUnusedSymbols))
+		{
+			for (int i = 0; i < object_map.getNumSymbols(); ++i)
+				old_symbols.insert(object_map.getSymbol(i));
+		}
+		
+		auto symbol_filter = std::vector<bool>(std::size_t(symbol_set.getNumSymbols()), true);
+		if (!options.testFlag(ImportAllSymbols))
+		{
+			// Import only symbols which are chosen as replacement symbols
+			auto item = symbol_filter.begin();
+			for (int i = 0; i < symbol_set.getNumSymbols(); ++i)
+			{
+				auto symbol = symbol_set.getSymbol(i);
+				*item = std::any_of(begin(), end(), [symbol](auto item) {
+					return item.symbol == symbol;
+				});
+				++item;
+			}
+		}
+		
+		auto symbol_mapping = object_map.importMap(symbol_set, Map::MinimalSymbolImport, &symbol_filter, -1, false);
+		
+		auto preserve_state = options.testFlag(PreserveSymbolState);
+		for (auto& item : *this)
+		{
+			if (!symbol_mapping.contains(item.symbol))
+				continue; // unused symbol
+			
+			auto replacement = symbol_mapping[item.symbol];
+			if (item.query.getOperator() == ObjectQuery::OperatorSymbol
+			    && preserve_state)
+			{
+				auto original = item.query.symbolOperand();
+				Q_ASSERT(original);
+				replacement->setHidden(original->isHidden());
+				replacement->setProtected(original->isProtected());
+			}
+			item.symbol = replacement;
+		}
+	}
+	
+	// Change symbols for all objects
+	object_map.applyOnAllObjects(*this);
+	
+	// Delete unused old symbols
+	if (!old_symbols.empty())
+	{
+		std::vector<bool> symbols_in_use;
+		object_map.determineSymbolsInUse(symbols_in_use);
+		
+		for (int i = object_map.getNumSymbols() - 1; i >= 0; --i)
+		{
+			auto symbol = object_map.getSymbol(i);
+			if (!symbols_in_use[std::size_t(i)]
+			    && old_symbols.find(symbol) != old_symbols.end())
+			{
+				object_map.deleteSymbol(i);
+			}
+		}
+	}
+	
+	// Delete unused colors
+	if (!options.testFlag(KeepUnusedColors))
+	{
+		std::vector<bool> all_symbols;
+		all_symbols.assign(std::size_t(object_map.getNumSymbols()), true);
+		std::vector<bool> colors_in_use;
+		object_map.determineColorsInUse(all_symbols, colors_in_use);
+		if (colors_in_use.empty())
+			colors_in_use.assign(std::size_t(object_map.getNumColors()), false);
+		
+		for (int i = object_map.getNumColors() - 1; i >= 0; --i)
+		{
+			if (!colors_in_use[std::size_t(i)])
+				object_map.deleteColor(i);
+		}
+	}
+	
+	// Finish
+	object_map.updateAllObjects();
+	object_map.setObjectsDirty();
+	object_map.setSymbolsDirty();
+	object_map.undoManager().clear();
+}

--- a/src/core/objects/symbol_rule_set.h
+++ b/src/core/objects/symbol_rule_set.h
@@ -1,0 +1,197 @@
+/*
+ *    Copyright 2017 Kai Pastor
+ *
+ *    This file is part of OpenOrienteering.
+ *
+ *    OpenOrienteering is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OpenOrienteering is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#ifndef OPENORIENTEERING_SYMBOL_RULE_SET_H
+#define OPENORIENTEERING_SYMBOL_RULE_SET_H
+
+
+#include <QFlags>
+#include <QString>
+
+#include "core/objects/object_query.h"
+
+class QTextStream;
+
+class Map;
+class MapPart;
+class Object;
+class Symbol;
+
+
+/**
+ * This struct defines a single symbol assignment rule.
+ * 
+ * Unless the type is NoAssignment, a rule specifies a new symbol for objects
+ * which match a particular query.
+ */
+struct SymbolRule
+{
+	// Intentionally no user-defined constructors, destructor, assignement.
+	// Default ones are fine.
+	
+	enum RuleType
+	{
+		NoAssignment = 0,
+		ManualAssignment,
+		AutomaticAssignment,
+		DefinedAssignment,
+	};
+	
+	ObjectQuery   query;
+	const Symbol* symbol;
+	RuleType      type;
+	
+};
+
+
+/**
+ * An utility for assigning symbols to objects based on queries.
+ */
+class SymbolRuleSet : public std::vector<SymbolRule>
+{
+public:
+	// Intentionally no user-defined constructors, destructor, assignement.
+	// Default ones are fine.
+	
+	/** 
+	 * Creates a list of NoAssignment items for the map's symbols as originals.
+	 * 
+	 * This function can be used to easily initialize variables of type
+	 * SymbolRuleSet despite the absence of specialized constructors.
+	 * Each item is initialized with an object query for a symbol from the map.
+	 * 
+	 * The created list is sorted by formatted symbol number.
+	 */
+	static SymbolRuleSet forOriginalSymbols(const Map& map);
+	
+	/**
+	 * Returns a copy which has all NoAssignment items removed.
+	 */
+	SymbolRuleSet squeezed() const;
+	
+	
+	/** 
+	 * Sorts the items by original symbol number and name if possible.
+	 * 
+	 * The symbol number and name are only available for queries with operator
+	 * ObjectQuery::OperatorSymbol. Othe rules are moved to the end.
+	 */
+	void sortByQuerySymbol();
+	
+	/** 
+	 * Sorts the items by tag query key and value if possible.
+	 * 
+	 * The tag key and value are only available for queries with operator
+	 * ObjectQuery::OperatorIs, ObjectQuery::OperatorIsNot, and
+	 * ObjectQuery::OperatorIs. Othe rules are moved to the end.
+	 */
+	void sortByQueryKeyAndValue();
+	
+	
+	/**
+	 * Sets the assigned symbols to match the original symbol name if possible.
+	 * 
+	 * The symbol name is only available for queries with operator
+	 * ObjectQuery::OperatorSymbol.
+	 * 
+	 * The symbols' types must be compatible.
+	 */
+	void matchQuerySymbolName(const Map& other_map);
+	
+	/**
+	 * Sets the assigned symbols to match the original symbol number if possible.
+	 * 
+	 * The symbol number is only available for queries with operator
+	 * ObjectQuery::OperatorSymbol.
+	 * 
+	 * The symbols' types must be compatible.
+	 */
+	void matchQuerySymbolNumber(const Map& other_map);
+	
+	
+	/**
+	 * Loads rules from a cross reference table (CRT) stream.
+	 * 
+	 * Each line in a CRT file takes the form:
+	 * 
+	 * REPLACEMENT    pattern
+	 * 
+	 * where REPLACEMENT is the formatted number of the replacement symbol.
+	 * 
+	 * If the replacement symbol number exists, the import creates a new entry
+	 * of type DefinedReplacement with the given replacement symbol. Otherwise,
+	 * the replacement symbool is set to nullptr, and the type is set to
+	 * NoReplacement. No other validation is performed.
+	 * 
+	 * The query is set to operand ObjectQuery::OperatorSearch and the tag value
+	 * is set to the given pattern.
+	 */
+	static SymbolRuleSet loadCrt(QTextStream& stream, const Map& replacement_map);
+	
+	/**
+	 * Writes rules to a cross reference table (CRT) stream.
+	 * 
+	 * Entries of type NoAssignment are skipped.
+	 * 
+	 * \see loadCrt
+	 */
+	void writeCrt(QTextStream& stream) const;
+	
+	
+	/**
+	 * Applies the matching rules to the object.
+	 * 
+	 * This operator can be used with Map::applyOnAllObjects etc.
+	 * 
+	 * Normally, you don't want to call this unless the new symbols are already
+	 * part of the object's map. Note that for efficiency, this should be
+	 * called on a squeezed() map.
+	 * 
+	 * \see apply
+	 */
+	bool operator()(Object* object, MapPart*, int) const;
+	
+	
+	/**
+	 * Options for importing of new colors and symbols in to a map.
+	 */
+	enum Option
+	{
+		ImportAllSymbols    = 0x01,
+		PreserveSymbolState = 0x02,
+		KeepUnusedSymbols   = 0x04,
+		KeepUnusedColors    = 0x08,
+	};
+	Q_DECLARE_FLAGS(Options, Option)
+	
+	/**
+	 * Adds colors and symbols from the symbol map to the object map,
+	 * and applies the rules.
+	 * 
+	 * Note that for efficiency, this should be called on a squeezed() map.
+	 */
+	void apply(Map& object_map, const Map& symbol_set, Options options = 0);
+	
+};
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(SymbolRuleSet::Options)
+
+
+#endif // OPENORIENTEERING_SYMBOL_RULE_SET_H

--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -1782,10 +1782,14 @@ void MapEditorController::showColorWindow(bool show)
 	color_dock_widget->setVisible(show);
 }
 
+
+
 void MapEditorController::loadSymbolsFromClicked()
 {
-	ReplaceSymbolSetDialog::showDialog(window, map);
+	ReplaceSymbolSetDialog::showDialog(window, *map);
 }
+
+
 void MapEditorController::loadColorsFromClicked()
 {
 	// TODO
@@ -3868,7 +3872,7 @@ bool MapEditorController::importMapFile(const QString& filename, bool show_error
 				                     Map::tr("Cannot open file:\n%1\nfor reading.").arg(crt_filename));
 				return false;
 			}
-			if (!ReplaceSymbolSetDialog::showDialogForCRT(window, map, &imported_map, crt_file))
+			if (!ReplaceSymbolSetDialog::showDialogForCRT(window, imported_map, *map, crt_file))
 			{
 				auto choice = QMessageBox::question(window, Map::tr("Import..."),
 				                                    Map::tr("Symbol replacement was canceled.\n"

--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -391,6 +391,7 @@ void MapEditorController::setEditingInProgress(bool value)
 		// Symbol menu
 		scale_all_symbols_act->setEnabled(!editing_in_progress);
 		load_symbols_from_act->setEnabled(!editing_in_progress);
+		load_crt_act->setEnabled(!editing_in_progress);
 		
 		updateObjectDependentActions();
 		updateSymbolDependentActions();
@@ -832,6 +833,7 @@ void MapEditorController::createActions()
 	symbol_window_act = newCheckAction("symbolwindow", tr("Symbol window"), this, SLOT(showSymbolWindow(bool)), "symbols.png", tr("Show/Hide the symbol window"), "symbol_dock_widget.html");
 	color_window_act = newCheckAction("colorwindow", tr("Color window"), this, SLOT(showColorWindow(bool)), "colors.png", tr("Show/Hide the color window"), "color_dock_widget.html");
 	load_symbols_from_act = newAction("loadsymbols", tr("Replace symbol set..."), this, SLOT(loadSymbolsFromClicked()), NULL, tr("Replace the symbols with those from another map file"), "symbol_replace_dialog.html");
+	load_crt_act = newAction("loadcrt", tr("Load CRT file..."), this, SLOT(loadCrtClicked()), NULL, tr("Assign new symbols by cross-reference table"), "symbol_replace_dialog.html");
 	/*QAction* load_colors_from_act = newAction("loadcolors", tr("Load colors from..."), this, SLOT(loadColorsFromClicked()), NULL, tr("Replace the colors with those from another map file"));*/
 	
 	scale_all_symbols_act = newAction("scaleall", tr("Scale all symbols..."), this, SLOT(scaleAllSymbolsClicked()), NULL, tr("Scale the whole symbol set"), "map_menu.html");
@@ -1089,6 +1091,7 @@ void MapEditorController::createMenuAndToolbars()
 	symbols_menu->addSeparator();
 	symbols_menu->addAction(scale_all_symbols_act);
 	symbols_menu->addAction(load_symbols_from_act);
+	symbols_menu->addAction(load_crt_act);
 	/*symbols_menu->addAction(load_colors_from_act);*/
 	
 	// Templates menu
@@ -1787,6 +1790,12 @@ void MapEditorController::showColorWindow(bool show)
 void MapEditorController::loadSymbolsFromClicked()
 {
 	ReplaceSymbolSetDialog::showDialog(window, *map);
+}
+
+
+void MapEditorController::loadCrtClicked()
+{
+	ReplaceSymbolSetDialog::showDialogForCRT(window, *map, *map);
 }
 
 

--- a/src/gui/map/map_editor.h
+++ b/src/gui/map/map_editor.h
@@ -296,6 +296,8 @@ public slots:
 	void showColorWindow(bool show);
 	/** Shows the "load symbols from" dialog. */
 	void loadSymbolsFromClicked();
+	/** Loads a CRT file and shows the symbol replacement dialog. */
+	void loadCrtClicked();
 	/** TODO: not implemented yet. */
 	void loadColorsFromClicked();
 	/** Shows the "scale all symbols" dialog. */
@@ -657,6 +659,7 @@ private:
 	QAction* color_window_act;
 	QPointer<EditorDockWidget> color_dock_widget;
 	QAction* load_symbols_from_act;
+	QAction* load_crt_act;
 	
 	QAction* symbol_window_act;
 	EditorDockWidget* symbol_dock_widget;

--- a/src/gui/symbols/replace_symbol_set_dialog.cpp
+++ b/src/gui/symbols/replace_symbol_set_dialog.cpp
@@ -254,12 +254,14 @@ void ReplaceSymbolSetDialog::openCrtFile()
 		{
 			for (auto& current : replacements)
 			{
-				if (item.type != SymbolRule::NoAssignment
-				    && item.query == current.query)
+				if (item.query == current.query)
 				{
-					current.symbol = item.symbol;
-					current.type = item.type;
-					item.type = SymbolRule::NoAssignment;
+					if (item.type != SymbolRule::NoAssignment)
+					{
+						current.symbol = item.symbol;
+						current.type = item.type;
+						item = {};
+					}
 					break;
 				}
 			}
@@ -268,7 +270,7 @@ void ReplaceSymbolSetDialog::openCrtFile()
 		{
 			for (auto&& item : new_replacements)
 			{
-				if (item.type != SymbolRule::NoAssignment)
+				if (item.query.getOperator() != ObjectQuery::OperatorInvalid)
 				{
 					replacements.emplace_back(std::move(item));
 				}

--- a/src/gui/symbols/replace_symbol_set_dialog.cpp
+++ b/src/gui/symbols/replace_symbol_set_dialog.cpp
@@ -595,6 +595,29 @@ bool ReplaceSymbolSetDialog::showDialog(QWidget* parent, Map& object_map)
 
 
 // static
+bool ReplaceSymbolSetDialog::showDialogForCRT(QWidget* parent, Map& object_map, const Map& symbol_set)
+{
+	auto replacements = SymbolRuleSet{};
+	ReplaceSymbolSetDialog dialog(parent, object_map, symbol_set, replacements, AssignByPattern);
+	dialog.setWindowModality(Qt::WindowModal);
+	dialog.show();
+	dialog.openCrtFile();
+	auto result = dialog.exec();
+	switch (result)
+	{
+	case QDialog::Accepted:
+		replacements.squeezed().apply(object_map, symbol_set);
+		return true;
+		
+	case QDialog::Rejected:
+		return false;
+	}
+	
+	Q_UNREACHABLE();
+}
+
+
+// static
 bool ReplaceSymbolSetDialog::showDialogForCRT(QWidget* parent, Map& object_map, const Map& symbol_set, QIODevice& crt_file)
 {
 	QTextStream stream{ &crt_file };

--- a/src/gui/symbols/replace_symbol_set_dialog.cpp
+++ b/src/gui/symbols/replace_symbol_set_dialog.cpp
@@ -449,36 +449,14 @@ void ReplaceSymbolSetDialog::updateMappingTable()
 				original_icon.fill(color);
 			}
 			
-			auto set_string_for_tags = [](const ObjectQuery& query, const char* op_string)->QString {
-				auto result = QString{};
-				if (auto operands = query.tagOperands())
-				{
-					result = operands->key + QLatin1String(op_string)
-					         + QLatin1Char('"') + operands->value + QLatin1Char('"');
-				}
-				return result;
-			};
-
 			switch (item.query.getOperator())
 			{
-			case ObjectQuery::OperatorContains:
-				original_string = set_string_for_tags(item.query, " ~ ");
-				break;
-				
-			case ObjectQuery::OperatorIs:
-				original_string = set_string_for_tags(item.query, " = ");
-				break;
-				
-			case ObjectQuery::OperatorIsNot:
-				original_string = set_string_for_tags(item.query, " != ");
-				break;
-									
-			case ObjectQuery::OperatorSearch:
-				original_string = set_string_for_tags(item.query, "");
+			case ObjectQuery::OperatorInvalid:
+			case ObjectQuery::OperatorSymbol:
 				break;
 				
 			default:
-				; // nothing
+				original_string = item.query.toString();
 			}
 		}
 		

--- a/src/gui/symbols/replace_symbol_set_dialog.cpp
+++ b/src/gui/symbols/replace_symbol_set_dialog.cpp
@@ -21,118 +21,132 @@
 
 #include "replace_symbol_set_dialog.h"
 
+#include <algorithm>
+
+#include <QAction>
 #include <QCheckBox>
 #include <QDialogButtonBox>
+#include <QFile>
+#include <QFileDialog>
+#include <QFormLayout>
+#include <QGuiApplication>
 #include <QHeaderView>
 #include <QLabel>
+#include <QMenu>
 #include <QMessageBox>
+#include <QPushButton>
 #include <QSet>
 #include <QTableWidget>
 #include <QTextStream>
-#include <QVBoxLayout>
+#include <QToolButton>
 
+#include "settings.h"
 #include "core/map.h"
 #include "core/objects/object.h"
+#include "core/symbols/line_symbol.h"
+#include "core/symbols/point_symbol.h"
+#include "core/symbols/text_symbol.h"
 #include "fileformats/file_format.h"
+#include "fileformats/file_format_registry.h"
 #include "gui/main_window.h"
+#include "gui/util_gui.h"
 #include "gui/widgets/symbol_dropdown.h"
 #include "undo/undo_manager.h"
 #include "util/util.h"
+#include "util/backports.h"
 
 
-//### ReplaceSymbolSetOperation ###
-
-struct ReplaceSymbolSetOperation
-{
-	using SymbolMapping = ReplaceSymbolSetDialog::SymbolMapping;
-	using ConstSymbolMapping = ReplaceSymbolSetDialog::ConstSymbolMapping;
-	
-	ReplaceSymbolSetOperation(ConstSymbolMapping& mapping, SymbolMapping& import_symbol_map) noexcept
-	 : mapping{ mapping }
-	 , import_symbol_map{ import_symbol_map }
-	{
-		// nothing else
-	}
-	
-	bool operator()(Object* object, MapPart*, int) const
-	{
-		if (mapping.contains(object->getSymbol()))
-		{
-			auto target_symbol = import_symbol_map.value(mapping.value(object->getSymbol()));
-			object->setSymbol(target_symbol, true);
-		}
-		return true;
-	}
-	
-private:
-	const ConstSymbolMapping& mapping;
-	const SymbolMapping& import_symbol_map;
-};
-
-
-
-//### ReplaceSymbolSetDialog ###
-
-ReplaceSymbolSetDialog::ReplaceSymbolSetDialog(QWidget* parent, Map* map, const Map* symbol_map, Mode mode)
+ReplaceSymbolSetDialog::ReplaceSymbolSetDialog(QWidget* parent, Map& object_map, const Map& symbol_set, SymbolRuleSet& replacements, Mode mode)
  : QDialog{ parent, Qt::WindowSystemMenuHint | Qt::WindowTitleHint }
- , map{ map }
- , symbol_map{ symbol_map }
- , mode{ mode }
+ , object_map{ object_map }
+ , symbol_set{ symbol_set }
+ , replacements{ replacements }
+ , import_all_check{ nullptr }
+ , delete_unused_symbols_check{ nullptr }
+ , delete_unused_colors_check{ nullptr }
+ , preserve_symbol_states_check{ nullptr }
+ , mode( &object_map==&symbol_set ? AssignByPattern : mode )
 {
-	auto check_enabled_default = mode != ModeCRT;
+	QFormLayout* form_layout = nullptr;
+	auto mapping_menu = new QMenu(this);
 	
-	setWindowTitle(tr("Replace symbol set"));
-	
-	QLabel* desc_label = new QLabel(tr("Configure how the symbols should be replaced, and which."));
-	
-	import_all_check = new QCheckBox(tr("Import all new symbols, even if not used as replacement"));
-	import_all_check->setChecked(check_enabled_default);
-	import_all_check->setEnabled(check_enabled_default);
-	delete_unused_symbols_check = new QCheckBox(tr("Delete original symbols which are unused after the replacement"));
-	delete_unused_symbols_check->setChecked(check_enabled_default);
-	delete_unused_symbols_check->setEnabled(check_enabled_default);
-	delete_unused_colors_check = new QCheckBox(tr("Delete unused colors after the replacement"));
-	delete_unused_colors_check->setChecked(check_enabled_default);
-	delete_unused_colors_check->setEnabled(check_enabled_default);
-	
-	QLabel* mapping_label = new QLabel(tr("Symbol mapping:"));
-	preserve_symbol_states_check = new QCheckBox(tr("Keep the symbols' hidden / protected states of the old symbol set"));
-	preserve_symbol_states_check->setChecked(check_enabled_default);
-	preserve_symbol_states_check->setEnabled(check_enabled_default);
-	match_by_number_check = new QCheckBox(tr("Match replacement symbols by symbol number"));
-	match_by_number_check->setChecked(true);
+	QStringList horizontal_headers;
+	horizontal_headers.reserve(2);
+	if (mode == ReplaceSymbolSet)
+	{
+		setWindowTitle(tr("Replace symbol set"));
+		form_layout = new QFormLayout();
+		QLabel* desc_label = new QLabel(tr("Configure how the symbols should be replaced, and which."));
+		form_layout->addRow(desc_label);
+		form_layout->addItem(Util::SpacerItem::create(this));
+		import_all_check = new QCheckBox(tr("Import all new symbols, even if not used as replacement"));
+		import_all_check->setChecked(true);
+		form_layout->addRow(import_all_check);
+		preserve_symbol_states_check = new QCheckBox(tr("Keep the symbols' hidden / protected states of the old symbol set"));
+		preserve_symbol_states_check->setChecked(true);
+		form_layout->addRow(preserve_symbol_states_check);
+		delete_unused_symbols_check = new QCheckBox(tr("Delete original symbols which are unused after the replacement"));
+		delete_unused_symbols_check->setChecked(true);
+		form_layout->addRow(delete_unused_symbols_check);
+		delete_unused_colors_check = new QCheckBox(tr("Delete unused colors after the replacement"));
+		delete_unused_colors_check->setChecked(true);
+		form_layout->addRow(delete_unused_colors_check);
+		form_layout->addItem(Util::SpacerItem::create(this));
+		
+		horizontal_headers << tr("Original") << tr("Replacement");
+		
+		auto action = mapping_menu->addAction(tr("Match replacement symbols by symbol number"));
+		connect(action, &QAction::triggered, this, &ReplaceSymbolSetDialog::matchByNumber);
+		action = mapping_menu->addAction(tr("Match by symbol name"));
+		connect(action, &QAction::triggered, this, &ReplaceSymbolSetDialog::matchByName);
+	}
+	else
+	{
+		setWindowTitle(tr("Assign new symbols"));
+		horizontal_headers << tr("Pattern") << tr("Replacement");
+	}
 	
 	mapping_table = new QTableWidget();
 	mapping_table->verticalHeader()->setVisible(false);
 	mapping_table->setColumnCount(2);
-	mapping_table->setHorizontalHeaderLabels(QStringList() << tr("Original") << tr("Replacement"));
+	mapping_table->setHorizontalHeaderLabels(horizontal_headers);
 	mapping_table->horizontalHeader()->setSectionsClickable(false);
 	mapping_table->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
 	mapping_table->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+	mapping_table->setEditTriggers(QAbstractItemView::AllEditTriggers);
+	
+	auto action = mapping_menu->addAction(tr("Clear replacements"));
+	connect(action, &QAction::triggered, this, &ReplaceSymbolSetDialog::resetReplacements);
+	mapping_menu->addSeparator();
+	action = mapping_menu->addAction(QIcon{QLatin1String{":/images/open.png"}}, tr("Open CRT file..."));
+	connect(action, &QAction::triggered, this, &ReplaceSymbolSetDialog::openCrtFile);
+	action = mapping_menu->addAction(QIcon{QLatin1String{":/images/save.png"}}, tr("Save CRT file..."));
+	connect(action, &QAction::triggered, this, &ReplaceSymbolSetDialog::saveCrtFile);
 	
 	QDialogButtonBox* button_box = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel | QDialogButtonBox::Help, Qt::Horizontal);
+	auto mapping_button = button_box->addButton(tr("Symbol mapping:").replace(QLatin1Char{':'}, QString{}), QDialogButtonBox::ActionRole);
+	void(tr("Symbol mapping")); /// \todo Switch translation
+	mapping_button->setMenu(mapping_menu);
 	
-	QVBoxLayout* layout = new QVBoxLayout();
-	layout->addWidget(desc_label);
-	layout->addSpacing(16);
-	layout->addWidget(import_all_check);
-	layout->addWidget(delete_unused_symbols_check);
-	layout->addWidget(delete_unused_colors_check);
-	layout->addSpacing(16);
-	layout->addWidget(mapping_label);
-	layout->addWidget(preserve_symbol_states_check);
-	layout->addWidget(match_by_number_check);
+	auto layout = new QVBoxLayout(this);
+	if (form_layout)
+		layout->addLayout(form_layout);
 	layout->addWidget(mapping_table);
-	layout->addSpacing(16);
+	layout->addItem(Util::SpacerItem::create(this));
 	layout->addWidget(button_box);
 	setLayout(layout);
 	
-	connect(match_by_number_check, &QAbstractButton::clicked, this, &ReplaceSymbolSetDialog::matchByNumberClicked);
 	connect(button_box, &QDialogButtonBox::helpRequested, this, &ReplaceSymbolSetDialog::showHelp);
-	connect(button_box, &QDialogButtonBox::accepted, this, &ReplaceSymbolSetDialog::apply);
+	connect(button_box, &QDialogButtonBox::accepted, this, &QDialog::accept);
 	connect(button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
 	
-	matchByNumberClicked(true);
+	if (replacements.empty() && mode == ReplaceSymbolSet)
+	{
+		this->replacements = SymbolRuleSet::forOriginalSymbols(object_map);
+		this->replacements.matchQuerySymbolName(symbol_set);
+	}
+	
+	updateMappingTable();
 }
 
 
@@ -143,363 +157,482 @@ ReplaceSymbolSetDialog::~ReplaceSymbolSetDialog()
 
 
 
-void ReplaceSymbolSetDialog::matchByNumberClicked(bool checked)
-{
-	auto triggers = QAbstractItemView::AllEditTriggers;
-	auto flags    = Qt::ItemIsEnabled | Qt::ItemIsEditable;
-	if (checked)
-	{
-		calculateNumberMatchMapping();
-		updateMappingTable();
-		triggers = QAbstractItemView::NoEditTriggers;
-		flags    = Qt::NoItemFlags;
-	}
-	
-	mapping_table->setEditTriggers(triggers);
-	for (int row = 0; row < mapping_table->rowCount(); ++row)
-	{
-		mapping_table->item(row, 1)->setFlags(flags);
-	}
-}
-
-
 void ReplaceSymbolSetDialog::showHelp()
 {
 	Util::showHelp(this, "symbol_replace_dialog.html");
 }
 
 
-void ReplaceSymbolSetDialog::apply()
+
+void ReplaceSymbolSetDialog::matchByName()
 {
-	SymbolMapping import_symbol_map;
-	
-	updateMappingFromTable();
-	
-	QSet<const Symbol*> old_symbols;
-	if (delete_unused_symbols_check->isChecked())
+	replacements.matchQuerySymbolName(symbol_set);
+	updateMappingTable();
+}
+
+
+void ReplaceSymbolSetDialog::matchByNumber()
+{
+	replacements.matchQuerySymbolNumber(symbol_set);
+	updateMappingTable();
+}
+
+
+void ReplaceSymbolSetDialog::resetReplacements()
+{
+	for (auto& item : replacements)
 	{
-		for (int i = 0; i < map->getNumSymbols(); ++i)
-			old_symbols.insert(map->getSymbol(i));
+		item.symbol = nullptr;
+		item.type = SymbolRule::NoAssignment;
 	}
+	updateMappingTable();
+}
+
+
+
+void ReplaceSymbolSetDialog::openCrtFile()
+{
+	auto dir = QLatin1String{"data:/symbol sets"};
+	auto filter = QString{tr("CRT file") + QLatin1String{" (*.crt *.CRT)"}};
+	QString path = QFileDialog::getOpenFileName(this, tr("Open CRT file..."), dir, filter);
+	if (path.isEmpty())
+		return;
 	
-	// Import new symbols
-	auto symbol_filter = std::unique_ptr<std::vector<bool>>{ nullptr };
-	if (!import_all_check->isChecked())
+	QFile crt_file{path};
+	crt_file.open(QIODevice::ReadOnly);
+	QTextStream stream{ &crt_file };
+	auto new_replacements = SymbolRuleSet::loadCrt(stream, symbol_set);
+	if (stream.status() == QTextStream::Ok)
 	{
-		// Import only symbols which are chosen as replacement symbols
-		symbol_filter.reset(new std::vector<bool>(std::size_t(symbol_map->getNumSymbols()), false));
-		for (int i = 0; i < symbol_map->getNumSymbols(); ++i)
+		// Postprocess CRT
+		for (auto& item : new_replacements)
 		{
-			for (auto it = mapping.begin(), end = mapping.end(); it != end; ++it)
+			if (item.type == SymbolRule::NoAssignment
+			    || item.query.getOperator() != ObjectQuery::OperatorSearch)
+				continue;
+			Q_ASSERT(item.symbol);
+			
+			auto operands = item.query.tagOperands();
+			if (!operands || operands->value.isEmpty())
+				continue;
+			
+			// Find original symbol number matching the pattern
+			for (int i = 0; i < object_map.getNumSymbols(); ++i)
 			{
-				if (it.value() == symbol_map->getSymbol(i))
+				auto symbol = object_map.getSymbol(i);
+				if (symbol->getNumberAsString() == operands->value)
 				{
-					symbol_filter->at(i) = true;
+					if (Symbol::areTypesCompatible(symbol->getType(), item.symbol->getType()))
+						item.query = { symbol };
+					break;
+				}
+			}
+			
+			// Find inconsistencies
+			if (item.query.getOperator() == ObjectQuery::OperatorSymbol)
+			{
+				auto has_conflict = [&item](const auto& other)->bool {
+					return &other != &item
+					       && other.type != SymbolRule::NoAssignment
+					       && item.query == other.query
+					       && item.symbol != other.symbol;
+				};
+				if (std::any_of(begin(new_replacements), end(new_replacements), has_conflict))
+				{
+					stream.setStatus(QTextStream::ReadCorruptData);
+					auto error_msg = tr("There are multiple replacements for symbol %1.")
+					                 .arg(item.query.symbolOperand()->getNumberAsString());
+					QMessageBox::warning(this, Map::tr("Error"),
+					  tr("Cannot open file:\n%1\n\n%2").arg(path).arg(error_msg) );
+					return;
+				}
+			}
+		}
+		
+		// Apply
+		for (auto& item : new_replacements)
+		{
+			for (auto& current : replacements)
+			{
+				if (item.type != SymbolRule::NoAssignment
+				    && item.query == current.query)
+				{
+					current.symbol = item.symbol;
+					current.type = item.type;
+					item.type = SymbolRule::NoAssignment;
 					break;
 				}
 			}
 		}
-	}
-	map->importMap(symbol_map, Map::MinimalSymbolImport, this, symbol_filter.get(), -1, false, &import_symbol_map);
-	
-	// Take over hidden / protected states from old symbol set?
-	if (preserve_symbol_states_check->isChecked())
-	{
-		for (auto it = mapping.begin(), end = mapping.end(); it != end; ++it)
+		if (mode == AssignByPattern)
 		{
-			auto target_symbol = import_symbol_map.value(it.value());
-			target_symbol->setHidden(it.key()->isHidden());
-			target_symbol->setProtected(it.key()->isProtected());
+			for (auto&& item : new_replacements)
+			{
+				if (item.type != SymbolRule::NoAssignment)
+				{
+					replacements.emplace_back(std::move(item));
+				}
+			}
 		}
-	}
-	
-	// Change symbols for all objects
-	map->applyOnAllObjects(ReplaceSymbolSetOperation(mapping, import_symbol_map));
-	
-	// Delete unused old symbols
-	if (delete_unused_symbols_check->isChecked())
-	{
-		std::vector<bool> symbols_in_use;
-		map->determineSymbolsInUse(symbols_in_use);
 		
-		for (int i = map->getNumSymbols() - 1; i >= 0; --i)
+		updateMappingTable();
+	}
+}
+
+
+bool ReplaceSymbolSetDialog::saveCrtFile()
+{
+	/// \todo Choose user-writable directory.
+	auto dir = QLatin1String{"data:/symbol sets"};
+	auto filter = QString{tr("CRT file") + QLatin1String{" (*.crt *.CRT)"}};
+	QString path = QFileDialog::getSaveFileName(this, tr("Save CRT file..."), dir, filter);
+	if (!path.isEmpty())
+	{
+		updateMappingFromTable();
+		QFile crt_file{path};
+		crt_file.open(QIODevice::WriteOnly);
+		QTextStream stream{ &crt_file };
+		replacements.writeCrt(stream);
+		if (stream.pos() != -1)
 		{
-			auto symbol = map->getSymbol(i);
-			if (!old_symbols.contains(symbol) || symbols_in_use[i])
-				continue;
+			return true;
+		}
+		/// \todo Reused translation, consider generalized context
+		QMessageBox::warning(this, Map::tr("Error"),
+		                     tr("Cannot save file:\n%1\n\n%2").arg(path).arg(crt_file.errorString()) );
+	}
+	return false;
+}
+
+
+
+void ReplaceSymbolSetDialog::done(int r)
+{
+	updateMappingFromTable();
+	if (std::any_of(begin(replacements), end(replacements), [](const auto& item) {
+	                return item.type == SymbolRule::ManualAssignment;
+	}))
+	{
+		auto save_crt = QMessageBox::warning(this, qGuiApp->applicationDisplayName(),
+		                                     tr("The cross reference table has been modified.\n"
+		                                        "Do you want to save your changes?"),
+		                                     // QGnomeThema label for Discard: "Close without saving"
+		                                     QMessageBox::Save | QMessageBox::No | QMessageBox::Cancel);
+		switch (save_crt)
+		{
+		case QMessageBox::Cancel:
+			return;
 			
-			map->deleteSymbol(i);
+		case QMessageBox::Discard:
+		case QMessageBox::No:
+			break;
+			
+		case QMessageBox::Save:
+			if (!saveCrtFile())
+				return;
+			break;
+			
+		default:
+			Q_UNREACHABLE();
 		}
 	}
-	
-	// Delete unused colors
-	if (delete_unused_colors_check->isChecked())
-	{
-		std::vector<bool> all_symbols;
-		all_symbols.assign(map->getNumSymbols(), true);
-		std::vector<bool> colors_in_use;
-		map->determineColorsInUse(all_symbols, colors_in_use);
-		if (colors_in_use.empty())
-			colors_in_use.assign(map->getNumColors(), false);
-		
-		for (int i = map->getNumColors() - 1; i >= 0; --i)
-		{
-			if (!colors_in_use[i])
-				map->deleteColor(i);
-		}
-	}
-	
-	// Finish
-	map->updateAllObjects();
-	map->setObjectsDirty();
-	map->setSymbolsDirty();
-	map->undoManager().clear();
-	accept();
+	QDialog::done(r);
 }
 
-
-void ReplaceSymbolSetDialog::calculateNumberMatchMapping()
-{
-	mapping.clear();
-	
-	for (int i = 0; i < map->getNumSymbols(); ++i)
-	{
-		auto original = map->getSymbol(i);
-		auto replacement = findNumberMatch(original, false);
-		if (!replacement)
-			// No match found. Do a second pass which ignores trailing zeros.
-			replacement = findNumberMatch(original, true);
-		
-		if (replacement)
-			mapping.insert(original, replacement);
-	}
-}
-
-
-const Symbol* ReplaceSymbolSetDialog::findNumberMatch(const Symbol* original, bool ignore_trailing_zeros)
-{
-	for (int k = 0; k < symbol_map->getNumSymbols(); ++k)
-	{
-		auto replacement = symbol_map->getSymbol(k);
-		if (original->numberEquals(replacement, ignore_trailing_zeros) &&
-			Symbol::areTypesCompatible(original->getType(), replacement->getType()))
-		{
-			return replacement;
-		}
-	}
-	return nullptr;
-}
 
 
 void ReplaceSymbolSetDialog::updateMappingTable()
 {
+	mapping_table->setUpdatesEnabled(false);
+	
 	mapping_table->clearContents();
-	mapping_table->setRowCount(map->getNumSymbols());
+	mapping_table->setRowCount(int(replacements.size()));
 	
 	symbol_widget_delegates.clear();
-	symbol_widget_delegates.resize(map->getNumSymbols());
+	symbol_widget_delegates.resize(replacements.size());
 	
-	for (int row = 0; row < map->getNumSymbols(); ++row)
+	std::size_t row = 0;
+	for (const auto& item : replacements)
 	{
-		Symbol* original_symbol = map->getSymbol(row);
-		auto original_string = original_symbol->getPlainTextName();
-		if (mode != ModeCRT)
+		const Symbol* original_symbol = nullptr;
+		auto original_icon = QImage{};
+		auto original_string = QString{};
+		auto compatible_symbols = int(Symbol::AllSymbols);
+		const auto replacement_symbol = item.symbol;
+		
+		if (item.query.getOperator() == ObjectQuery::OperatorSymbol
+		    && item.query.symbolOperand())
+		{
+			original_symbol = item.query.symbolOperand();
+			original_string = original_symbol->getPlainTextName();
 			original_string.prepend(original_symbol->getNumberAsString() + QLatin1Char(' '));
+			original_icon = original_symbol->getIcon(&object_map);
+			compatible_symbols = Symbol::getCompatibleTypes(original_symbol->getType());
+		}
+		else
+		{
+			if (replacement_symbol)
+			{
+				switch (replacement_symbol->getType())
+				{
+				case Symbol::Area:
+					original_icon = object_map.getUndefinedLine()->getIcon(&object_map);
+					original_string = QCoreApplication::translate("SymbolRenderWidget", "Area");
+					compatible_symbols = Symbol::getCompatibleTypes(replacement_symbol->getType());
+					break;
+				case Symbol::Combined:
+					original_icon = object_map.getUndefinedLine()->getIcon(&object_map);
+					original_string = QCoreApplication::translate("SymbolRenderWidget", "Combined");
+					compatible_symbols = Symbol::getCompatibleTypes(replacement_symbol->getType());
+					break;
+				case Symbol::Line:
+					original_icon = object_map.getUndefinedLine()->getIcon(&object_map);
+					original_string = QCoreApplication::translate("SymbolRenderWidget", "Line");
+					compatible_symbols = Symbol::getCompatibleTypes(replacement_symbol->getType());
+					break;
+				case Symbol::Point:
+					original_icon = object_map.getUndefinedPoint()->getIcon(&object_map);
+					original_string = QCoreApplication::translate("SymbolRenderWidget", "Point");
+					compatible_symbols = Symbol::getCompatibleTypes(replacement_symbol->getType());
+					break;
+				case Symbol::Text:
+					original_icon = object_map.getUndefinedText()->getIcon(&object_map);
+					original_string = QCoreApplication::translate("SymbolRenderWidget", "Text");
+					compatible_symbols = Symbol::getCompatibleTypes(replacement_symbol->getType());
+					break;
+				case Symbol::AllSymbols:
+				case Symbol::NoSymbol:
+					; // no icon, no string
+				}
+			}
+			
+			const Symbol* unique_symbol = nullptr;
+			auto matching_types = int(Symbol::NoSymbol);
+			auto update_matching = [&unique_symbol, &matching_types](Object* object, MapPart*, int)->bool {
+				if (auto symbol = object->getSymbol())
+				{
+					if (matching_types == Symbol::NoSymbol)
+					{
+						unique_symbol = symbol;
+						matching_types = Symbol::getCompatibleTypes(symbol->getType());
+					}
+					else
+					{
+						if (symbol != unique_symbol)
+							unique_symbol = nullptr;
+						matching_types |= Symbol::getCompatibleTypes(symbol->getType());
+					}
+				}
+				return true;
+			};
+			object_map.applyOnMatchingObjects(update_matching, item.query);
+			if (matching_types != Symbol::NoSymbol)
+			{
+				compatible_symbols = matching_types;
+				if (unique_symbol)
+				{
+					original_symbol = unique_symbol;
+					original_string = original_symbol->getPlainTextName();
+					original_string.prepend(original_symbol->getNumberAsString() + QLatin1Char(' '));
+					original_icon = original_symbol->getIcon(&object_map);
+				}
+			}
+			
+			if (original_icon.isNull())
+			{
+				auto side_length = Settings::getInstance().getSymbolWidgetIconSizePx();
+				original_icon = QImage{side_length, side_length, QImage::Format_ARGB32_Premultiplied};
+				auto color = object_map.getUndefinedColor()->operator const QColor &();
+				color.setAlphaF(0.5);
+				original_icon.fill(color);
+			}
+			
+			auto set_string_for_tags = [](const ObjectQuery& query, const char* op_string)->QString {
+				auto result = QString{};
+				if (auto operands = query.tagOperands())
+				{
+					result = operands->key + QLatin1String(op_string)
+					         + QLatin1Char('"') + operands->value + QLatin1Char('"');
+				}
+				return result;
+			};
+
+			switch (item.query.getOperator())
+			{
+			case ObjectQuery::OperatorContains:
+				original_string = set_string_for_tags(item.query, " ~ ");
+				break;
+				
+			case ObjectQuery::OperatorIs:
+				original_string = set_string_for_tags(item.query, " = ");
+				break;
+				
+			case ObjectQuery::OperatorIsNot:
+				original_string = set_string_for_tags(item.query, " != ");
+				break;
+									
+			case ObjectQuery::OperatorSearch:
+				original_string = set_string_for_tags(item.query, "");
+				break;
+				
+			default:
+				; // nothing
+			}
+		}
+		
 		QTableWidgetItem* original_item = new QTableWidgetItem(original_string);
 		original_item->setFlags(Qt::ItemIsEnabled); // make item non-editable
 		QVariantList original_item_data =
-			QVariantList() << qVariantFromValue<const Map*>(map) << qVariantFromValue<const Symbol*>(original_symbol);
+			QVariantList() << qVariantFromValue<const Map*>(&object_map) << qVariantFromValue<const Symbol*>(original_symbol);
 		original_item->setData(Qt::UserRole, QVariant(original_item_data));
-		original_item->setData(Qt::DecorationRole, original_symbol->getIcon(map));
-		mapping_table->setItem(row, 0, original_item);
+		original_item->setData(Qt::DecorationRole, original_icon);
+		mapping_table->setItem(int(row), 0, original_item);
 		
 		// Note on const: this is not a const method.
-		const Symbol* replacement_symbol = mapping.contains(original_symbol) ? mapping.value(original_symbol) : nullptr;
 		QTableWidgetItem* replacement_item;
 		if (replacement_symbol)
 			replacement_item = new QTableWidgetItem(replacement_symbol->getNumberAsString() + QLatin1Char(' ') + replacement_symbol->getPlainTextName());
 		else
 			replacement_item = new QTableWidgetItem(tr("- None -"));
 		QVariantList replacement_item_data =
-			QVariantList() << qVariantFromValue<const Map*>(symbol_map) << qVariantFromValue<const Symbol*>(replacement_symbol);
+			QVariantList() << qVariantFromValue<const Map*>(&symbol_set) << qVariantFromValue<const Symbol*>(replacement_symbol);
 		replacement_item->setData(Qt::UserRole, QVariant(replacement_item_data));
 		if (replacement_symbol)
-			replacement_item->setData(Qt::DecorationRole, replacement_symbol->getIcon(symbol_map));
-		mapping_table->setItem(row, 1, replacement_item);
+			replacement_item->setData(Qt::DecorationRole, replacement_symbol->getIcon(&symbol_set));
+		mapping_table->setItem(int(row), 1, replacement_item);
 		
-		auto hide = (mode == ModeCRT && original_symbol->isHidden());
-		mapping_table->setRowHidden(row, hide);
+		//auto hide = (mode == ModeCRT && original_symbol->isHidden());
+		//mapping_table->setRowHidden(row, hide);
 		
-		symbol_widget_delegates[row].reset(new SymbolDropDownDelegate(Symbol::getCompatibleTypes(original_symbol->getType())));
-		mapping_table->setItemDelegateForRow(row, symbol_widget_delegates[row].get());
+		symbol_widget_delegates[row].reset(new SymbolDropDownDelegate(compatible_symbols));
+		mapping_table->setItemDelegateForRow(int(row), symbol_widget_delegates[row].get());
+		
+		++row;
 	}
+	
+	mapping_table->setUpdatesEnabled(true);
 }
 
 
 void ReplaceSymbolSetDialog::updateMappingFromTable()
 {
-	mapping.clear();
-	
-	for (int row = 0; row < map->getNumSymbols(); ++row)
+	Q_ASSERT(int(replacements.size()) == mapping_table->rowCount());
+	auto item = begin(replacements);
+	for (int row = 0; row < mapping_table->rowCount(); ++row)
 	{
 		auto replacement_symbol = mapping_table->item(row, 1)->data(Qt::UserRole).toList().at(1).value<const Symbol*>();
-		if (replacement_symbol)
-			mapping.insert(map->getSymbol(row), replacement_symbol);
+		if (item->symbol != replacement_symbol)
+		{
+			item->symbol = replacement_symbol;
+			item->type = SymbolRule::ManualAssignment;
+		}
+		++item;
 	}
 }
 
 
 
-bool ReplaceSymbolSetDialog::showDialog(QWidget* parent, Map* map)
+// static
+bool ReplaceSymbolSetDialog::showDialog(QWidget* parent, Map& object_map)
 {
-	auto symbol_map = std::unique_ptr<Map>{ nullptr };
-	while (true)
+	auto symbol_set = std::unique_ptr<Map>{};
+	while (!symbol_set)
 	{
 		auto path = MainWindow::getOpenFileName(parent, tr("Choose map file to load symbols from"),
 		                                        FileFormat::MapFile);
 		if (path.isEmpty())
 			return false;
 		
-		symbol_map.reset(new Map);
-		if (!symbol_map->loadFrom(path, parent, nullptr, true))
+		symbol_set.reset(new Map);
+		if (!symbol_set->loadFrom(path, parent, nullptr, true))
 		{
 			QMessageBox::warning(parent, tr("Error"), tr("Cannot load map file, aborting."));
 			return false;
 		}
 		
-		if (symbol_map->getScaleDenominator() != map->getScaleDenominator())
+		if (symbol_set->getScaleDenominator() != object_map.getScaleDenominator())
 		{
 			if (QMessageBox::warning(parent, tr("Warning"),
-				tr("The chosen symbol set has a scale of 1:%1, while the map scale is 1:%2. Do you really want to choose this set?").arg(symbol_map->getScaleDenominator()).arg(map->getScaleDenominator()),
+				tr("The chosen symbol set has a scale of 1:%1, while the map scale is 1:%2. Do you really want to choose this set?").arg(symbol_set->getScaleDenominator()).arg(object_map.getScaleDenominator()),
 				QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
 			{
-				continue;
+				symbol_set.reset(nullptr);
 			}
 		}
-		
-		break;
 	}
 	
-	ReplaceSymbolSetDialog dialog(parent, map, symbol_map.get());
+	auto replacements = SymbolRuleSet::forOriginalSymbols(object_map);
+	replacements.matchQuerySymbolName(*symbol_set);
+	
+	auto flags_from_dialog = [](const ReplaceSymbolSetDialog& dialog){
+		auto options = SymbolRuleSet::Options{};
+		if (dialog.import_all_check->isChecked())
+			options |= SymbolRuleSet::ImportAllSymbols;
+		if (dialog.preserve_symbol_states_check->isChecked())
+			options |= SymbolRuleSet::PreserveSymbolState;
+		if (!dialog.delete_unused_symbols_check->isChecked())
+			options |= SymbolRuleSet::KeepUnusedSymbols;
+		if (!dialog.delete_unused_colors_check->isChecked())
+			options |= SymbolRuleSet::KeepUnusedColors;
+		return options;
+	};
+
+	ReplaceSymbolSetDialog dialog(parent, object_map, *symbol_set, replacements, ReplaceSymbolSet);
 	dialog.setWindowModality(Qt::WindowModal);
 	auto result = dialog.exec();
-	return result == QDialog::Accepted;
+	switch (result)
+	{
+	case QDialog::Accepted:
+		replacements.squeezed().apply(object_map, *symbol_set, flags_from_dialog(dialog));
+		return true;
+		
+	case QDialog::Rejected:
+		return false;
+	}
+	
+	Q_UNREACHABLE();
 }
 
 
-bool ReplaceSymbolSetDialog::showDialogForCRT(QWidget* parent, const Map* base_map, Map* imported_map, QIODevice& crt_file)
+// static
+bool ReplaceSymbolSetDialog::showDialogForCRT(QWidget* parent, Map& object_map, const Map& symbol_set, QIODevice& crt_file)
 {
 	QTextStream stream{ &crt_file };
-	stream.setIntegerBase(10); // No autodectection; 001 is 1.
-	while (!stream.atEnd())
+	auto replacements = SymbolRuleSet::loadCrt(stream, symbol_set);
+	if (stream.status() != QTextStream::Ok)
 	{
-		int major = -1;
-		int minor =  0;
-		QChar separator;
-		stream >> major >> separator;
-		if (separator == QLatin1Char('.'))
-			stream >> minor;
-		auto layer = stream.readLine().trimmed();
+		QMessageBox::warning(parent, tr("Error"), tr("Cannot load CRT file, aborting."));
+		return false;
+	}
+	
+	for (auto& item : replacements)
+	{
+		if (item.query.getOperator() != ObjectQuery::OperatorSearch)
+			continue;
 		
-		// We use a tag with an empty key to temporarily save the index of the
-		// original symbol. This is needed to case to reset the data in case the
-		// dialog is canceled. In addition, this tag serves as a flag that an
-		// object was already handled.
-		auto query = [&layer](Object* object)->bool
+		auto operands = item.query.tagOperands();
+		if (operands && !operands->value.isEmpty())
 		{
-			const auto& tags = object->tags();
-			return !tags.contains({})
-			       && tags[QStringLiteral("Layer")] == layer;
-		};
-		
-		SymbolMapping layerized_symbols;
-		for (int i = 0; i < base_map->getNumSymbols(); ++i)
-		{
-			auto symbol = base_map->getSymbol(i);
-			
-			if (symbol->getNumberComponent(0) != major)
-				continue;
-			
-			if (minor > 0 && symbol->getNumberComponent(1) > 0
-			    && symbol->getNumberComponent(1) != minor)
-				continue;
-			
-			if (symbol->getNumberComponent(1) >= 0
-			    && symbol->getNumberComponent(2) >= 0)
-				continue;
-			
-			// Target symbol exists, now adjust imported symbols for automatic matching
-			auto layerize = [imported_map, symbol, &layer, &layerized_symbols](Object* object, MapPart*, int)->bool
-			{
-				if (symbol->isTypeCompatibleTo(object))
-				{
-				    auto object_symbol = object->getSymbol();
-					if (!layerized_symbols.contains(object_symbol))
-					{
-						auto layerized_symbol = object_symbol->duplicate();
-						layerized_symbol->setNumberComponent(0, symbol->getNumberComponent(0));
-						layerized_symbol->setNumberComponent(1, symbol->getNumberComponent(1));
-						layerized_symbol->setNumberComponent(2, symbol->getNumberComponent(2));
-						layerized_symbol->setName(layer);
-						imported_map->addSymbol(layerized_symbol, imported_map->getNumSymbols());
-						layerized_symbols.insert(object_symbol, layerized_symbol);
-					}
-					object->setSymbol(layerized_symbols[object_symbol], true);
-					object->setTag({}, QString::number(imported_map->findSymbolIndex(object_symbol)));
-				}
-				return false;
-			};
-			
-			imported_map->applyOnMatchingObjects(layerize, query);
+			// Construct layer queries
+			item.query = { QLatin1String("Layer"), ObjectQuery::OperatorIs, operands->value };
 		}
 	}
+		
+	/// \todo Collect source symbols for all patterns, for source icon in dialog
 	
-	// Hide symbols which are no longer in use
-	std::vector<bool> symbols_in_use;
-	imported_map->determineSymbolsInUse(symbols_in_use);
-	
-	for (int i = imported_map->getNumSymbols() - 1; i >= 0; --i)
-	{
-		if (!symbols_in_use[std::size_t(i)])
-			imported_map->getSymbol(i)->setHidden(true);
-	}
-	
-	// Now show the replacement dialog
-	ReplaceSymbolSetDialog dialog(parent, imported_map, base_map, ModeCRT);
+	ReplaceSymbolSetDialog dialog(parent, object_map, symbol_set, replacements, AssignByPattern);
 	dialog.setWindowModality(Qt::WindowModal);
-	const auto accepted = dialog.exec() == QDialog::Accepted;
-	
-	if (accepted)
+	auto result = dialog.exec();
+	switch (result)
 	{
-		// Accepted and done. Just remove the extra tag.
-		auto reset = [](Object* object, MapPart*, int)->bool
-		{
-			object->removeTag({});
-			return false;
-		};
-		imported_map->applyOnAllObjects(reset);
-	}
-	else
-	{
-		// Rejected. Restore the original symbols, and remove the extra tag.
-		auto num_symbols = imported_map->getNumSymbols();
-		for (int i = num_symbols - 1; i >= 0; --i)
-		{
-			imported_map->getSymbol(i)->setHidden(false);
-		}
-		auto unlayerize = [imported_map, num_symbols](Object* object, MapPart*, int)->bool
-		{
-			bool ok;
-			auto number = object->getTag({}).toInt(&ok);
-			if (ok && 0 <= number && number < num_symbols)
-			{
-				object->setSymbol(imported_map->getSymbol(number), false);
-			}
-			object->removeTag({});
-			return false;
-		};
-		imported_map->applyOnAllObjects(unlayerize);
+	case QDialog::Accepted:
+		replacements.squeezed().apply(object_map, symbol_set);
+		return true;
+		
+	case QDialog::Rejected:
+		return false;
 	}
 	
-	return accepted;
+	Q_UNREACHABLE();
 }
+

--- a/src/gui/symbols/replace_symbol_set_dialog.h
+++ b/src/gui/symbols/replace_symbol_set_dialog.h
@@ -27,9 +27,13 @@
 #include <QDialog>
 #include <QHash>
 
+#include "core/objects/symbol_rule_set.h"
+
+
 QT_BEGIN_NAMESPACE
 class QCheckBox;
 class QTableWidget;
+class QTextStream;
 QT_END_NAMESPACE
 
 class Map;
@@ -47,48 +51,47 @@ class ReplaceSymbolSetDialog : public QDialog
 {
 Q_OBJECT
 public:
-	using SymbolMapping      = QHash<const Symbol*, Symbol*>;
-	using ConstSymbolMapping = QHash<const Symbol*, const Symbol*>;
-	
 	/**
 	 * Lets the user select a file to load the symbols from and shows the dialog.
 	 * 
 	 * Returns true if the replacement has been finished, false if aborted.
 	 */
-	static bool showDialog(QWidget* parent, Map* map);
+	static bool showDialog(QWidget* parent, Map& object_map);
 	
 	/**
-	 * Shows the dialog for a given base map, imported map, and cross reference file.
+	 * Shows the dialog for a given object map, symbol map, and cross reference file.
 	 * 
-	 * The replacement takes place in the imported map.
 	 * Returns true if the replacement has been finished, false if aborted.
 	 */
-	static bool showDialogForCRT(QWidget* parent, const Map* base_map, Map* imported_map, QIODevice& crt_file);
-	
-private slots:
-	void matchByNumberClicked(bool checked);
-	void showHelp();
-	void apply();
+	static bool showDialogForCRT(QWidget* parent, Map& object_map, const Map& symbol_set, QIODevice& crt_file);
 	
 private:
 	enum Mode
 	{
-		ModeStandard,
-		ModeCRT
+		ReplaceSymbolSet,  ///< Replace current current symbols
+		AssignByPattern,   ///< Assign new symbols based on a pattern
 	};
 	
-	ReplaceSymbolSetDialog(QWidget* parent, Map* map, const Map* symbol_map, Mode mode = ModeStandard);
-	virtual ~ReplaceSymbolSetDialog();
+	ReplaceSymbolSetDialog(QWidget* parent, Map& object_map, const Map& symbol_set, SymbolRuleSet& replacements, Mode mode);
+	~ReplaceSymbolSetDialog() override;
 	
-	void calculateNumberMatchMapping();
-	const Symbol* findNumberMatch(const Symbol* original, bool ignore_trailing_zeros);
+	void showHelp();
+	
+	void matchByName();
+	void matchByNumber();
+	void resetReplacements();
+	
+	void openCrtFile();
+	bool saveCrtFile();
+	
+	void done(int r) override;
+	
 	void updateMappingTable();
 	void updateMappingFromTable();
 	
-	Map* map;
-	const Map* symbol_map;
-	ConstSymbolMapping mapping;
-	Mode mode;
+	Map& object_map;
+	const Map& symbol_set;
+	SymbolRuleSet& replacements;
 	
 	QCheckBox* import_all_check;
 	QCheckBox* delete_unused_symbols_check;
@@ -97,6 +100,8 @@ private:
 	QCheckBox* match_by_number_check;
 	QTableWidget* mapping_table;
 	std::vector<std::unique_ptr<SymbolDropDownDelegate>> symbol_widget_delegates;
+	
+	Mode mode;
 };
 
 #endif

--- a/src/gui/symbols/replace_symbol_set_dialog.h
+++ b/src/gui/symbols/replace_symbol_set_dialog.h
@@ -52,11 +52,18 @@ class ReplaceSymbolSetDialog : public QDialog
 Q_OBJECT
 public:
 	/**
-	 * Lets the user select a file to load the symbols from and shows the dialog.
+	 * Lets the user select a symbol set file, and shows the dialog.
 	 * 
 	 * Returns true if the replacement has been finished, false if aborted.
 	 */
 	static bool showDialog(QWidget* parent, Map& object_map);
+	
+	/**
+	 * Lets the user select a CRT file, and shows the dialog.
+	 * 
+	 * Returns true if the replacement has been finished, false if aborted.
+	 */
+	static bool showDialogForCRT(QWidget* parent, Map& object_map, const Map& symbol_set);
 	
 	/**
 	 * Shows the dialog for a given object map, symbol map, and cross reference file.

--- a/symbol sets/OSM-ISOM2000.crt
+++ b/symbol sets/OSM-ISOM2000.crt
@@ -1,0 +1,23 @@
+501.0  highway = motorway
+502    highway = primary OR highway = secondary OR highway = tertiary
+502    highway = trunk AND lanes = 2
+502    highway = trunk_link AND lanes = 1
+
+505    highway = track
+504    highway = track AND (smoothness = good OR smoothness = intermediate)
+505    highway = track AND (smoothness = bad OR smoothness = very_bad)
+506    highway = track AND (smoothness = horrible OR smoothness = very_horrible)
+
+507    highway = path
+506    highway = path AND (smoothness = good OR smoothness = intermediate)
+507    highway = path AND (smoothness = bad OR smoothness = very_bad)
+508    highway = path AND (smoothness = horrible OR smoothness = very_horrible)
+
+506    highway = footway
+
+504    (highway = unclassified OR highway = residential OR highway = service OR highway = living_street)
+503    (highway = unclassified OR highway = residential OR highway = service OR highway = living_street) AND (surface = asphalt OR surface = concrete OR surface = concrete:plates OR surface = concrete:lanes)
+503.1  (highway = unclassified OR highway = residential OR highway = service OR highway = living_street) AND (surface = compacted OR surface = gravel)
+504    (highway = unclassified OR highway = residential OR highway = service OR highway = living_street) AND (surface = ground OR surface = sand OR surface = unpaved)
+505    (highway = unclassified OR highway = residential) AND (surface = grass OR surface = dirt)
+

--- a/test/map_t.h
+++ b/test/map_t.h
@@ -46,6 +46,14 @@ private slots:
 	/** Tests various modes of Map::importMap(). */
 	void importTest_data();
 	void importTest();
+	
+	/** Basic tests for symbol set replacements. */
+	void crtFileTest();
+	
+	/** Tests symbol set replacements with example files. */
+	void matchQuerySymbolNumberTest_data();
+	void matchQuerySymbolNumberTest();
+	
 };
 
 #endif

--- a/test/object_query_t.cpp
+++ b/test/object_query_t.cpp
@@ -185,6 +185,25 @@ void ObjectQueryTest::testAndQuery()
 	QVERIFY(!query_and_invalid_3);
 }
 
+void ObjectQueryTest::testSearch()
+{
+	auto object = testObject();
+
+	ObjectQuery single_query_is_true_1{ObjectQuery::OperatorSearch, QLatin1String("Bc")};
+	QVERIFY(single_query_is_true_1(object) == true);
+	ObjectQuery single_query_is_true_2{ObjectQuery::OperatorSearch, QLatin1String("23")};
+	QVERIFY(single_query_is_true_2(object) == true);
+	ObjectQuery single_query_is_false_1{ObjectQuery::OperatorSearch, QLatin1String("Ac")};
+	QVERIFY(single_query_is_false_1(object) == false);
+	ObjectQuery single_query_is_false_2{ObjectQuery::OperatorSearch, QLatin1String("13")};
+	QVERIFY(single_query_is_false_2(object) == false);
+	
+	auto clone = single_query_is_true_1;
+	auto operands = clone.tagOperands();
+	QVERIFY(operands);
+	QCOMPARE(operands->value, QLatin1String("Bc"));
+}
+
 void ObjectQueryTest::testSymbol()
 {
 	PointSymbol symbol_1;

--- a/test/object_query_t.cpp
+++ b/test/object_query_t.cpp
@@ -67,6 +67,11 @@ void ObjectQueryTest::testIsQuery()
 	QCOMPARE(query_moved_false.getOperator(), ObjectQuery::OperatorIs);
 	QCOMPARE(single_query_is_false_2.getOperator(), ObjectQuery::OperatorInvalid);
 	QVERIFY(query_moved_false(object) == false);
+	
+	auto operands = query_moved_false.tagOperands();
+	QVERIFY(operands);
+	QCOMPARE(operands->key, QString::fromLatin1("d"));
+	QCOMPARE(operands->value, QString::fromLatin1("1"));
 }
 
 void ObjectQueryTest::testIsNotQuery()
@@ -122,6 +127,13 @@ void ObjectQueryTest::testOrQuery()
 	auto false_2 = ObjectQuery(QLatin1String("a"), ObjectQuery::OperatorIs, QLatin1String("2"));
 	ObjectQuery single_query_or_both_false{std::move(false_1), ObjectQuery::OperatorOr, std::move(false_2)};
 	QVERIFY(single_query_or_both_false(object) == false);
+	
+	auto operands = single_query_or_both_false.logicalOperands();
+	QVERIFY(operands);
+	QVERIFY(operands->first.get());
+	QCOMPARE(operands->first->getOperator(), ObjectQuery::OperatorIs);
+	QVERIFY(operands->second.get());
+	QCOMPARE(operands->second->getOperator(), ObjectQuery::OperatorIs);
 }
 
 void ObjectQueryTest::testAndQuery()

--- a/test/object_query_t.cpp
+++ b/test/object_query_t.cpp
@@ -62,13 +62,15 @@ void ObjectQueryTest::testIsQuery()
 	
 	auto query_copy_true = single_query_is_true;
 	QCOMPARE(query_copy_true.getOperator(), ObjectQuery::OperatorIs);
-	QCOMPARE(single_query_is_true.getOperator(), ObjectQuery::OperatorIs);
+	QCOMPARE(query_copy_true, single_query_is_true);
 	QVERIFY(query_copy_true(object) == true);
+	QVERIFY(query_copy_true != single_query_is_false_1);
 	
 	auto query_moved_false = std::move(single_query_is_false_2);
 	QCOMPARE(query_moved_false.getOperator(), ObjectQuery::OperatorIs);
 	QCOMPARE(single_query_is_false_2.getOperator(), ObjectQuery::OperatorInvalid);
 	QVERIFY(query_moved_false(object) == false);
+	QVERIFY(query_moved_false != single_query_is_false_2);
 	
 	auto operands = query_moved_false.tagOperands();
 	QVERIFY(operands);
@@ -172,8 +174,9 @@ void ObjectQueryTest::testAndQuery()
 	
 	auto query_copy_true = single_query_and_both_true;
 	QCOMPARE(query_copy_true.getOperator(), ObjectQuery::OperatorAnd);
-	QCOMPARE(single_query_and_both_true.getOperator(), ObjectQuery::OperatorAnd);
+	QCOMPARE(query_copy_true, single_query_and_both_true);
 	QVERIFY(query_copy_true(object) == true);
+	QVERIFY(query_copy_true != single_query_and_left_true_right_false);
 	
 	auto query_moved_false = std::move(single_query_and_right_true_left_false);
 	QCOMPARE(query_moved_false.getOperator(), ObjectQuery::OperatorAnd);
@@ -199,6 +202,8 @@ void ObjectQueryTest::testSearch()
 	QVERIFY(single_query_is_false_2(object) == false);
 	
 	auto clone = single_query_is_true_1;
+	QCOMPARE(clone, single_query_is_true_1);
+	QVERIFY(clone != single_query_is_true_2);
 	auto operands = clone.tagOperands();
 	QVERIFY(operands);
 	QCOMPARE(operands->value, QLatin1String("Bc"));
@@ -225,6 +230,8 @@ void ObjectQueryTest::testSymbol()
 	QCOMPARE(operand, &symbol_2);
 	
 	auto clone = symbol_query;
+	QCOMPARE(clone, symbol_query);
+	QVERIFY(clone != ObjectQuery{});
 	operand = clone.symbolOperand();
 	QVERIFY(operand);
 	QCOMPARE(operand, &symbol_2);

--- a/test/object_query_t.cpp
+++ b/test/object_query_t.cpp
@@ -55,10 +55,14 @@ void ObjectQueryTest::testIsQuery()
 
 	ObjectQuery single_query_is_true{QLatin1String("a"), ObjectQuery::OperatorIs, QLatin1String("1")};
 	QVERIFY(single_query_is_true(object) == true);
+	QVERIFY(single_query_is_true == single_query_is_true);
+	QVERIFY(single_query_is_true != ObjectQuery{});
 	ObjectQuery single_query_is_false_1{QLatin1String("a"), ObjectQuery::OperatorIs, QLatin1String("2")};
 	QVERIFY(single_query_is_false_1(object) == false);
 	ObjectQuery single_query_is_false_2{QLatin1String("d"), ObjectQuery::OperatorIs, QLatin1String("1")}; // key d doesn't exist
 	QVERIFY(single_query_is_false_2(object) == false);
+	QVERIFY(single_query_is_false_2 != single_query_is_true);
+	QVERIFY(single_query_is_true != single_query_is_false_2);
 	
 	auto query_copy_true = single_query_is_true;
 	QCOMPARE(query_copy_true.getOperator(), ObjectQuery::OperatorIs);
@@ -116,11 +120,15 @@ void ObjectQueryTest::testOrQuery()
 	auto true_2 = ObjectQuery(QLatin1String("a"), ObjectQuery::OperatorIs, QLatin1String("1"));
 	ObjectQuery single_query_or_both_true{std::move(true_1), ObjectQuery::OperatorOr, std::move(true_2)};
 	QVERIFY(single_query_or_both_true(object) == true);
+	QVERIFY(single_query_or_both_true == single_query_or_both_true);
+	QVERIFY(single_query_or_both_true != ObjectQuery{});
 
 	true_1 = ObjectQuery(QLatin1String("a"), ObjectQuery::OperatorIs, QLatin1String("1"));
 	auto false_1 = ObjectQuery(QLatin1String("a"), ObjectQuery::OperatorIs, QLatin1String("2"));
 	ObjectQuery single_query_or_left_true_right_false{std::move(true_1), ObjectQuery::OperatorOr, std::move(false_1)};
 	QVERIFY(single_query_or_left_true_right_false(object) == true);
+	QVERIFY(single_query_or_left_true_right_false != single_query_or_both_true);
+	QVERIFY(single_query_or_both_true != single_query_or_left_true_right_false);
 
 	true_1 = ObjectQuery(QLatin1String("a"), ObjectQuery::OperatorIs, QLatin1String("1"));
 	false_1 = ObjectQuery(QLatin1String("a"), ObjectQuery::OperatorIs, QLatin1String("2"));

--- a/test/object_query_t.cpp
+++ b/test/object_query_t.cpp
@@ -1,5 +1,6 @@
 /*
  *    Copyright 2016 Mitchell Krome
+ *    Copyright 2017 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -23,6 +24,7 @@
 
 #include "core/objects/object.h"
 #include "core/objects/object_query.h"
+#include "core/symbols/point_symbol.h"
 
 
 ObjectQueryTest::ObjectQueryTest(QObject* parent)
@@ -181,6 +183,32 @@ void ObjectQueryTest::testAndQuery()
 	auto query_and_invalid_3 = ObjectQuery(std::move(query_and_invalid_1), ObjectQuery::OperatorAnd, std::move(true_2));
 	QCOMPARE(query_and_invalid_3.getOperator(), ObjectQuery::OperatorInvalid);
 	QVERIFY(!query_and_invalid_3);
+}
+
+void ObjectQueryTest::testSymbol()
+{
+	PointSymbol symbol_1;
+	PointObject object(&symbol_1);
+	
+	auto symbol_query = ObjectQuery(&symbol_1);
+	QCOMPARE(symbol_query.getOperator(), ObjectQuery::OperatorSymbol);
+	QVERIFY(symbol_query(&object) == true);
+	
+	PointSymbol symbol_2;
+	symbol_query = ObjectQuery(&symbol_2);
+	QVERIFY(symbol_query(&object) == false);
+	
+	object.setSymbol(&symbol_2, false);
+	QVERIFY(symbol_query(&object) == true);
+	
+	auto operand = symbol_query.symbolOperand();
+	QVERIFY(operand);
+	QCOMPARE(operand, &symbol_2);
+	
+	auto clone = symbol_query;
+	operand = clone.symbolOperand();
+	QVERIFY(operand);
+	QCOMPARE(operand, &symbol_2);
 }
 
 QTEST_APPLESS_MAIN(ObjectQueryTest)

--- a/test/object_query_t.h
+++ b/test/object_query_t.h
@@ -43,6 +43,7 @@ private slots:
 	void testSearch();
 	void testSymbol();
 	void testToString();
+	void testParser();
 
 private:
 	const Object* testObject();

--- a/test/object_query_t.h
+++ b/test/object_query_t.h
@@ -42,6 +42,7 @@ private slots:
 	void testAndQuery();
 	void testSearch();
 	void testSymbol();
+	void testToString();
 
 private:
 	const Object* testObject();

--- a/test/object_query_t.h
+++ b/test/object_query_t.h
@@ -1,5 +1,6 @@
 /*
  *    Copyright 2016 Mitchell Krome
+ *    Copyright 2017 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -39,6 +40,7 @@ private slots:
 	void testContainsQuery();
 	void testOrQuery();
 	void testAndQuery();
+	void testSymbol();
 
 private:
 	const Object* testObject();

--- a/test/object_query_t.h
+++ b/test/object_query_t.h
@@ -40,6 +40,7 @@ private slots:
 	void testContainsQuery();
 	void testOrQuery();
 	void testAndQuery();
+	void testSearch();
 	void testSymbol();
 
 private:


### PR DESCRIPTION
Until now, CRT file support was limited to DXF import. These changes leverage ObjectQuery for powerful symbol replacement and CRT file support:
- CRT files may be loaded during symbol set replacement operations.
- CRT files may be loaded at any time, searching for symbol numbers or any tag contents. In the future, there could be complex queries, e.g. for complex OSM tag combinations.
- Symbol replacement/assignments may be saved to CRT files.
