### PR TITLE
Add missing Qt messages

### DIFF
--- a/translations/qt_eo.ts
+++ b/translations/qt_eo.ts
@@ -494,6 +494,14 @@ Bonvolu kontroli, ke dosiernomo estis ĝusta.</translation>
     </message>
 </context>
 <context>
+    <name>QGuiApplication</name>
+    <message>
+        <source>QT_LAYOUT_DIRECTION</source>
+        <comment>Translate this string to the string &apos;LTR&apos; in left-to-right languages or to &apos;RTL&apos; in right-to-left languages (such as Hebrew and Arabic) to get proper widget layout.</comment>
+        <translation>LTR</translation>
+    </message>
+</context>
+<context>
     <name>QIODevice</name>
     <message>
         <source>No such file or directory</source>
@@ -579,6 +587,10 @@ Bonvolu kontroli, ke dosiernomo estis ĝusta.</translation>
     <message>
         <source>&lt;h3&gt;About Qt&lt;/h3&gt;&lt;p&gt;This program uses Qt version %1.&lt;/p&gt;</source>
         <translation>&lt;h3&gt;Pri Qt&lt;/h3&gt;&lt;p&gt;Ĉi tiu programo uzos Qt-version %1.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;Qt is a C++ toolkit for cross-platform application development.&lt;/p&gt;&lt;p&gt;Qt provides single-source portability across all major desktop operating systems. It is also available for embedded Linux and other embedded and mobile operating systems.&lt;/p&gt;&lt;p&gt;Qt is available under three different licensing options designed to accommodate the needs of our various users.&lt;/p&gt;&lt;p&gt;Qt licensed under our commercial license agreement is appropriate for development of proprietary/commercial software where you do not want to share any source code with third parties or otherwise cannot comply with the terms of the GNU LGPL version 3 or GNU LGPL version 2.1.&lt;/p&gt;&lt;p&gt;Qt licensed under the GNU LGPL version 3 is appropriate for the development of Qt&amp;nbsp;applications provided you can comply with the terms and conditions of the GNU LGPL version 3.&lt;/p&gt;&lt;p&gt;Qt licensed under the GNU LGPL version 2.1 is appropriate for the development of Qt&amp;nbsp;applications provided you can comply with the terms and conditions of the GNU LGPL version 2.1.&lt;/p&gt;&lt;p&gt;Please see &lt;a href=&quot;http://%2/&quot;&gt;%2&lt;/a&gt; for an overview of Qt licensing.&lt;/p&gt;&lt;p&gt;Copyright (C) %1 The Qt Company Ltd and other contributors.&lt;/p&gt;&lt;p&gt;Qt and the Qt logo are trademarks of The Qt Company Ltd.&lt;/p&gt;&lt;p&gt;Qt is The Qt Company Ltd product developed as an open source project. See &lt;a href=&quot;http://%3/&quot;&gt;%3&lt;/a&gt; for more information.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -680,6 +692,14 @@ Bonvolu kontroli, ke dosiernomo estis ĝusta.</translation>
     <message>
         <source>OK</source>
         <translation>Bone</translation>
+    </message>
+    <message>
+        <source>&amp;Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;No</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/text_browser_dialog.cpp" line="63"/>

--- a/translations/qt_et.ts
+++ b/translations/qt_et.ts
@@ -34,7 +34,7 @@
 <context>
     <name>QDialog</name>
     <message>
-        <source>What's This?</source>
+        <source>What&apos;s This?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -133,7 +133,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Don't Save</source>
+        <source>Don&apos;t Save</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,12 +254,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>'%1' is write protected.
+        <source>&apos;%1&apos; is write protected.
 Do you want to delete it anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Are you sure you want to delete '%1'?</source>
+        <source>Are you sure you want to delete &apos;%1&apos;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -459,7 +459,7 @@ Please verify the correct file name was given.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;The name "%1" can not be used.&lt;/b&gt;&lt;p&gt;Try using another name, with fewer characters or no punctuations marks.</source>
+        <source>&lt;b&gt;The name &quot;%1&quot; can not be used.&lt;/b&gt;&lt;p&gt;Try using another name, with fewer characters or no punctuations marks.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -485,6 +485,14 @@ Please verify the correct file name was given.</source>
     <message>
         <source>Date Modified</source>
         <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QGuiApplication</name>
+    <message>
+        <source>QT_LAYOUT_DIRECTION</source>
+        <comment>Translate this string to the string &apos;LTR&apos; in left-to-right languages or to &apos;RTL&apos; in right-to-left languages (such as Hebrew and Arabic) to get proper widget layout.</comment>
+        <translation>LTR</translation>
     </message>
 </context>
 <context>
