### PR TITLE
Build and upload AppImage for each git push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ install:
     - sudo apt-get update
     - sudo apt-get -y install gcc-4.9 g++-4.9
     - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9
-    - echo "xxxxxxxxxxxxxxxxxxxxxxxxxxx"
-    - find /opt | grep "libQt5Network.so.5"
 
 script:
   - cmake . -DCMAKE_INSTALL_PREFIX=/usr
@@ -26,7 +24,7 @@ script:
 after_success:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage
-  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - unset QTDIR; unset QT_PLUGIN_PATH # ; unset LD_LIBRARY_PATH
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ before_install:
 install: 
     - sudo apt-get -y install qt59base qt59base cmake doxygen libcups2-dev libgdal-dev libpolyclipping-dev libproj-dev zlib1g-dev qt59tools 
     - source /opt/qt*/bin/qt*-env.sh
+    - # Needs newer compiler
+    - sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+    - sudo apt-get update
+    - sudo apt-get install gcc-4.9 g++-4.9
+    - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9
 
 script:
   - cmake . -DCMAKE_INSTALL_PREFIX=/usr

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ install:
     - sudo apt-get -y install qt59base qt59base cmake doxygen libcups2-dev libgdal-dev libpolyclipping-dev libproj-dev zlib1g-dev qt59tools 
     - source /opt/qt*/bin/qt*-env.sh
     - # Needs newer compiler
-    - sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+    - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
     - sudo apt-get update
-    - sudo apt-get install gcc-4.9 g++-4.9
+    - sudo apt-get -y install gcc-4.9 g++-4.9
     - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: cpp
+compiler: gcc
+sudo: require
+dist: trusty
+
+before_install:
+    - sudo add-apt-repository ppa:beineri/opt-qt59-trusty -y
+    - sudo apt-get update -qq
+    
+install: 
+    - sudo apt-get -y install qt59base
+    - source /opt/qt*/bin/qt*-env.sh
+
+script:
+  - cmake . -DCMAKE_INSTALL_PREFIX=/usr
+  - make -j$(nproc)
+  - make DESTDIR=appdir install ; find appdir/
+
+after_success:
+  - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
+  - chmod a+x linuxdeployqt*.AppImage
+  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
+  - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
+  - curl --upload-file ./OpenOrienteering_Mapper*.AppImage https://transfer.sh/OpenOrienteering_Mapper-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt59base
+    - sudo apt-get -y install qt59base qt59base cmake doxygen libcups2-dev libgdal-dev libpolyclipping-dev libproj-dev zlib1g-dev qt59tools 
     - source /opt/qt*/bin/qt*-env.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,15 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt59base qt59base cmake doxygen libcups2-dev libgdal-dev libpolyclipping-dev libproj-dev zlib1g-dev qt59tools 
+    - sudo apt-get -y install qt59base cmake doxygen libcups2-dev libgdal-dev libpolyclipping-dev libproj-dev zlib1g-dev qt59tools 
     - source /opt/qt*/bin/qt*-env.sh
     - # Needs newer compiler
     - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
     - sudo apt-get update
     - sudo apt-get -y install gcc-4.9 g++-4.9
     - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.9
+    - echo "xxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    - find /opt | grep "libQt5Network.so.5"
 
 script:
   - cmake . -DCMAKE_INSTALL_PREFIX=/usr


### PR DESCRIPTION
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to a temporary download URL on transfer.sh (available for 14 days). The download URL is toward the end of each Travis CI build log of each build (see below for how to set up automatic uploading to your GitHub Releases page).

For this to work, you need to enable Travis CI for your repository as [described here](https://travis-ci.org/getting_started) __prior to merging this__, if you haven't already done so.

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Applications packaged as an AppImage can run on many distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Works out of the box, no installation of runtimes needed
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)
- Works on Live ISOs
- Can use the same AppImages when dual-booting multiple distributions

[Here is an overview](https://github.com/probonopd/AppImageKit/wiki/AppImages) of projects that are already distributing upstream-provided, official AppImages.

__Please note:__ Instead of storing AppImage builds temporarily for 14 days each on transfer.sh, you could use GitHub Releases to store the binaries permanently. This way, they would be visible on the Releases page of your project. This is what I recommend. See https://docs.travis-ci.com/user/deployment/releases/. If you want to do this for continuous builds, also see https://github.com/probonopd/uploadtool.

If you would like to see only one entry for the Pull Request in your project's history, then please enable [this GitHub functionality](https://help.github.com/articles/configuring-commit-squashing-for-pull-requests/) on your repo. It allows you to squash (combine) the commits when merging.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.