### PR TITLE
Fix OSX application menu

### DIFF
--- a/translations/OpenOrienteering_cs.ts
+++ b/translations/OpenOrienteering_cs.ts
@@ -2713,37 +2713,6 @@
     </message>
 </context>
 <context>
-    <name>MAC_APPLICATION_MENU</name>
-    <message>
-        <source>Services</source>
-        <translation type="vanished">Služby</translation>
-    </message>
-    <message>
-        <source>Hide %1</source>
-        <translation type="vanished">Skrýt %1</translation>
-    </message>
-    <message>
-        <source>Hide Others</source>
-        <translation type="vanished">Skrýt ostatní</translation>
-    </message>
-    <message>
-        <source>Show All</source>
-        <translation type="vanished">Ukázat vše</translation>
-    </message>
-    <message>
-        <source>Preferences...</source>
-        <translation type="vanished">Nastavení...</translation>
-    </message>
-    <message>
-        <source>Quit %1</source>
-        <translation type="vanished">Ukončit %1</translation>
-    </message>
-    <message>
-        <source>About %1</source>
-        <translation type="vanished">O %1</translation>
-    </message>
-</context>
-<context>
     <name>MainWindow</name>
     <message>
         <location filename="../src/gui/main_window.cpp" line="757"/>

--- a/translations/OpenOrienteering_de.ts
+++ b/translations/OpenOrienteering_de.ts
@@ -2612,37 +2612,6 @@
     </message>
 </context>
 <context>
-    <name>MAC_APPLICATION_MENU</name>
-    <message>
-        <source>Services</source>
-        <translation type="vanished">Dienste</translation>
-    </message>
-    <message>
-        <source>Hide %1</source>
-        <translation type="vanished">%1 ausblenden</translation>
-    </message>
-    <message>
-        <source>Hide Others</source>
-        <translation type="vanished">Andere ausblenden</translation>
-    </message>
-    <message>
-        <source>Show All</source>
-        <translation type="vanished">Alle einblenden</translation>
-    </message>
-    <message>
-        <source>Preferences...</source>
-        <translation type="vanished">Einstellungen ...</translation>
-    </message>
-    <message>
-        <source>Quit %1</source>
-        <translation type="vanished">%1 beenden</translation>
-    </message>
-    <message>
-        <source>About %1</source>
-        <translation type="vanished">Über %1</translation>
-    </message>
-</context>
-<context>
     <name>MainWindow</name>
     <message>
         <location filename="../src/gui/main_window.cpp" line="757"/>

--- a/translations/OpenOrienteering_es.ts
+++ b/translations/OpenOrienteering_es.ts
@@ -2722,37 +2722,6 @@
     </message>
 </context>
 <context>
-    <name>MAC_APPLICATION_MENU</name>
-    <message>
-        <source>Services</source>
-        <translation type="vanished">Servicios</translation>
-    </message>
-    <message>
-        <source>Hide %1</source>
-        <translation type="vanished">Ocultar %1</translation>
-    </message>
-    <message>
-        <source>Hide Others</source>
-        <translation type="vanished">Ocultar Otros</translation>
-    </message>
-    <message>
-        <source>Show All</source>
-        <translation type="vanished">Mostrar Todo</translation>
-    </message>
-    <message>
-        <source>Preferences...</source>
-        <translation type="vanished">Preferencias...</translation>
-    </message>
-    <message>
-        <source>Quit %1</source>
-        <translation type="vanished">Quitar %1</translation>
-    </message>
-    <message>
-        <source>About %1</source>
-        <translation type="vanished">Acerca de %1</translation>
-    </message>
-</context>
-<context>
     <name>MainWindow</name>
     <message>
         <location filename="../src/gui/main_window.cpp" line="269"/>

--- a/translations/OpenOrienteering_fi.ts
+++ b/translations/OpenOrienteering_fi.ts
@@ -2678,37 +2678,6 @@ löytääksesi taustakarttatiedoston nimen.</translation>
     </message>
 </context>
 <context>