@@ -572,6 +580,10 @@ Please verify the correct file name was given.</source>
     </message>
     <message>
         <source>&lt;h3&gt;About Qt&lt;/h3&gt;&lt;p&gt;This program uses Qt version %1.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;Qt is a C++ toolkit for cross-platform application development.&lt;/p&gt;&lt;p&gt;Qt provides single-source portability across all major desktop operating systems. It is also available for embedded Linux and other embedded and mobile operating systems.&lt;/p&gt;&lt;p&gt;Qt is available under three different licensing options designed to accommodate the needs of our various users.&lt;/p&gt;&lt;p&gt;Qt licensed under our commercial license agreement is appropriate for development of proprietary/commercial software where you do not want to share any source code with third parties or otherwise cannot comply with the terms of the GNU LGPL version 3 or GNU LGPL version 2.1.&lt;/p&gt;&lt;p&gt;Qt licensed under the GNU LGPL version 3 is appropriate for the development of Qt&amp;nbsp;applications provided you can comply with the terms and conditions of the GNU LGPL version 3.&lt;/p&gt;&lt;p&gt;Qt licensed under the GNU LGPL version 2.1 is appropriate for the development of Qt&amp;nbsp;applications provided you can comply with the terms and conditions of the GNU LGPL version 2.1.&lt;/p&gt;&lt;p&gt;Please see &lt;a href=&quot;http://%2/&quot;&gt;%2&lt;/a&gt; for an overview of Qt licensing.&lt;/p&gt;&lt;p&gt;Copyright (C) %1 The Qt Company Ltd and other contributors.&lt;/p&gt;&lt;p&gt;Qt and the Qt logo are trademarks of The Qt Company Ltd.&lt;/p&gt;&lt;p&gt;Qt is The Qt Company Ltd product developed as an open source project. See &lt;a href=&quot;http://%3/&quot;&gt;%3&lt;/a&gt; for more information.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -674,6 +686,14 @@ Please verify the correct file name was given.</source>
     <message>
         <source>OK</source>
         <translation></translation>
+    </message>
+    <message>
+        <source>&amp;Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;No</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/text_browser_dialog.cpp" line="63"/>
@@ -857,7 +877,7 @@ Do you want to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The 'From' value cannot be greater than the 'To' value.</source>
+        <source>The &apos;From&apos; value cannot be greater than the &apos;To&apos; value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1593,7 +1613,7 @@ Please choose a different file name.</source>
 <context>
     <name>QWhatsThisAction</name>
     <message>
-        <source>What's This?</source>
+        <source>What&apos;s This?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/qt_id.ts
+++ b/translations/qt_id.ts
@@ -34,7 +34,7 @@
 <context>
     <name>QDialog</name>
     <message>
-        <source>What's This?</source>
+        <source>What&apos;s This?</source>
         <translation>Apa ini?</translation>
     </message>
 </context>
@@ -133,7 +133,7 @@
         <translation>Ya untuk &amp;semua</translation>
     </message>
     <message>
-        <source>Don't Save</source>
+        <source>Don&apos;t Save</source>
         <translation>Jangan Simpan</translation>
     </message>
 </context>
@@ -254,14 +254,14 @@
         <translation>Tampilkan </translation>
     </message>
     <message>
-        <source>'%1' is write protected.
+        <source>&apos;%1&apos; is write protected.
 Do you want to delete it anyway?</source>
-        <translation>'%1' adalah menulis yang dilindungi.
+        <translation>&apos;%1&apos; adalah menulis yang dilindungi.
 Apakah Anda ingin menghapus bagaimanapun itu?</translation>
     </message>
     <message>
-        <source>Are you sure you want to delete '%1'?</source>
-        <translation>Apakah Anda yakin mau menghapus '%1'?</translation>
+        <source>Are you sure you want to delete &apos;%1&apos;?</source>
+        <translation>Apakah Anda yakin mau menghapus &apos;%1&apos;?</translation>
     </message>
     <message>
         <source>List of places and bookmarks</source>
@@ -464,8 +464,8 @@ Pastikan nama file benar diberikan.</translation>
         <translation>%1 TB</translation>
     </message>
     <message>
-        <source>&lt;b&gt;The name "%1" can not be used.&lt;/b&gt;&lt;p&gt;Try using another name, with fewer characters or no punctuations marks.</source>
-        <translation>&lt;b&gt;Nama "%1" tidak dapat digunakan.&lt;/b&gt;&lt;p&gt;Coba gunakan nama lain, dengan karakter lebih sedikit atau tidak ada tanda tanda.</translation>
+        <source>&lt;b&gt;The name &quot;%1&quot; can not be used.&lt;/b&gt;&lt;p&gt;Try using another name, with fewer characters or no punctuations marks.</source>
+        <translation>&lt;b&gt;Nama &quot;%1&quot; tidak dapat digunakan.&lt;/b&gt;&lt;p&gt;Coba gunakan nama lain, dengan karakter lebih sedikit atau tidak ada tanda tanda.</translation>
     </message>
     <message>
         <source>%1 bytes</source>
