### PR TITLE
translations: quick-fix azimuth helper text

### DIFF
--- a/translations/OpenOrienteering_cs.ts
+++ b/translations/OpenOrienteering_cs.ts
@@ -8160,7 +8160,7 @@ Nejvyšší podporovaná verze je %2.</translation>
         <location filename="../src/tools/tool_helpers.cpp" line="620"/>
         <source>%1°</source>
         <comment>degree</comment>
-        <translation type="unfinished">%1x {1°?}</translation>
+        <translation type="unfinished">%1°</translation>
     </message>
     <message>
         <location filename="../src/tools/tool_helpers.cpp" line="621"/>

--- a/translations/OpenOrienteering_de.ts
+++ b/translations/OpenOrienteering_de.ts
@@ -7915,7 +7915,7 @@ Die höchste unterstütze Version ist %2.</translation>
         <location filename="../src/tools/tool_helpers.cpp" line="620"/>
         <source>%1°</source>
         <comment>degree</comment>
-        <translation type="unfinished">%1x {1°?}</translation>
+        <translation type="unfinished">%1°</translation>
     </message>
     <message>
         <location filename="../src/tools/tool_helpers.cpp" line="621"/>

--- a/translations/OpenOrienteering_eo.ts
+++ b/translations/OpenOrienteering_eo.ts
@@ -7690,7 +7690,7 @@ La maksimuma subtenata versio estas %2.</translation>
         <location filename="../src/tools/tool_helpers.cpp" line="620"/>
         <source>%1°</source>
         <comment>degree</comment>
-        <translation type="unfinished">%1x {1°?}</translation>
+        <translation type="unfinished">%1°</translation>
     </message>
     <message>
         <location filename="../src/tools/tool_helpers.cpp" line="621"/>

--- a/translations/OpenOrienteering_es.ts
+++ b/translations/OpenOrienteering_es.ts
@@ -8087,7 +8087,7 @@ La máxima versión soportada es %2.</translation>
         <location filename="../src/tools/tool_helpers.cpp" line="620"/>
         <source>%1°</source>
         <comment>degree</comment>
-        <translation type="unfinished">%1x {1°?}</translation>
+        <translation type="unfinished">%1°</translation>
     </message>
     <message>
         <location filename="../src/tools/tool_helpers.cpp" line="621"/>

--- a/translations/OpenOrienteering_fi.ts
+++ b/translations/OpenOrienteering_fi.ts
@@ -8000,7 +8000,7 @@ Tuetaan vain versioon %2 asti.</translation>
         <location filename="../src/tools/tool_helpers.cpp" line="620"/>
         <source>%1°</source>
         <comment>degree</comment>
-        <translation type="unfinished">%1x {1°?}</translation>
+        <translation type="unfinished">%1°</translation>
     </message>
     <message>
         <location filename="../src/tools/tool_helpers.cpp" line="621"/>

--- a/translations/OpenOrienteering_fr.ts
+++ b/translations/OpenOrienteering_fr.ts
@@ -8025,7 +8025,7 @@ La version maximale supportée est la version %2.</translation>
         <location filename="../src/tools/tool_helpers.cpp" line="620"/>
         <source>%1°</source>
         <comment>degree</comment>
-        <translation type="unfinished">%1x {1°?}</translation>
+        <translation type="unfinished">%1°</translation>
     </message>
     <message>
         <location filename="../src/tools/tool_helpers.cpp" line="621"/>

--- a/translations/OpenOrienteering_hu.ts
+++ b/translations/OpenOrienteering_hu.ts
@@ -8023,7 +8023,7 @@ A legnagyobb támogatott verzió a %2.</translation>
         <location filename="../src/tools/tool_helpers.cpp" line="620"/>
         <source>%1°</source>
         <comment>degree</comment>
-        <translation type="unfinished">%1x {1°?}</translation>
+        <translation type="unfinished">%1°</translation>
     </message>
     <message>
         <location filename="../src/tools/tool_helpers.cpp" line="621"/>

--- a/translations/OpenOrienteering_id.ts
+++ b/translations/OpenOrienteering_id.ts
@@ -7702,7 +7702,7 @@ Didukung versi maksimum adalah %2.</translation>
         <location filename="../src/tools/tool_helpers.cpp" line="620"/>
         <source>%1°</source>
         <comment>degree</comment>
-        <translation type="unfinished">%1x {1°?}</translation>
+        <translation type="unfinished">%1°</translation>
     </message>
     <message>
         <location filename="../src/tools/tool_helpers.cpp" line="621"/>

--- a/translations/OpenOrienteering_it.ts
+++ b/translations/OpenOrienteering_it.ts
@@ -7843,7 +7843,7 @@ La versione massima supportata è %2.</translation>
         <location filename="../src/tools/tool_helpers.cpp" line="620"/>
         <source>%1°</source>
         <comment>degree</comment>
-        <translation type="unfinished">%1x {1°?}</translation>
+        <translation type="unfinished">%1°</translation>
     </message>
     <message>
         <location filename="../src/tools/tool_helpers.cpp" line="621"/>