-    <name>MAC_APPLICATION_MENU</name>
-    <message>
-        <source>Services</source>
-        <translation type="vanished">Palvelut</translation>
-    </message>
-    <message>
-        <source>Hide %1</source>
-        <translation type="vanished">Piilota %1</translation>
-    </message>
-    <message>
-        <source>Hide Others</source>
-        <translation type="vanished">Piilota muut</translation>
-    </message>
-    <message>
-        <source>Show All</source>
-        <translation type="vanished">Näytä Kaikki</translation>
-    </message>
-    <message>
-        <source>Preferences...</source>
-        <translation type="vanished">Asetukset…</translation>
-    </message>
-    <message>
-        <source>Quit %1</source>
-        <translation type="vanished">Lopeta %1</translation>
-    </message>
-    <message>
-        <source>About %1</source>
-        <translation type="vanished">Tietoja %1</translation>
-    </message>
-</context>
-<context>
     <name>MainWindow</name>
     <message>
         <location filename="../src/gui/main_window.cpp" line="269"/>

--- a/translations/OpenOrienteering_fr.ts
+++ b/translations/OpenOrienteering_fr.ts
@@ -2691,37 +2691,6 @@
     </message>
 </context>
 <context>
-    <name>MAC_APPLICATION_MENU</name>
-    <message>
-        <source>Services</source>
-        <translation type="vanished">Services</translation>
-    </message>
-    <message>
-        <source>Hide %1</source>
-        <translation type="vanished">Masquer %1</translation>
-    </message>
-    <message>
-        <source>Hide Others</source>
-        <translation type="vanished">Masquer les autres</translation>
-    </message>
-    <message>
-        <source>Show All</source>
-        <translation type="vanished">Tout afficher</translation>
-    </message>
-    <message>
-        <source>Preferences...</source>
-        <translation type="vanished">Préférences…</translation>
-    </message>
-    <message>
-        <source>Quit %1</source>
-        <translation type="vanished">Quitter %1</translation>
-    </message>
-    <message>
-        <source>About %1</source>
-        <translation type="vanished">À propos de %1</translation>
-    </message>
-</context>
-<context>
     <name>MainWindow</name>
     <message>
         <location filename="../src/gui/main_window.cpp" line="269"/>

--- a/translations/OpenOrienteering_hu.ts
+++ b/translations/OpenOrienteering_hu.ts
@@ -2633,37 +2633,6 @@
     </message>
 </context>
 <context>
-    <name>MAC_APPLICATION_MENU</name>
-    <message>
-        <source>Services</source>
-        <translation type="vanished">Szolgáltatások</translation>
-    </message>
-    <message>
-        <source>Hide %1</source>
-        <translation type="vanished">%1 elrejtése</translation>
-    </message>
-    <message>
-        <source>Hide Others</source>
-        <translation type="vanished">Minden mást rejt</translation>
-    </message>
-    <message>
-        <source>Show All</source>
-        <translation type="vanished">Mindent mutat</translation>
-    </message>
-    <message>
-        <source>Preferences...</source>
-        <translation type="vanished">Tulajdonságok...</translation>
-    </message>
-    <message>
-        <source>Quit %1</source>
-        <translation type="vanished">Kilépés ebből: %1</translation>
-    </message>
-    <message>
-        <source>About %1</source>
-        <translation type="vanished">Névjegy %1</translation>
-    </message>
-</context>
-<context>
     <name>MainWindow</name>
     <message>
         <location filename="../src/gui/main_window.cpp" line="269"/>

--- a/translations/OpenOrienteering_it.ts
+++ b/translations/OpenOrienteering_it.ts
@@ -2596,37 +2596,6 @@
     </message>
 </context>
 <context>
-    <name>MAC_APPLICATION_MENU</name>
-    <message>
-        <source>Services</source>
-        <translation type="vanished">Servizi</translation>
-    </message>
-    <message>
-        <source>Hide %1</source>
-        <translation type="vanished">Nascondi %1</translation>
-    </message>
-    <message>
-        <source>Hide Others</source>
-        <translation type="vanished">Nascondi Altri</translation>
-    </message>
-    <message>
-        <source>Show All</source>
-        <translation type="vanished">Mostra tutti</translation>
-    </message>
-    <message>
-        <source>Preferences...</source>
-        <translation type="vanished">Preferenze...</translation>
-    </message>
-    <message>
-        <source>Quit %1</source>
-        <translation type="vanished">Quit (esci) %1</translation>
-    </message>
-    <message>
-        <source>About %1</source>
-        <translation type="vanished">Informazioni %1</translation>
-    </message>
-</context>
-<context>
     <name>MainWindow</name>
     <message>
         <location filename="../src/gui/main_window.cpp" line="269"/>

