### PR TITLE
Georef rework prep

### DIFF
--- a/src/core/georeferencing.cpp
+++ b/src/core/georeferencing.cpp
@@ -367,7 +367,7 @@ void Georeferencing::load(QXmlStreamReader& xml, bool load_scale_only)
 	emit projectionChanged();
 }
 
-void Georeferencing::save(QXmlStreamWriter& xml, int xml_format_version) const
+void Georeferencing::save(QXmlStreamWriter& xml, XMLFileFormat::FormatVersion xml_format_version) const
 {
 	XmlElementWriter georef_element(xml, literal::georeferencing);
 	georef_element.writeAttribute(literal::scale, scale_denominator);

--- a/src/core/georeferencing.cpp
+++ b/src/core/georeferencing.cpp
@@ -367,7 +367,7 @@ void Georeferencing::load(QXmlStreamReader& xml, bool load_scale_only)
 	emit projectionChanged();
 }
 
-void Georeferencing::save(QXmlStreamWriter& xml) const
+void Georeferencing::save(QXmlStreamWriter& xml, int xml_format_version) const
 {
 	XmlElementWriter georef_element(xml, literal::georeferencing);
 	georef_element.writeAttribute(literal::scale, scale_denominator);
@@ -424,7 +424,7 @@ void Georeferencing::save(QXmlStreamWriter& xml) const
 			spec_element.writeAttribute(literal::language, literal::proj_4);
 			xml.writeCharacters(geographic_crs_spec);
 		}
