### PR TITLE
Fix Cut out tool

### DIFF
--- a/src/tools/cutout_tool.cpp
+++ b/src/tools/cutout_tool.cpp
@@ -177,6 +177,7 @@ struct PhysicalCutoutOperation
 	, cutout_object(cutout_object)
 	, cut_away(cut_away)
 	{
+		new_objects = new std::vector<PathObject*>();
 		add_step = new AddObjectsUndoStep(map);
 		delete_step = new DeleteObjectsUndoStep(map);
 	}
@@ -219,7 +220,7 @@ struct PhysicalCutoutOperation
 					return;
 				
 				add_step->addObject(object, object);
-				new_objects.insert(new_objects.end(), out_objects.begin(), out_objects.end());
+				new_objects->insert(new_objects->end(), out_objects.begin(), out_objects.end());
 			}
 			else
 			{
@@ -229,7 +230,7 @@ struct PhysicalCutoutOperation
 				boolean_tool.executeForLine(cutout_object, object->asPath(), out_objects);
 				
 				add_step->addObject(object, object);
-				new_objects.insert(new_objects.end(), out_objects.begin(), out_objects.end());
+				new_objects->insert(new_objects->end(), out_objects.begin(), out_objects.end());
 			}
 		}
 		
@@ -242,16 +243,16 @@ struct PhysicalCutoutOperation
 		
 		map->clearObjectSelection(false);
 		add_step->removeContainedObjects(false);
-		for (size_t i = 0; i < new_objects.size(); ++i)
+		for (size_t i = 0; i < new_objects->size(); ++i)
 		{
-			Object* object = new_objects[i];
+			Object* object = (*new_objects)[i];
 			map->addObject(object);
 		}
 		// Do not merge this loop into the upper one;
 		// theoretically undo step indices could be wrong this way.
-		for (size_t i = 0; i < new_objects.size(); ++i)
+		for (size_t i = 0; i < new_objects->size(); ++i)
 		{
-			Object* object = new_objects[i];
+			Object* object = (*new_objects)[i];
 			delete_step->addObject(part->findObjectIndex(object));
 		}
 		map->emitSelectionChanged();
@@ -289,7 +290,7 @@ private:
 	PathObject* cutout_object;
 	bool cut_away;
 	
-	std::vector<PathObject*> new_objects;
+	std::vector<PathObject*>* new_objects;
 	AddObjectsUndoStep* add_step;
 	DeleteObjectsUndoStep* delete_step;
 };


### PR DESCRIPTION
Broken since https://github.com/OpenOrienteering/mapper/commit/9bb9f2542b59cc66b1824765496af53f0183b2c6

Basically, in finish(), new_objects didn't have anything in it so the cut objects weren't being added back in.  I'm definitely not a C++ expert, but this fixes the issue I was seeing.

Solves #910 