@@ -490,6 +490,14 @@ Pastikan nama file benar diberikan.</translation>
     <message>
         <source>Date Modified</source>
         <translation>Tanggal dimodifikasi</translation>
+    </message>
+</context>
+<context>
+    <name>QGuiApplication</name>
+    <message>
+        <source>QT_LAYOUT_DIRECTION</source>
+        <comment>Translate this string to the string &apos;LTR&apos; in left-to-right languages or to &apos;RTL&apos; in right-to-left languages (such as Hebrew and Arabic) to get proper widget layout.</comment>
+        <translation>LTR</translation>
     </message>
 </context>
 <context>
@@ -578,6 +586,10 @@ Pastikan nama file benar diberikan.</translation>
     <message>
         <source>&lt;h3&gt;About Qt&lt;/h3&gt;&lt;p&gt;This program uses Qt version %1.&lt;/p&gt;</source>
         <translation>&lt;h3&gt;Tentang Qt&lt;/h3&gt;&lt;p&gt;Program ini menggunakan Qt versi %1.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;Qt is a C++ toolkit for cross-platform application development.&lt;/p&gt;&lt;p&gt;Qt provides single-source portability across all major desktop operating systems. It is also available for embedded Linux and other embedded and mobile operating systems.&lt;/p&gt;&lt;p&gt;Qt is available under three different licensing options designed to accommodate the needs of our various users.&lt;/p&gt;&lt;p&gt;Qt licensed under our commercial license agreement is appropriate for development of proprietary/commercial software where you do not want to share any source code with third parties or otherwise cannot comply with the terms of the GNU LGPL version 3 or GNU LGPL version 2.1.&lt;/p&gt;&lt;p&gt;Qt licensed under the GNU LGPL version 3 is appropriate for the development of Qt&amp;nbsp;applications provided you can comply with the terms and conditions of the GNU LGPL version 3.&lt;/p&gt;&lt;p&gt;Qt licensed under the GNU LGPL version 2.1 is appropriate for the development of Qt&amp;nbsp;applications provided you can comply with the terms and conditions of the GNU LGPL version 2.1.&lt;/p&gt;&lt;p&gt;Please see &lt;a href=&quot;http://%2/&quot;&gt;%2&lt;/a&gt; for an overview of Qt licensing.&lt;/p&gt;&lt;p&gt;Copyright (C) %1 The Qt Company Ltd and other contributors.&lt;/p&gt;&lt;p&gt;Qt and the Qt logo are trademarks of The Qt Company Ltd.&lt;/p&gt;&lt;p&gt;Qt is The Qt Company Ltd product developed as an open source project. See &lt;a href=&quot;http://%3/&quot;&gt;%3&lt;/a&gt; for more information.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -679,6 +691,14 @@ Pastikan nama file benar diberikan.</translation>
     <message>
         <source>OK</source>
         <translation></translation>
+    </message>
+    <message>
+        <source>&amp;Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;No</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/text_browser_dialog.cpp" line="63"/>
@@ -863,8 +883,8 @@ Apakah Anda ingin menimpa itu?</translation>
         <translation>Eksekutif</translation>
     </message>
     <message>
-        <source>The 'From' value cannot be greater than the 'To' value.</source>
-        <translation>Nilai 'Dari' tidak dapat lebih besar dari nilai 'Ke'.</translation>
+        <source>The &apos;From&apos; value cannot be greater than the &apos;To&apos; value.</source>
+        <translation>Nilai &apos;Dari&apos; tidak dapat lebih besar dari nilai &apos;Ke&apos;.</translation>
     </message>
     <message>
         <source>US Common #10 Envelope</source>
@@ -1601,7 +1621,7 @@ Silakan pilih nama file yang berbeda.</translation>
 <context>
     <name>QWhatsThisAction</name>
     <message>
-        <source>What's This?</source>
+        <source>What&apos;s This?</source>
         <translation>Apa ini?</translation>
     </message>
 </context>

--- a/translations/qt_lv.ts
+++ b/translations/qt_lv.ts
@@ -42,7 +42,7 @@
 <context>
     <name>QDialog</name>
     <message>
-        <source>What's This?</source>
+        <source>What&apos;s This?</source>
         <translation>Kas tas?</translation>
     </message>
     <message>
@@ -145,7 +145,7 @@
         <translation>Jā &amp;visiem</translation>
     </message>
     <message>
-        <source>Don't Save</source>
+        <source>Don&apos;t Save</source>
         <translation>Nesaglabāt</translation>
     </message>
 </context>
@@ -280,14 +280,14 @@
         <translation>Rādīt </translation>
     </message>
     <message>
-        <source>'%1' is write protected.
+        <source>&apos;%1&apos; is write protected.
 Do you want to delete it anyway?</source>
         <translation>%1 ir aizsargāts pret ierakstu.
 Vai vēlies to dzēst?</translation>
     </message>
     <message>
