### PR TITLE
OCAD8FileExport: Move coords into OCAD 8 drawing area

### DIFF
--- a/src/fileformats/ocad8_file_format.cpp
+++ b/src/fileformats/ocad8_file_format.cpp
@@ -1905,6 +1905,16 @@ MapCoord OCAD8FileExport::calculateAreaOffset()
 			addWarning(tr("Some coordinates remain outside of the OCAD 8 drawing area."
 			              " They might be unreachable in OCAD."));
 		}
+		
+		if (area_offset.manhattanLength() > 0)
+		{
+			// Round offset to 100 m in projected coordinates, to avoid crude grid offset.
+			constexpr auto unit = 100;
+			auto projected_offset = map->getGeoreferencing().toProjectedCoords(MapCoordF(area_offset));
+			projected_offset.rx() = std::round(projected_offset.x()/unit) * unit;
+			projected_offset.ry() = std::round(projected_offset.y()/unit) * unit;
+			area_offset = map->getGeoreferencing().toMapCoordF(projected_offset);
+		}
 	}
 	
 	return MapCoord{area_offset};

--- a/src/fileformats/ocad8_file_format.cpp
+++ b/src/fileformats/ocad8_file_format.cpp
@@ -1743,7 +1743,7 @@ void OCAD8FileExport::doExport()
 						setTextSymbolFormatting(ocad_text_symbol, text_object);
 						
 						TextFormatList new_list;
-						new_list.push_back(std::make_pair(text_object, *it));
+						new_list.push_back(std::make_pair(text_object->getHorizontalAlignment(), *it));
 						text_format_map.insert(text_symbol, new_list);
 					}
 					else
@@ -1754,7 +1754,7 @@ void OCAD8FileExport::doExport()
 						bool found = false;
 						for (size_t i = 0, end = format_list.size(); i < end; ++i)
 						{
-							if (format_list[i].first->getHorizontalAlignment() == text_object->getHorizontalAlignment())
+							if (format_list[i].first == text_object->getHorizontalAlignment())
 							{
 								index_to_use = format_list[i].second;
 								found = true;
@@ -1783,7 +1783,7 @@ void OCAD8FileExport::doExport()
 							// otherwise when compiling for Android this causes the error:
 							// cannot bind packed field 'new_symbol->_OCADTextSymbol::number' to 'short int&'
 							s16 new_symbol_number = new_symbol->number;
-							format_list.push_back(std::make_pair(text_object, new_symbol_number));
+							format_list.push_back(std::make_pair(text_object->getHorizontalAlignment(), new_symbol_number));
 						}
 					}
 				}

--- a/src/fileformats/ocad8_file_format.cpp
+++ b/src/fileformats/ocad8_file_format.cpp
@@ -1911,8 +1911,8 @@ MapCoord OCAD8FileExport::calculateAreaOffset()
 			// Round offset to 100 m in projected coordinates, to avoid crude grid offset.
 			constexpr auto unit = 100;
 			auto projected_offset = map->getGeoreferencing().toProjectedCoords(MapCoordF(area_offset));
-			projected_offset.rx() = std::round(projected_offset.x()/unit) * unit;
-			projected_offset.ry() = std::round(projected_offset.y()/unit) * unit;
+			projected_offset.rx() = qreal(qRound(projected_offset.x()/unit)) * unit;
+			projected_offset.ry() = qreal(qRound(projected_offset.y()/unit)) * unit;
 			area_offset = map->getGeoreferencing().toMapCoordF(projected_offset);
 		}
 	}

--- a/src/fileformats/ocad8_file_format.cpp
+++ b/src/fileformats/ocad8_file_format.cpp
@@ -1869,17 +1869,15 @@ void OCAD8FileExport::doExport()
 
 MapCoord OCAD8FileExport::calculateAreaOffset()
 {
-	auto area_offset = QPointF {};
+	auto area_offset = QPointF{};
+	
+	// Attention: When changing ocd_bounds, update the warning messages, too.
+	auto ocd_bounds = QRectF{QPointF{-2000, -2000}, QPointF{2000, 2000}};
 	auto objects_extent = map->calculateExtent();
-	if (objects_extent.left() < -2000
-	    || objects_extent.right() > 2000
-	    || objects_extent.top() < -2000
-	    || objects_extent.bottom() > 2000)
+	if (!ocd_bounds.contains(objects_extent))
 	{
-		// Some or all objects are outside of a 4 m x 4 m area.
-		
-		if (objects_extent.width() < 4000
-		    && objects_extent.height() < 4000)
+		if (objects_extent.width() < ocd_bounds.width()
+		    && objects_extent.height() < ocd_bounds.height())
 		{
 			// The extent fits into the limited area.
 			addWarning(tr("Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m)."));
@@ -1891,7 +1889,7 @@ MapCoord OCAD8FileExport::calculateAreaOffset()
 			
 			// Only move the objects if they are completely outside the drawing area.
 			// This avoids repeated moves on open/save/close cycles.
-			if (!objects_extent.intersects(QRectF{QPointF{-2000, -2000}, QPointF{2000, 2000}}))
+			if (!objects_extent.intersects(ocd_bounds))
 			{
 				addWarning(tr("Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m)."));
 				std::size_t count = 0;
@@ -1908,6 +1906,7 @@ MapCoord OCAD8FileExport::calculateAreaOffset()
 			              " They might be unreachable in OCAD."));
 		}
 	}
+	
 	return MapCoord{area_offset};
 }
 

--- a/src/fileformats/ocad8_file_format_p.h
+++ b/src/fileformats/ocad8_file_format_p.h
@@ -152,7 +152,10 @@ public:
 	
 	void doExport();
 	
+	
 protected:
+	// Determines an offset for moving objects to the OCD drawing area.
+	MapCoord calculateAreaOffset();
 	
 	// Symbol export
 	void exportCommonSymbolFields(const Symbol* symbol, OCADSymbol* ocad_symbol, int size);

--- a/src/fileformats/ocad8_file_format_p.h
+++ b/src/fileformats/ocad8_file_format_p.h
@@ -215,11 +215,11 @@ private:
 	/// In .ocd 8, text alignment needs to be specified in the text symbols instead of objects, so it is possible
 	/// that multiple ocd text symbols have to be created for one native TextSymbol.
 	/// This structure maps text symbols to lists containing information about the already created ocd symbols.
-	/// The TextObject in each pair just gives information about the alignment option used for the symbol indexed by the
+	/// The first member in each pair just gives information about the alignment option used for the symbol indexed by the
 	/// second part of the pair.
 	/// If there is no entry for a TextSymbol in this map yet, no object using this symbol has been encountered yet,
 	/// no no specific formatting was set in the corresponding symbol (which has to be looked up using symbol_index).
-	typedef std::vector< std::pair< TextObject*, s16 > > TextFormatList;
+	typedef std::vector< std::pair< int, s16 > > TextFormatList;
 	QHash<const TextSymbol*, TextFormatList > text_format_map;
 	
 	/// Helper object for pattern export


### PR DESCRIPTION
Do not just issue a warning, but move coordinates as needed to make objects visible in the bounds of the OCAD drawing area.