### PR TITLE
Fix Swiss CH1903 OCAD zone import

### DIFF
--- a/src/fileformats/ocd_file_import.cpp
+++ b/src/fileformats/ocd_file_import.cpp
@@ -360,7 +360,7 @@ void OcdFileImport::applyGridAndZone(Georeferencing& georef, const QString& comb
 		values.reserve(1);
 		values.push_back(QLatin1String{"3067"});
 	}
-	else if (combined_grid_zone == QLatin1String("14000"))
+	else if (combined_grid_zone == QLatin1String("14001"))
 	{
 		id = QLatin1String{"EPSG"};
 		crs_template = CRSTemplateRegistry().find(id);


### PR DESCRIPTION
It is unclear where did the OCAD code 14/000 come from. Swiss Grid / CH1093 is assigned 14/001 these days.