-        <source>Are you sure you want to delete '%1'?</source>
-        <translation>Vai tiešām vēlies dzēst '%1'?</translation>
+        <source>Are you sure you want to delete &apos;%1&apos;?</source>
+        <translation>Vai tiešām vēlies dzēst &apos;%1&apos;?</translation>
     </message>
     <message>
         <source>List of places and bookmarks</source>
@@ -480,8 +480,8 @@ Pārbaudi vai datnes nosaukums ir uzrādīts korekti.</translation>
         <translation>Visas datnes (*.*)</translation>
     </message>
     <message>
-        <source>Are sure you want to delete '%1'?</source>
-        <translation>Vai tiešām vēlies dzēst '%1'?</translation>
+        <source>Are sure you want to delete &apos;%1&apos;?</source>
+        <translation>Vai tiešām vēlies dzēst &apos;%1&apos;?</translation>
     </message>
 </context>
 <context>
@@ -519,8 +519,8 @@ Pārbaudi vai datnes nosaukums ir uzrādīts korekti.</translation>
         <translation>%1 TB</translation>
     </message>
     <message>
-        <source>&lt;b&gt;The name "%1" can not be used.&lt;/b&gt;&lt;p&gt;Try using another name, with fewer characters or no punctuations marks.</source>
-        <translation>&lt;b&gt; Nosaukumu "%1" nevar izmantot.&lt;/b&gt;&lt;p&gt;Mēģini izmantot citu nosaukumu, lietojot mazāk simbolus un bez pieturzīmēm.</translation>
+        <source>&lt;b&gt;The name &quot;%1&quot; can not be used.&lt;/b&gt;&lt;p&gt;Try using another name, with fewer characters or no punctuations marks.</source>
+        <translation>&lt;b&gt; Nosaukumu &quot;%1&quot; nevar izmantot.&lt;/b&gt;&lt;p&gt;Mēģini izmantot citu nosaukumu, lietojot mazāk simbolus un bez pieturzīmēm.</translation>
     </message>
     <message>
         <source>%1 bytes</source>
@@ -555,6 +555,14 @@ Pārbaudi vai datnes nosaukums ir uzrādīts korekti.</translation>
         <source>Type</source>
         <comment>All other platforms</comment>
         <translation>Tips</translation>
+    </message>
+</context>
+<context>
+    <name>QGuiApplication</name>
+    <message>
+        <source>QT_LAYOUT_DIRECTION</source>
+        <comment>Translate this string to the string &apos;LTR&apos; in left-to-right languages or to &apos;RTL&apos; in right-to-left languages (such as Hebrew and Arabic) to get proper widget layout.</comment>
+        <translation>LTR</translation>
     </message>
 </context>
 <context>
@@ -598,36 +606,36 @@ Pārbaudi vai datnes nosaukums ir uzrādīts korekti.</translation>
         <translation>Neizdevās ielasīt bibliotēku %1: %2</translation>
     </message>
     <message>
-        <source>'%1' is not an ELF object (%2)</source>
-        <translation>'%1' nav ELF objekts (%2)</translation>
+        <source>&apos;%1&apos; is not an ELF object (%2)</source>
+        <translation>&apos;%1&apos; nav ELF objekts (%2)</translation>
     </message>
     <message>
-        <source>The plugin '%1' uses incompatible Qt library. (%2.%3.%4) [%5]</source>
-        <translation>Spraudnis '%1' lieto nesaderīgu Qt bibliotēku. (%2.%3.%4) [%5]</translation>
+        <source>The plugin &apos;%1&apos; uses incompatible Qt library. (%2.%3.%4) [%5]</source>
+        <translation>Spraudnis &apos;%1&apos; lieto nesaderīgu Qt bibliotēku. (%2.%3.%4) [%5]</translation>
     </message>
     <message>
-        <source>Cannot resolve symbol "%1" in %2: %3</source>
-        <translation>Neizdevās izšķirt simbolu "%1", kas atradās %2: %3</translation>
+        <source>Cannot resolve symbol &quot;%1&quot; in %2: %3</source>
+        <translation>Neizdevās izšķirt simbolu &quot;%1&quot;, kas atradās %2: %3</translation>
     </message>
     <message>
-        <source>Plugin verification data mismatch in '%1'</source>
-        <translation>Spraudņa pārbaudes datu nesaderība '%1'</translation>
+        <source>Plugin verification data mismatch in &apos;%1&apos;</source>
+        <translation>Spraudņa pārbaudes datu nesaderība &apos;%1&apos;</translation>
     </message>
     <message>
-        <source>'%1' is an invalid ELF object (%2)</source>
-        <translation>'%1' ir nepieļaujams ELF objekts (%2)</translation>
+        <source>&apos;%1&apos; is an invalid ELF object (%2)</source>
+        <translation>&apos;%1&apos; ir nepieļaujams ELF objekts (%2)</translation>
     </message>
     <message>