--- a/translations/OpenOrienteering_ja.ts
+++ b/translations/OpenOrienteering_ja.ts
@@ -2896,29 +2896,6 @@
     </message>
 </context>
 <context>
-    <name>MAC_APPLICATION_MENU</name>
-    <message>
-        <source>Services</source>
-        <translation type="vanished">サービス</translation>
-    </message>
-    <message>
-        <source>Hide %1</source>
-        <translation type="vanished">%1 を非表示</translation>
-    </message>
-    <message>
-        <source>Show All</source>
-        <translation type="vanished">すべて表示</translation>
-    </message>
-    <message>
-        <source>Quit %1</source>
-        <translation type="vanished">%1 を終了</translation>
-    </message>
-    <message>
-        <source>About %1</source>
-        <translation type="vanished">%1 について</translation>
-    </message>
-</context>
-<context>
     <name>MainWindow</name>
     <message>
         <location filename="../src/gui/main_window.cpp" line="269"/>

--- a/translations/OpenOrienteering_lv.ts
+++ b/translations/OpenOrienteering_lv.ts
@@ -2693,37 +2693,6 @@
     </message>
 </context>
 <context>
-    <name>MAC_APPLICATION_MENU</name>
-    <message>
-        <source>Services</source>
-        <translation type="vanished">Servisi</translation>
-    </message>
-    <message>
-        <source>Hide %1</source>
-        <translation type="vanished">Slēpt %1</translation>
-    </message>
-    <message>
-        <source>Hide Others</source>
-        <translation type="vanished">Slēpt Citus</translation>
-    </message>
-    <message>
-        <source>Show All</source>
-        <translation type="vanished">Rādīt Visu</translation>
-    </message>
-    <message>
-        <source>Preferences...</source>
-        <translation type="vanished">Iestatījumi...</translation>
-    </message>
-    <message>
-        <source>Quit %1</source>
-        <translation type="vanished">Beigt %1</translation>
-    </message>
-    <message>
-        <source>About %1</source>
-        <translation type="vanished">Par %1</translation>
-    </message>
-</context>
-<context>
     <name>MainWindow</name>
     <message>
         <location filename="../src/gui/main_window.cpp" line="269"/>

--- a/translations/OpenOrienteering_nb.ts
+++ b/translations/OpenOrienteering_nb.ts
@@ -2713,37 +2713,6 @@
     </message>
 </context>
 <context>
-    <name>MAC_APPLICATION_MENU</name>
-    <message>
-        <source>Services</source>
-        <translation type="vanished">Valg</translation>
-    </message>
-    <message>
-        <source>Hide %1</source>
-        <translation type="vanished">Skjul %1</translation>
-    </message>
-    <message>
-        <source>Hide Others</source>
-        <translation type="vanished">Skjul andre</translation>
-    </message>
-    <message>
-        <source>Show All</source>
-        <translation type="vanished">Vis alle</translation>
-    </message>
-    <message>
-        <source>Preferences...</source>
-        <translation type="vanished">Innstillinger...</translation>
-    </message>
-    <message>
-        <source>Quit %1</source>
-        <translation type="vanished">Avslutt %1</translation>
-    </message>
-    <message>
-        <source>About %1</source>
-        <translation type="vanished">Om %1</translation>
-    </message>
-</context>
-<context>
     <name>MainWindow</name>
     <message>
         <location filename="../src/gui/main_window.cpp" line="269"/>

--- a/translations/OpenOrienteering_nl.ts
+++ b/translations/OpenOrienteering_nl.ts
@@ -2792,37 +2792,6 @@
     </message>
 </context>
 <context>