--- a/translations/OpenOrienteering_ja.ts
+++ b/translations/OpenOrienteering_ja.ts
@@ -8644,7 +8644,7 @@ The maximum supported version is %2.</source>
         <location filename="../src/tools/tool_helpers.cpp" line="620"/>
         <source>%1°</source>
         <comment>degree</comment>
-        <translation type="unfinished">%1x {1°?}</translation>
+        <translation type="unfinished">%1°</translation>
     </message>
     <message>
         <location filename="../src/tools/tool_helpers.cpp" line="621"/>

--- a/translations/OpenOrienteering_lv.ts
+++ b/translations/OpenOrienteering_lv.ts
@@ -7998,7 +7998,7 @@ Maksimālā atbalstītā versija ir %2.</translation>
         <location filename="../src/tools/tool_helpers.cpp" line="620"/>
         <source>%1°</source>
         <comment>degree</comment>
-        <translation type="unfinished">%1x {1°?}</translation>
+        <translation type="unfinished">%1°</translation>
     </message>
     <message>
         <location filename="../src/tools/tool_helpers.cpp" line="621"/>

--- a/translations/OpenOrienteering_nb.ts
+++ b/translations/OpenOrienteering_nb.ts
@@ -8096,7 +8096,7 @@ Høyeste støttede versjon er %2.</translation>
         <location filename="../src/tools/tool_helpers.cpp" line="620"/>
         <source>%1°</source>
         <comment>degree</comment>
-        <translation type="unfinished">%1x {1°?}</translation>
+        <translation type="unfinished">%1°</translation>
     </message>
     <message>
         <location filename="../src/tools/tool_helpers.cpp" line="621"/>

--- a/translations/OpenOrienteering_nl.ts
+++ b/translations/OpenOrienteering_nl.ts
@@ -8240,7 +8240,7 @@ Vorlage konnte Niet geladen werden. Existiert deze Gegevens?</translation>
         <location filename="../src/tools/tool_helpers.cpp" line="620"/>
         <source>%1°</source>
         <comment>degree</comment>
-        <translation type="unfinished">%1x {1°?}</translation>
+        <translation type="unfinished">%1°</translation>
     </message>
     <message>
         <location filename="../src/tools/tool_helpers.cpp" line="621"/>

--- a/translations/OpenOrienteering_pl.ts
+++ b/translations/OpenOrienteering_pl.ts
@@ -8113,7 +8113,7 @@ Not an OSM file.</source>
         <location filename="../src/tools/tool_helpers.cpp" line="620"/>
         <source>%1°</source>
         <comment>degree</comment>
-        <translation type="unfinished">%1x {1°?}</translation>
+        <translation type="unfinished">%1°</translation>
     </message>
     <message>
         <location filename="../src/tools/tool_helpers.cpp" line="621"/>

--- a/translations/OpenOrienteering_pt_BR.ts
+++ b/translations/OpenOrienteering_pt_BR.ts
@@ -7809,7 +7809,7 @@ A versão máxima suportada é %2.</translation>
         <location filename="../src/tools/tool_helpers.cpp" line="620"/>
         <source>%1°</source>
         <comment>degree</comment>
-        <translation type="unfinished">%1x {1°?}</translation>
+        <translation type="unfinished">%1°</translation>
     </message>
     <message>
         <location filename="../src/tools/tool_helpers.cpp" line="621"/>

--- a/translations/OpenOrienteering_ru.ts
+++ b/translations/OpenOrienteering_ru.ts
@@ -7767,7 +7767,7 @@ The maximum supported version is %2.</source>
         <location filename="../src/tools/tool_helpers.cpp" line="620"/>
         <source>%1°</source>
         <comment>degree</comment>
-        <translation type="unfinished">%1x {1°?}</translation>
+        <translation type="unfinished">%1°</translation>
     </message>
     <message>
         <location filename="../src/tools/tool_helpers.cpp" line="621"/>

--- a/translations/OpenOrienteering_sv.ts
+++ b/translations/OpenOrienteering_sv.ts
@@ -8669,7 +8669,7 @@ Högsta versionen som stöds är %2.</translation>
         <location filename="../src/tools/tool_helpers.cpp" line="620"/>
         <source>%1°</source>
         <comment>degree</comment>
-        <translation type="unfinished">%1x {1°?}</translation>
+        <translation type="unfinished">%1°</translation>
     </message>
     <message>
         <location filename="../src/tools/tool_helpers.cpp" line="621"/>

--- a/translations/OpenOrienteering_uk.ts
+++ b/translations/OpenOrienteering_uk.ts
@@ -7764,7 +7764,7 @@ The maximum supported version is %2.</source>
         <location filename="../src/tools/tool_helpers.cpp" line="620"/>
         <source>%1°</source>
         <comment>degree</comment>
-        <translation type="unfinished">%1x {1°?}</translation>
+        <translation type="unfinished">%1°</translation>
     </message>
     <message>
         <location filename="../src/tools/tool_helpers.cpp" line="621"/>


### PR DESCRIPTION
The malformed translation propagates onto screen and leaks out of its text rectangle. ![image](https://user-images.githubusercontent.com/5584406/32514982-e05fa1cc-c3fe-11e7-8e26-d6d4c4f44f93.png)