-        <source>The plugin '%1' uses incompatible Qt library. (Cannot mix debug and release libraries.)</source>
-        <translation>Spraudnis '%1' lieto nesaderīgu Qt bibliotēku. (Nevar miksēt skaņošanas un izlaides bibliotēkas.)</translation>
+        <source>The plugin &apos;%1&apos; uses incompatible Qt library. (Cannot mix debug and release libraries.)</source>
+        <translation>Spraudnis &apos;%1&apos; lieto nesaderīgu Qt bibliotēku. (Nevar miksēt skaņošanas un izlaides bibliotēkas.)</translation>
     </message>
     <message>
-        <source>'%1' is not an ELF object</source>
-        <translation>'%1' nav ELF objekts</translation>
+        <source>&apos;%1&apos; is not an ELF object</source>
+        <translation>&apos;%1&apos; nav ELF objekts</translation>
     </message>
     <message>
-        <source>The file '%1' is not a valid Qt plugin.</source>
-        <translation>Datne '%1' nav pieļaujams Qt spraudnis.</translation>
+        <source>The file &apos;%1&apos; is not a valid Qt plugin.</source>
+        <translation>Datne &apos;%1&apos; nav pieļaujams Qt spraudnis.</translation>
     </message>
     <message>
         <source>The shared library was not found.</source>
@@ -638,8 +646,8 @@ Pārbaudi vai datnes nosaukums ir uzrādīts korekti.</translation>
         <translation>Nezināma kļūda</translation>
     </message>
     <message>
-        <source>The plugin '%1' uses incompatible Qt library. Expected build key "%2", got "%3"</source>
-        <translation>Spraudnis '%1' lieto nesaderīgu Qt bibliotēku. Izveides atslēgas "%2" vietā bija "%3"</translation>
+        <source>The plugin &apos;%1&apos; uses incompatible Qt library. Expected build key &quot;%2&quot;, got &quot;%3&quot;</source>
+        <translation>Spraudnis &apos;%1&apos; lieto nesaderīgu Qt bibliotēku. Izveides atslēgas &quot;%2&quot; vietā bija &quot;%3&quot;</translation>
     </message>
 </context>
 <context>
@@ -803,6 +811,14 @@ Pārbaudi vai datnes nosaukums ir uzrādīts korekti.</translation>
     <message>
         <source>OK</source>
         <translation></translation>
+    </message>
+    <message>
+        <source>&amp;Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;No</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/text_browser_dialog.cpp" line="63"/>
@@ -998,8 +1014,8 @@ Vai vēlies to pārrakstīt?</translation>
         <translation>Executive</translation>
     </message>
     <message>
-        <source>The 'From' value cannot be greater than the 'To' value.</source>
-        <translation>'No' vērtība nevar būt lielāka par 'Līdz' vērtibu.</translation>
+        <source>The &apos;From&apos; value cannot be greater than the &apos;To&apos; value.</source>
+        <translation>&apos;No&apos; vērtība nevar būt lielāka par &apos;Līdz&apos; vērtibu.</translation>
     </message>
     <message>
         <source>US Common #10 Envelope</source>
@@ -1985,7 +2001,7 @@ Izvēlies citu datnes nosaukumu.</translation>
 <context>
     <name>QWhatsThisAction</name>
     <message>
-        <source>What's This?</source>
+        <source>What&apos;s This?</source>
         <translation>Kas tas?</translation>
     </message>
 </context>

--- a/translations/qt_nb.ts
+++ b/translations/qt_nb.ts
@@ -34,7 +34,7 @@
 <context>
     <name>QDialog</name>
     <message>
-        <source>What's This?</source>
+        <source>What&apos;s This?</source>
         <translation>Hva er dette?</translation>
     </message>
 </context>
@@ -133,7 +133,7 @@
         <translation>Ja til &amp;alt</translation>
     </message>
     <message>
-        <source>Don't Save</source>
+        <source>Don&apos;t Save</source>
         <translation>Ikke lagre</translation>
     </message>
 </context>
@@ -254,14 +254,14 @@
         <translation>Vis </translation>
     </message>
     <message>
-        <source>'%1' is write protected.
+        <source>&apos;%1&apos; is write protected.
 Do you want to delete it anyway?</source>
-        <translation>'%1' er skrivebeskyttet.
+        <translation>&apos;%1&apos; er skrivebeskyttet.
 Do you want to delete it anyway?</translation>
     </message>
     <message>
-        <source>Are you sure you want to delete '%1'?</source>
-        <translation>Vil du virkelig slette '%1'?</translation>
+        <source>Are you sure you want to delete &apos;%1&apos;?</source>
+        <translation>Vil du virkelig slette &apos;%1&apos;?</translation>
     </message>
     <message>
         <source>List of places and bookmarks</source>
@@ -465,7 +465,7 @@ Vennligst sjekk at riktig filnavn ble angitt.</translation>
         <translation>%1 TB</translation>
     </message>
     <message>
