### PR TITLE
Change package list to space separated and mark as code block

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -55,17 +55,9 @@ git clone https://github.com/OpenOrienteering/mapper.git
 The standard g++ (>= 4.9) compiler from a recent distribution should work. Make
 sure that the required development and tool packages are installed. For a Ubuntu
 or Debian system, install:
-
-cmake,
-doxygen,
-libcups2-dev,
-libgdal-dev,
-libpolyclipping-dev
-libproj-dev,
-qt5-default,
-qtbase5-dev, qtbase5-private-dev, qtbase5-dev-tools,
-qttools5-dev, qttools5-dev-tools, libqt5sql5-sqlite,
-zlib1g-dev
+```
+cmake doxygen libcups2-dev libgdal-dev libpolyclipping-dev libproj-dev qt5-default qtbase5-dev qtbase5-private-dev qtbase5-dev-tools qttools5-dev qttools5-dev-tools libqt5sql5-sqlite zlib1g-dev
+```
 
 When not using Qt Creator, open a terminal, and create a build directory, e.g.
 as subdirectory build in the source directory, and change to that directory.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -56,7 +56,16 @@ The standard g++ (>= 4.9) compiler from a recent distribution should work. Make
 sure that the required development and tool packages are installed. For a Ubuntu
 or Debian system, install:
 ```
-cmake doxygen libcups2-dev libgdal-dev libpolyclipping-dev libproj-dev qt5-default qtbase5-dev qtbase5-private-dev qtbase5-dev-tools qttools5-dev qttools5-dev-tools libqt5sql5-sqlite zlib1g-dev
+cmake \
+doxygen \
+libcups2-dev \
+libgdal-dev \
+libpolyclipping-dev \
+libproj-dev \
+qt5-default \
+qtbase5-dev qtbase5-private-dev qtbase5-dev-tools \
+qttools5-dev qttools5-dev-tools libqt5sql5-sqlite \
+zlib1g-dev
 ```
 
 When not using Qt Creator, open a terminal, and create a build directory, e.g.


### PR DESCRIPTION
A space separated list is easier to copy-paste into a terminal, whereas the comma separated list would not run (for example with `sudo apt install cmake, ...`