### PR TITLE
Set version to 0.8.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ include(FeatureSummary)
 
 # Project declaration
 
-project(Mapper VERSION 0.7.1 LANGUAGES CXX C)
+project(Mapper VERSION 0.8.0 LANGUAGES CXX C)
 
 set(Mapper_COPYRIGHT "(C) 2012-2017 The OpenOrienteering developers")
 

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="0.7.1" android:versionCode="701" package="org.openorienteering.mapper" android:installLocation="auto">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="0.8.0" android:versionCode="800" package="org.openorienteering.mapper" android:installLocation="auto">
     <application android:name="org.qtproject.qt5.android.bindings.QtApplication" android:label="@string/long_app_name" android:icon="@drawable/icon">
         <activity android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|locale|fontScale|keyboard|keyboardHidden|navigation"
                   android:name="org.openorienteering.mapper.MapperActivity"


### PR DESCRIPTION
Since 0.7.0, there has been a lot of new features:

- modified pattern clipping (change in file format)
- ISOM 2017 symbol set
- symbol set translations
- Find dialog with object queries
- advanced CRT file support with object queries
- CRT files for ISOM2017 and OSM
- modified dash symbol scaling (change in file format)

plus a lot of refactoring and fixes. Cf. https://github.com/OpenOrienteering/mapper/issues?utf8=%E2%9C%93&q=milestone%3Av0.7.1%20. (Documentation is lagging as usual...)

So I would suggest to use 0.8.0, and to repeat the deprecation warnings (file formats, OS X 10.7) rather than activating these changes.