-        <source>&lt;b&gt;The name "%1" can not be used.&lt;/b&gt;&lt;p&gt;Try using another name, with fewer characters or no punctuations marks.</source>
+        <source>&lt;b&gt;The name &quot;%1&quot; can not be used.&lt;/b&gt;&lt;p&gt;Try using another name, with fewer characters or no punctuations marks.</source>
         <translation>&lt;b&gt;Kan ikke bruke navnet «%1».&lt;/b&gt;&lt;p&gt;Prøv et annet navn, med færre tegn, eller uten tegnsetting.</translation>
     </message>
     <message>
@@ -491,6 +491,14 @@ Vennligst sjekk at riktig filnavn ble angitt.</translation>
     <message>
         <source>Date Modified</source>
         <translation>Dato endret</translation>
+    </message>
+</context>
+<context>
+    <name>QGuiApplication</name>
+    <message>
+        <source>QT_LAYOUT_DIRECTION</source>
+        <comment>Translate this string to the string &apos;LTR&apos; in left-to-right languages or to &apos;RTL&apos; in right-to-left languages (such as Hebrew and Arabic) to get proper widget layout.</comment>
+        <translation>LTR</translation>
     </message>
 </context>
 <context>
@@ -534,35 +542,35 @@ Vennligst sjekk at riktig filnavn ble angitt.</translation>
         <translation>Kan ikke laste biblioteket %1: %2</translation>
     </message>
     <message>
-        <source>'%1' is not an ELF object (%2)</source>
+        <source>&apos;%1&apos; is not an ELF object (%2)</source>
         <translation>«%1» er ikke et ELF-objekt (%2)</translation>
     </message>
     <message>
-        <source>The plugin '%1' uses incompatible Qt library. (%2.%3.%4) [%5]</source>
+        <source>The plugin &apos;%1&apos; uses incompatible Qt library. (%2.%3.%4) [%5]</source>
         <translation>Programtillegget «%1» bruker inkompatibelt Qt-bibliotek. (%2.%3.%4) [%5]</translation>
     </message>
     <message>
-        <source>Cannot resolve symbol "%1" in %2: %3</source>
+        <source>Cannot resolve symbol &quot;%1&quot; in %2: %3</source>
         <translation>Klarte ikke slå opp symbolet «%1» i %2: %3</translation>
     </message>
     <message>
-        <source>Plugin verification data mismatch in '%1'</source>
+        <source>Plugin verification data mismatch in &apos;%1&apos;</source>
         <translation>Ikke samsvar i data for programtillegg-verifisering i «%1»</translation>
     </message>
     <message>
-        <source>'%1' is an invalid ELF object (%2)</source>
+        <source>&apos;%1&apos; is an invalid ELF object (%2)</source>
         <translation>«%1» er et ugyldig ELF-objekt (%2)</translation>
     </message>
     <message>
-        <source>The plugin '%1' uses incompatible Qt library. (Cannot mix debug and release libraries.)</source>
+        <source>The plugin &apos;%1&apos; uses incompatible Qt library. (Cannot mix debug and release libraries.)</source>
         <translation>Programtillegget «%1» bruker inkompatibelt Qt-bibliotek. (Kan ikke blande biblioteker for feilsøking og utgave.)</translation>
     </message>
     <message>
-        <source>'%1' is not an ELF object</source>
+        <source>&apos;%1&apos; is not an ELF object</source>
         <translation>«%1» er ikke et ELF-objekt</translation>
     </message>
     <message>
-        <source>The file '%1' is not a valid Qt plugin.</source>
+        <source>The file &apos;%1&apos; is not a valid Qt plugin.</source>
         <translation>Fila «%1» er ikke et gyldig Qt-programtillegg.</translation>
     </message>
     <message>
@@ -630,6 +638,10 @@ Vennligst sjekk at riktig filnavn ble angitt.</translation>
     <message>
         <source>&lt;h3&gt;About Qt&lt;/h3&gt;&lt;p&gt;This program uses Qt version %1.&lt;/p&gt;</source>
         <translation>&lt;h3&gt;Om Qt&lt;/h3&gt;&lt;p&gt;Dette programmet bruker versjon %1 av Qt.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;Qt is a C++ toolkit for cross-platform application development.&lt;/p&gt;&lt;p&gt;Qt provides single-source portability across all major desktop operating systems. It is also available for embedded Linux and other embedded and mobile operating systems.&lt;/p&gt;&lt;p&gt;Qt is available under three different licensing options designed to accommodate the needs of our various users.&lt;/p&gt;&lt;p&gt;Qt licensed under our commercial license agreement is appropriate for development of proprietary/commercial software where you do not want to share any source code with third parties or otherwise cannot comply with the terms of the GNU LGPL version 3 or GNU LGPL version 2.1.&lt;/p&gt;&lt;p&gt;Qt licensed under the GNU LGPL version 3 is appropriate for the development of Qt&amp;nbsp;applications provided you can comply with the terms and conditions of the GNU LGPL version 3.&lt;/p&gt;&lt;p&gt;Qt licensed under the GNU LGPL version 2.1 is appropriate for the development of Qt&amp;nbsp;applications provided you can comply with the terms and conditions of the GNU LGPL version 2.1.&lt;/p&gt;&lt;p&gt;Please see &lt;a href=&quot;http://%2/&quot;&gt;%2&lt;/a&gt; for an overview of Qt licensing.&lt;/p&gt;&lt;p&gt;Copyright (C) %1 The Qt Company Ltd and other contributors.&lt;/p&gt;&lt;p&gt;Qt and the Qt logo are trademarks of The Qt Company Ltd.&lt;/p&gt;&lt;p&gt;Qt is The Qt Company Ltd product developed as an open source project. See &lt;a href=&quot;http://%3/&quot;&gt;%3&lt;/a&gt; for more information.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -731,6 +743,14 @@ Vennligst sjekk at riktig filnavn ble angitt.</translation>
     <message>
         <source>OK</source>
         <translation></translation>