-    <name>MAC_APPLICATION_MENU</name>
-    <message>
-        <source>Services</source>
-        <translation type="vanished">Ondersteunende functies</translation>
-    </message>
-    <message>
-        <source>Hide %1</source>
-        <translation type="vanished">%1 verbergen</translation>
-    </message>
-    <message>
-        <source>Hide Others</source>
-        <translation type="vanished">Verberg anderen</translation>
-    </message>
-    <message>
-        <source>Show All</source>
-        <translation type="vanished">Toon alles</translation>
-    </message>
-    <message>
-        <source>Preferences...</source>
-        <translation type="vanished">Instellingen...</translation>
-    </message>
-    <message>
-        <source>Quit %1</source>
-        <translation type="vanished">%1 afsluiten</translation>
-    </message>
-    <message>
-        <source>About %1</source>
-        <translation type="vanished">Over %1</translation>
-    </message>
-</context>
-<context>
     <name>MainWindow</name>
     <message>
         <location filename="../src/gui/main_window.cpp" line="757"/>

--- a/translations/OpenOrienteering_pl.ts
+++ b/translations/OpenOrienteering_pl.ts
@@ -2738,37 +2738,6 @@
     </message>
 </context>
 <context>
-    <name>MAC_APPLICATION_MENU</name>
-    <message>
-        <source>Hide Others</source>
-        <translation type="vanished">Ukryj pozostałe</translation>
-    </message>
-    <message>
-        <source>Quit %1</source>
-        <translation type="vanished">Wyjdź %1</translation>
-    </message>
-    <message>
-        <source>About %1</source>
-        <translation type="vanished">O %1</translation>
-    </message>
-    <message>
-        <source>Preferences...</source>
-        <translation type="vanished">Preferencje...</translation>
-    </message>
-    <message>
-        <source>Services</source>
-        <translation type="vanished">Usługi</translation>
-    </message>
-    <message>
-        <source>Hide %1</source>
-        <translation type="vanished">Ukryj %1</translation>
-    </message>
-    <message>
-        <source>Show All</source>
-        <translation type="vanished">Pokaż wszystkie</translation>
-    </message>
-</context>
-<context>
     <name>MainWindow</name>
     <message>
         <location filename="../src/gui/main_window.cpp" line="269"/>

--- a/translations/OpenOrienteering_pt_BR.ts
+++ b/translations/OpenOrienteering_pt_BR.ts
@@ -2570,37 +2570,6 @@ Tradução em Português-BR feita por João Manoel Franco.</translation>
     </message>
 </context>
 <context>
-    <name>MAC_APPLICATION_MENU</name>
-    <message>
-        <source>Services</source>
-        <translation type="vanished">Serviços</translation>
-    </message>
-    <message>
-        <source>Hide %1</source>
-        <translation type="vanished">Ocultar %1</translation>
-    </message>
-    <message>
-        <source>Hide Others</source>
-        <translation type="vanished">Ocultar outros</translation>
-    </message>
-    <message>
-        <source>Show All</source>
-        <translation type="vanished">Mostrar tudo</translation>
-    </message>
-    <message>
-        <source>Preferences...</source>
-        <translation type="vanished">Preferências...</translation>
-    </message>
-    <message>
-        <source>Quit %1</source>
-        <translation type="vanished">Desistir de %1</translation>
-    </message>
-    <message>
-        <source>About %1</source>
-        <translation type="vanished">Sobre %1</translation>
-    </message>
-</context>
-<context>
     <name>MainWindow</name>
     <message>
         <location filename="../src/gui/main_window.cpp" line="269"/>

--- a/translations/OpenOrienteering_ru.ts
+++ b/translations/OpenOrienteering_ru.ts
@@ -2549,37 +2549,6 @@
     </message>
 </context>
 <context>