-		if (XMLFileFormat::active_version < 6)
+		if (xml_format_version < 6)
 		{
 			// Legacy compatibility
 			XmlElementWriter ref_point_element(xml, literal::ref_point);

--- a/src/core/georeferencing.h
+++ b/src/core/georeferencing.h
@@ -31,6 +31,7 @@
 
 #include "core/latlon.h"
 #include "core/map_coord.h"
+#include "fileformats/xml_file_format.h"
 
 class QDebug;
 class QXmlStreamReader;
@@ -157,7 +158,7 @@ public:
 	/** 
 	 * Saves the georeferencing to an XML stream.
 	 */
-	void save(QXmlStreamWriter& xml, int xml_format_version) const;
+	void save(QXmlStreamWriter& xml, XMLFileFormat::FormatVersion xml_format_version) const;
 	
 	/**
 	 * Creates a georeferencing from an XML stream.

--- a/src/core/georeferencing.h
+++ b/src/core/georeferencing.h
@@ -157,7 +157,7 @@ public:
 	/** 
 	 * Saves the georeferencing to an XML stream.
 	 */
-	void save(QXmlStreamWriter& xml) const;
+	void save(QXmlStreamWriter& xml, int xml_format_version) const;
 	
 	/**
 	 * Creates a georeferencing from an XML stream.

--- a/src/fileformats/ocad8_file_format.cpp
+++ b/src/fileformats/ocad8_file_format.cpp
@@ -206,7 +206,7 @@ void OCAD8FileImport::import(bool load_symbols_only)
 		}
 		
 		if (i == 0 && color->isBlack() && color->getName() == QLatin1String("Registration black")
-		           && XMLFileFormat::active_version >= 6 )
+		           && XMLFileFormat::active_version >= XMLFileFormat::XML_FILE_FORMAT_V6 )
 		{
 			delete color; color = nullptr;
 			color_index[ocad_color->number] = Map::getRegistrationColor();

--- a/src/fileformats/xml_file_format.cpp
+++ b/src/fileformats/xml_file_format.cpp
@@ -253,7 +253,7 @@ void XMLFileExporter::doExport()
 
 void XMLFileExporter::exportGeoreferencing()
 {
-	map->getGeoreferencing().save(xml);
+	map->getGeoreferencing().save(xml, XMLFileFormat::active_version);
 	writeLineBreak(xml);
 }
 

--- a/src/fileformats/xml_file_format.cpp
+++ b/src/fileformats/xml_file_format.cpp
@@ -47,10 +47,10 @@
 
 // ### XMLFileFormat definition ###
 
-constexpr int XMLFileFormat::minimum_version = 2;
-constexpr int XMLFileFormat::current_version = 7;
+constexpr XMLFileFormat::FormatVersion XMLFileFormat::minimum_version = XMLFileFormat::XML_FILE_FORMAT_V2;
+constexpr XMLFileFormat::FormatVersion XMLFileFormat::current_version = XMLFileFormat::XML_FILE_FORMAT_LATEST;
 
-int XMLFileFormat::active_version = 5; // updated by XMLFileExporter::doExport()
+XMLFileFormat::FormatVersion XMLFileFormat::active_version = XMLFileFormat::XML_FILE_FORMAT_V5; // updated by XMLFileExporter::doExport()
 
 
 
@@ -180,11 +180,11 @@ void XMLFileExporter::doExport()
 		xml.setAutoFormatting(true);
 	
 #ifdef MAPPER_ENABLE_COMPATIBILITY
-	int current_version = XMLFileFormat::current_version;
+	XMLFileFormat::FormatVersion current_version = XMLFileFormat::current_version;
 	bool retain_compatibility = Settings::getInstance().getSetting(Settings::General_RetainCompatiblity).toBool();
-	XMLFileFormat::active_version = retain_compatibility ? 5 : current_version;
+	XMLFileFormat::active_version = retain_compatibility ? XMLFileFormat::XML_FILE_FORMAT_V5 : current_version;
 	
-	if (XMLFileFormat::active_version < 6 && map->getNumParts() != 1)
+	if (XMLFileFormat::active_version < XMLFileFormat::XML_FILE_FORMAT_V6 && map->getNumParts() != 1)
 	{
 		throw FileFormatException(tr("Older versions of Mapper do not support multiple map parts. To save the map in compatibility mode, you must first merge all map parts."));
 	}
@@ -209,7 +209,7 @@ void XMLFileExporter::doExport()
 		writeLineBreak(xml);
 
 		XmlElementWriter* barrier = nullptr;
-		if (XMLFileFormat::active_version >= 6)
+		if (XMLFileFormat::active_version >= XMLFileFormat::XML_FILE_FORMAT_V6)
 		{
 			// Prevent Mapper versions < 0.6.0 from crashing
 			// when compatibilty mode is NOT activated

--- a/src/fileformats/xml_file_format.h
+++ b/src/fileformats/xml_file_format.h
@@ -55,19 +55,30 @@ public:
 	 */
 	Exporter *createExporter(QIODevice* stream, Map *map, MapView *view) const override;
 	
+	enum FormatVersion
+	{
+		XML_FILE_FORMAT_V2 = 2,
+		XML_FILE_FORMAT_V3,
+		XML_FILE_FORMAT_V4,
+		XML_FILE_FORMAT_V5,
+		XML_FILE_FORMAT_V6,
+		XML_FILE_FORMAT_V7,
+		XML_FILE_FORMAT_LATEST = XML_FILE_FORMAT_V7
+	};
+
 	/** @brief The minimum XML file format version supported by this implementation.
 	 */
-	static const int minimum_version;
+	static const FormatVersion minimum_version;
 	
 	/** @brief The optimal XML file format version created by this implementation.
 	 */
-	static const int current_version;
+	static const FormatVersion current_version;
 	
 	/** @brief The actual XML file format version to be written.
 	 * 
 	 * This value must be less than or equal to current_version.
 	 */
-	static int active_version;
+	static FormatVersion active_version;
 	
 };
 

--- a/src/gdal/ogr_template.cpp
+++ b/src/gdal/ogr_template.cpp
@@ -496,6 +496,6 @@ void OgrTemplate::saveTypeSpecificTemplateConfiguration(QXmlStreamWriter& xml) c
 	}
 	else if (explicit_georef)
 	{
-		explicit_georef->save(xml);
+		explicit_georef->save(xml, 7); // FIXME - create format version enum
 	}
 }