+    </message>
+    <message>
+        <source>&amp;Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;No</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/text_browser_dialog.cpp" line="63"/>
@@ -926,7 +946,7 @@ Vil du skrive over den?</translation>
         <translation>Executive</translation>
     </message>
     <message>
-        <source>The 'From' value cannot be greater than the 'To' value.</source>
+        <source>The &apos;From&apos; value cannot be greater than the &apos;To&apos; value.</source>
         <translation>«Fra»-verdien kan ikke være større enn «Til»-verdien.</translation>
     </message>
     <message>
@@ -1711,7 +1731,7 @@ Velg et annet navn.</translation>
 <context>
     <name>QWhatsThisAction</name>
     <message>
-        <source>What's This?</source>
+        <source>What&apos;s This?</source>
         <translation>Hva er dette?</translation>
     </message>
 </context>
@@ -1793,7 +1813,7 @@ Velg et annet navn.</translation>
     </message>
     <message>
         <source>&amp;Next &gt;</source>
-        <translation>&amp;Neste →</translation>
+        <translation>&amp;Neste &gt;</translation>
     </message>
     <message>
         <source>Go Back</source>
@@ -1801,7 +1821,7 @@ Velg et annet navn.</translation>
     </message>
     <message>
         <source>&lt; &amp;Back</source>
-        <translation>← &amp;Tilbake</translation>
+        <translation>&lt; &amp;Tilbake</translation>
     </message>
 </context>
 </TS>

--- a/translations/qt_nl.ts
+++ b/translations/qt_nl.ts
@@ -494,6 +494,14 @@ Controleer of de juiste bestandsnaam is opgegeven.</translation>
     </message>
 </context>
 <context>
+    <name>QGuiApplication</name>
+    <message>
+        <source>QT_LAYOUT_DIRECTION</source>
+        <comment>Translate this string to the string &apos;LTR&apos; in left-to-right languages or to &apos;RTL&apos; in right-to-left languages (such as Hebrew and Arabic) to get proper widget layout.</comment>
+        <translation>LTR</translation>
+    </message>
+</context>
+<context>
     <name>QIODevice</name>
     <message>
         <source>No such file or directory</source>
@@ -579,6 +587,10 @@ Controleer of de juiste bestandsnaam is opgegeven.</translation>
     <message>
         <source>&lt;h3&gt;About Qt&lt;/h3&gt;&lt;p&gt;This program uses Qt version %1.&lt;/p&gt;</source>
         <translation>&lt;h3&gt;Over Qt&lt;/h3&gt; &lt;p&gt;Dit programma gebruikt Qt versie %1.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;Qt is a C++ toolkit for cross-platform application development.&lt;/p&gt;&lt;p&gt;Qt provides single-source portability across all major desktop operating systems. It is also available for embedded Linux and other embedded and mobile operating systems.&lt;/p&gt;&lt;p&gt;Qt is available under three different licensing options designed to accommodate the needs of our various users.&lt;/p&gt;&lt;p&gt;Qt licensed under our commercial license agreement is appropriate for development of proprietary/commercial software where you do not want to share any source code with third parties or otherwise cannot comply with the terms of the GNU LGPL version 3 or GNU LGPL version 2.1.&lt;/p&gt;&lt;p&gt;Qt licensed under the GNU LGPL version 3 is appropriate for the development of Qt&amp;nbsp;applications provided you can comply with the terms and conditions of the GNU LGPL version 3.&lt;/p&gt;&lt;p&gt;Qt licensed under the GNU LGPL version 2.1 is appropriate for the development of Qt&amp;nbsp;applications provided you can comply with the terms and conditions of the GNU LGPL version 2.1.&lt;/p&gt;&lt;p&gt;Please see &lt;a href=&quot;http://%2/&quot;&gt;%2&lt;/a&gt; for an overview of Qt licensing.&lt;/p&gt;&lt;p&gt;Copyright (C) %1 The Qt Company Ltd and other contributors.&lt;/p&gt;&lt;p&gt;Qt and the Qt logo are trademarks of The Qt Company Ltd.&lt;/p&gt;&lt;p&gt;Qt is The Qt Company Ltd product developed as an open source project. See &lt;a href=&quot;http://%3/&quot;&gt;%3&lt;/a&gt; for more information.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -680,6 +692,14 @@ Controleer of de juiste bestandsnaam is opgegeven.</translation>
     <message>
         <source>OK</source>
         <translation></translation>
