### PR TITLE
Simplify logic expressions

### DIFF
--- a/src/core/objects/object.cpp
+++ b/src/core/objects/object.cpp
@@ -125,8 +125,7 @@ bool Object::equals(const Object* other, bool compare_symbol) const
 		return false;
 	if (compare_symbol)
 	{
-		if ((!symbol && other->symbol) ||
-			(symbol && !other->symbol))
+		if (bool(symbol) != bool(other->symbol))
 			return false;
 		if (symbol && !symbol->equals(other->symbol))
 			return false;

--- a/src/core/symbols/area_symbol.cpp
+++ b/src/core/symbols/area_symbol.cpp
@@ -199,8 +199,7 @@ bool AreaSymbol::FillPattern::equals(const AreaSymbol::FillPattern& other, Qt::C
 			return false;
 		if (point_distance != other.point_distance)
 			return false;
-		if ((!point && other.point) ||
-		    (point && !other.point))
+		if (bool(point) != bool(other.point))
 			return false;
 		if (point && !point->equals(other.point, case_sensitivity))
 			return false;

--- a/src/core/symbols/line_symbol.cpp
+++ b/src/core/symbols/line_symbol.cpp
@@ -2007,26 +2007,22 @@ bool LineSymbol::equalsImpl(const Symbol* other, Qt::CaseSensitivity case_sensit
 		}
 	}
 
-	if ((!start_symbol && line->start_symbol) ||
-	    (start_symbol && !line->start_symbol))
+	if (bool(start_symbol) != bool(line->start_symbol))
 		return false;
 	if (start_symbol && !start_symbol->equals(line->start_symbol))
 		return false;
 	
-	if ((!mid_symbol && line->mid_symbol) ||
-	    (mid_symbol && !line->mid_symbol))
+	if (bool(mid_symbol) != bool(line->mid_symbol))
 		return false;
 	if (mid_symbol && !mid_symbol->equals(line->mid_symbol))
 		return false;
 	
-	if ((!end_symbol && line->end_symbol) ||
-	    (end_symbol && !line->end_symbol))
+	if (bool(end_symbol) != bool(line->end_symbol))
 		return false;
 	if (end_symbol && !end_symbol->equals(line->end_symbol))
 		return false;
 	
-	if ((!dash_symbol && line->dash_symbol) ||
-	    (dash_symbol && !line->dash_symbol))
+	if (bool(dash_symbol) != bool(line->dash_symbol))
 		return false;
 	if (dash_symbol && !dash_symbol->equals(line->dash_symbol))
 		return false;

--- a/src/sensors/gps_track.cpp
+++ b/src/sensors/gps_track.cpp
@@ -115,6 +115,9 @@ Track::~Track()
 
 Track& Track::operator=(const Track& rhs)
 {
+	if (this == &rhs)
+		return *this;
+	
 	clear();
 	
 	waypoints = rhs.waypoints;

--- a/src/tools/draw_rectangle_tool.cpp
+++ b/src/tools/draw_rectangle_tool.cpp
@@ -382,7 +382,7 @@ bool DrawRectangleTool::keyReleaseEvent(QKeyEvent* event)
 	{
 	case Qt::Key_Control:
 		ctrl_pressed = false;
-		if (!picked_direction && (!editingInProgress() || (editingInProgress() && angles.size() == 1)))
+		if (!picked_direction && (!editingInProgress() || angles.size() == 1))
 		{
 			angle_helper->setActive(false);
 			if (dragging && editingInProgress())

--- a/src/util/matrix.h
+++ b/src/util/matrix.h
@@ -77,6 +77,9 @@ public:
 	/** Assignment */
 	void operator=(const Matrix& other)
 	{
+		if (this == &other)
+			return *this;
+		
 		delete[] d;
 		n = other.n;
 		m = other.m;


### PR DESCRIPTION
Changelog:
- replace '(ptr1 && !ptr2) || (!ptr1 && ptr2)' with 'bool(ptr1) != bool(ptr2)'
- replace '!A || (A && B)' with '!A || B'
- protect copy operators against self-assignment