--- a/src/gdal/ogr_template.cpp
+++ b/src/gdal/ogr_template.cpp
@@ -496,6 +496,6 @@ void OgrTemplate::saveTypeSpecificTemplateConfiguration(QXmlStreamWriter& xml) c
 	}
 	else if (explicit_georef)
 	{
-		explicit_georef->save(xml, 7); // FIXME - create format version enum
+		explicit_georef->save(xml, XMLFileFormat::XML_FILE_FORMAT_LATEST);
 	}
 }

--- a/src/templates/template_track.cpp
+++ b/src/templates/template_track.cpp
@@ -82,7 +82,7 @@ void TemplateTrack::saveTypeSpecificTemplateConfiguration(QXmlStreamWriter& xml)
 	if (preserved_georef)
 	{
 		// Preserve explicit georeferencing from OgrTemplate.
-		preserved_georef->save(xml, 7); // FIXME - create format version enum
+		preserved_georef->save(xml, XMLFileFormat::XML_FILE_FORMAT_LATEST);
 		return;
 	}
 	

--- a/src/templates/template_track.cpp
+++ b/src/templates/template_track.cpp
@@ -82,7 +82,7 @@ void TemplateTrack::saveTypeSpecificTemplateConfiguration(QXmlStreamWriter& xml)
 	if (preserved_georef)
 	{
 		// Preserve explicit georeferencing from OgrTemplate.
-		preserved_georef->save(xml);
+		preserved_georef->save(xml, 7); // FIXME - create format version enum
 		return;
 	}
 	

--- a/src/util/xml_stream_util.cpp
+++ b/src/util/xml_stream_util.cpp
@@ -157,7 +157,7 @@ void XmlElementWriter::write(const MapCoordVector& coords)
 	
 	writeAttribute(literal::count, coords.size());
 	
-	if (XMLFileFormat::active_version < 6 || xml.autoFormatting())
+	if (XMLFileFormat::active_version < XMLFileFormat::XML_FILE_FORMAT_V6 || xml.autoFormatting())
 	{
 		// XMAP files and old format: syntactically rich output
 		for (auto& coord : coords)

--- a/test/coord_xml_t.cpp
+++ b/test/coord_xml_t.cpp
@@ -353,7 +353,7 @@ void CoordXmlTest::writeFastImplementation()
 	xml.setAutoFormatting(false);
 	xml.writeStartDocument();
 	
-	XMLFileFormat::active_version = 6; // Activate fast text format.
+	XMLFileFormat::active_version = XMLFileFormat::XML_FILE_FORMAT_V6; // Activate fast text format.
 	XmlElementWriter element(xml, QLatin1String("root"));
 	
 	QFETCH(int, num_coords);
@@ -1007,7 +1007,7 @@ void CoordXmlTest::readFastImplementation()
 		xml.setAutoFormatting(false);
 		xml.writeStartDocument();
 		
-		XMLFileFormat::active_version = 6; // Activate fast text format.
+		XMLFileFormat::active_version = XMLFileFormat::XML_FILE_FORMAT_V6; // Activate fast text format.
 		
 		xml.writeStartElement(QString::fromLatin1("root"));
 		xml.writeCharacters(QString{}); // flush root start element

--- a/test/georeferencing_t.cpp
+++ b/test/georeferencing_t.cpp
@@ -27,9 +27,6 @@
 #include "fileformats/xml_file_format.h"
 
 
-int XMLFileFormat::active_version = 6;
-
-
 namespace
 {
 	// clazy:excludeall=non-pod-global-static


### PR DESCRIPTION
Ground work for a new OCAD/Mapper georeferencing translation test. As a side effect, georeferencing_t is now using the latest XML format.

XML format version strong type patch is optional.