-    <name>MAC_APPLICATION_MENU</name>
-    <message>
-        <source>Services</source>
-        <translation type="vanished">Службы</translation>
-    </message>
-    <message>
-        <source>Hide %1</source>
-        <translation type="vanished">Скрыть %1</translation>
-    </message>
-    <message>
-        <source>Hide Others</source>
-        <translation type="vanished">Скрыть другие</translation>
-    </message>
-    <message>
-        <source>Show All</source>
-        <translation type="vanished">Показать всё</translation>
-    </message>
-    <message>
-        <source>Preferences...</source>
-        <translation type="vanished">Параметры…</translation>
-    </message>
-    <message>
-        <source>Quit %1</source>
-        <translation type="vanished">Выйти из %1</translation>
-    </message>
-    <message>
-        <source>About %1</source>
-        <translation type="vanished">Про %1</translation>
-    </message>
-</context>
-<context>
     <name>MainWindow</name>
     <message>
         <location filename="../src/gui/main_window.cpp" line="269"/>

--- a/translations/OpenOrienteering_sv.ts
+++ b/translations/OpenOrienteering_sv.ts
@@ -3015,37 +3015,6 @@ Detta fönster låter dig välja en typsnittsstorlek som ger en exakt storlek f�
     </message>
 </context>
 <context>
-    <name>MAC_APPLICATION_MENU</name>
-    <message>
-        <source>Services</source>
-        <translation type="vanished">Tjänster</translation>
-    </message>
-    <message>
-        <source>Hide %1</source>
-        <translation type="vanished">Dölj %1</translation>
-    </message>
-    <message>
-        <source>Hide Others</source>
-        <translation type="vanished">Dölj Andra</translation>
-    </message>
-    <message>
-        <source>Show All</source>
-        <translation type="vanished">Visa alla</translation>
-    </message>
-    <message>
-        <source>Preferences...</source>
-        <translation type="vanished">Personliga inställningar...</translation>
-    </message>
-    <message>
-        <source>Quit %1</source>
-        <translation type="vanished">Avsluta %1</translation>
-    </message>
-    <message>
-        <source>About %1</source>
-        <translation type="vanished">Om %1</translation>
-    </message>
-</context>
-<context>
     <name>MainWindow</name>
     <message>
         <location filename="../src/gui/main_window.cpp" line="269"/>

--- a/translations/locversion.plist.in
+++ b/translations/locversion.plist.in
@@ -5,7 +5,7 @@
     <key>LprojCompatibleVersion</key>
     <string>123</string>
     <key>LprojLocale</key>
-    <string>@LANGUAGE_CODE@</string>
+    <string>@language_code@</string>
     <key>LprojRevisionLevel</key>
     <string>1</string>
     <key>LprojVersion</key>

--- a/translations/qt_eo.ts
+++ b/translations/qt_eo.ts
@@ -2,6 +2,37 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="eo">
 <context>
+    <name>MAC_APPLICATION_MENU</name>
+    <message>
+        <source>Services</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preferences...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QAbstractSpinBox</name>
     <message>
         <source>Step &amp;down</source>

--- a/translations/qt_et.ts
+++ b/translations/qt_et.ts
@@ -2,6 +2,37 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="et">
 <context>
+    <name>MAC_APPLICATION_MENU</name>
+    <message>
+        <source>Services</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preferences...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QAbstractSpinBox</name>
     <message>
         <source>Step &amp;down</source>

--- a/translations/qt_id.ts
+++ b/translations/qt_id.ts
@@ -2,6 +2,37 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="id">
 <context>
+    <name>MAC_APPLICATION_MENU</name>
+    <message>
+        <source>Services</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preferences...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QAbstractSpinBox</name>
     <message>
         <source>Step &amp;down</source>

--- a/translations/qt_lv.ts
+++ b/translations/qt_lv.ts
@@ -2,6 +2,37 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="lv_LV">
 <context>
+    <name>MAC_APPLICATION_MENU</name>
+    <message>
+        <source>Services</source>
+        <translation>Servisi</translation>
+    </message>
+    <message>
+        <source>Hide %1</source>
+        <translation>Slēpt %1</translation>
+    </message>
+    <message>
+        <source>Hide Others</source>
+        <translation>Slēpt Citus</translation>
+    </message>
+    <message>
+        <source>Show All</source>
+        <translation>Rādīt Visu</translation>
+    </message>
+    <message>
+        <source>Preferences...</source>
+        <translation>Iestatījumi...</translation>
+    </message>
+    <message>
+        <source>Quit %1</source>
+        <translation>Beigt %1</translation>
+    </message>
+    <message>
+        <source>About %1</source>
+        <translation>Par %1</translation>
+    </message>
+</context>
+<context>
     <name>QAbstractSpinBox</name>
     <message>
         <source>Step &amp;down</source>