+    </message>
+    <message>
+        <source>&amp;Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;No</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/text_browser_dialog.cpp" line="63"/>

--- a/translations/qt_template.ts
+++ b/translations/qt_template.ts
@@ -34,7 +34,7 @@
 <context>
     <name>QDialog</name>
     <message>
-        <source>What's This?</source>
+        <source>What&apos;s This?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -133,7 +133,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Don't Save</source>
+        <source>Don&apos;t Save</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -254,12 +254,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>'%1' is write protected.
+        <source>&apos;%1&apos; is write protected.
 Do you want to delete it anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Are you sure you want to delete '%1'?</source>
+        <source>Are you sure you want to delete &apos;%1&apos;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -459,7 +459,7 @@ Please verify the correct file name was given.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;b&gt;The name "%1" can not be used.&lt;/b&gt;&lt;p&gt;Try using another name, with fewer characters or no punctuations marks.</source>
+        <source>&lt;b&gt;The name &quot;%1&quot; can not be used.&lt;/b&gt;&lt;p&gt;Try using another name, with fewer characters or no punctuations marks.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -484,6 +484,14 @@ Please verify the correct file name was given.</source>
     </message>
     <message>
         <source>Date Modified</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QGuiApplication</name>
+    <message>
+        <source>QT_LAYOUT_DIRECTION</source>
+        <comment>Translate this string to the string &apos;LTR&apos; in left-to-right languages or to &apos;RTL&apos; in right-to-left languages (such as Hebrew and Arabic) to get proper widget layout.</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -572,6 +580,10 @@ Please verify the correct file name was given.</source>
     </message>
     <message>
         <source>&lt;h3&gt;About Qt&lt;/h3&gt;&lt;p&gt;This program uses Qt version %1.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;Qt is a C++ toolkit for cross-platform application development.&lt;/p&gt;&lt;p&gt;Qt provides single-source portability across all major desktop operating systems. It is also available for embedded Linux and other embedded and mobile operating systems.&lt;/p&gt;&lt;p&gt;Qt is available under three different licensing options designed to accommodate the needs of our various users.&lt;/p&gt;&lt;p&gt;Qt licensed under our commercial license agreement is appropriate for development of proprietary/commercial software where you do not want to share any source code with third parties or otherwise cannot comply with the terms of the GNU LGPL version 3 or GNU LGPL version 2.1.&lt;/p&gt;&lt;p&gt;Qt licensed under the GNU LGPL version 3 is appropriate for the development of Qt&amp;nbsp;applications provided you can comply with the terms and conditions of the GNU LGPL version 3.&lt;/p&gt;&lt;p&gt;Qt licensed under the GNU LGPL version 2.1 is appropriate for the development of Qt&amp;nbsp;applications provided you can comply with the terms and conditions of the GNU LGPL version 2.1.&lt;/p&gt;&lt;p&gt;Please see &lt;a href=&quot;http://%2/&quot;&gt;%2&lt;/a&gt; for an overview of Qt licensing.&lt;/p&gt;&lt;p&gt;Copyright (C) %1 The Qt Company Ltd and other contributors.&lt;/p&gt;&lt;p&gt;Qt and the Qt logo are trademarks of The Qt Company Ltd.&lt;/p&gt;&lt;p&gt;Qt is The Qt Company Ltd product developed as an open source project. See &lt;a href=&quot;http://%3/&quot;&gt;%3&lt;/a&gt; for more information.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -674,6 +686,14 @@ Please verify the correct file name was given.</source>
     <message>
         <source>OK</source>
         <translation></translation>
+    </message>
+    <message>
+        <source>&amp;Yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;No</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/text_browser_dialog.cpp" line="64"></location>
@@ -857,7 +877,7 @@ Do you want to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>The 'From' value cannot be greater than the 'To' value.</source>
+        <source>The &apos;From&apos; value cannot be greater than the &apos;To&apos; value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1593,7 +1613,7 @@ Please choose a different file name.</source>
 <context>
     <name>QWhatsThisAction</name>
     <message>
-        <source>What's This?</source>
+        <source>What&apos;s This?</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
Changelog:
- Added some more missing qt messages (https://github.com/OpenOrienteering/mapper/pull/926#issuecomment-324529483)
- Updated to use `&quot;` and `&apos;`