--- a/translations/qt_nb.ts
+++ b/translations/qt_nb.ts
@@ -2,6 +2,37 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="nb_NO">
 <context>
+    <name>MAC_APPLICATION_MENU</name>
+    <message>
+        <source>Services</source>
+        <translation>Valg</translation>
+    </message>
+    <message>
+        <source>Hide %1</source>
+        <translation>Skjul %1</translation>
+    </message>
+    <message>
+        <source>Hide Others</source>
+        <translation>Skjul andre</translation>
+    </message>
+    <message>
+        <source>Show All</source>
+        <translation>Vis alle</translation>
+    </message>
+    <message>
+        <source>Preferences...</source>
+        <translation>Innstillinger...</translation>
+    </message>
+    <message>
+        <source>Quit %1</source>
+        <translation>Avslutt %1</translation>
+    </message>
+    <message>
+        <source>About %1</source>
+        <translation>Om %1</translation>
+    </message>
+</context>
+<context>
     <name>QAbstractSpinBox</name>
     <message>
         <source>Step &amp;down</source>

--- a/translations/qt_nl.ts
+++ b/translations/qt_nl.ts
@@ -2,6 +2,37 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="nl_NL">
 <context>
+    <name>MAC_APPLICATION_MENU</name>
+    <message>
+        <source>Services</source>
+        <translation>Ondersteunende functies</translation>
+    </message>
+    <message>
+        <source>Hide %1</source>
+        <translation>%1 verbergen</translation>
+    </message>
+    <message>
+        <source>Hide Others</source>
+        <translation>Verberg anderen</translation>
+    </message>
+    <message>
+        <source>Show All</source>
+        <translation>Toon alles</translation>
+    </message>
+    <message>
+        <source>Preferences...</source>
+        <translation>Instellingen...</translation>
+    </message>
+    <message>
+        <source>Quit %1</source>
+        <translation>%1 afsluiten</translation>
+    </message>
+    <message>
+        <source>About %1</source>
+        <translation>Over %1</translation>
+    </message>
+</context>
+<context>
     <name>QAbstractSpinBox</name>
     <message>
         <source>Step &amp;down</source>

--- a/translations/qt_template.ts
+++ b/translations/qt_template.ts
@@ -2,6 +2,37 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="cs">
 <context>
+    <name>MAC_APPLICATION_MENU</name>
+    <message>
+        <source>Services</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Others</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preferences...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quit %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>QAbstractSpinBox</name>
     <message>
         <source>Step &amp;down</source>


### PR DESCRIPTION
Briefly:

- (es,fr,hu,ja,pl,pt_BR,sv,de,ru,cs,it,fi) Removed MAC_APPLICATION_MENU context from OpenOrienteering_\*.ts
- (lv,nb,nl) Moved MAC_APPLICATION_MENU context from OpenOrienteering_\*.ts to qt_\*.ts
- (qt_template.ts) Added MAC_APPLICATION_MENU context
- (locversion.plist.in) Fixed s/@LANGUAGE_CODE@/@language_code@/ (https://github.com/OpenOrienteering/mapper/commit/38a3ed259b5d39be96ea7b27f3732c797aac6ed2, v0.7.91 is affected)

MAC_APPLICATION_MENU was initially introduced in https://github.com/OpenOrienteering/mapper/commit/8781511136d06bf40b1d8ffb864322a928e780a8 due to lack of translations in Qt 5.0.1, and removed in https://github.com/OpenOrienteering/mapper/commit/59ef03784b67967f0a2900d0fe3573415405ebb6.

Status of MAC_APPLICATION_MENU translation in Qt:

| locale | Qt |
| -------- | --- |
| es, fr, hu, ja, pl, pt_BR, sv | >5.0 |
| de, ru | >5.1 |
| cs, it | >5.2 |
| fi | >5.3 |
| lv,nb,nl | n/a |

Superbuild uses Qt 5.6.2.
