### PR TITLE
[WIP] Georef rework

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,6 +86,7 @@ set(Mapper_Common_SRCS
   fileformats/ocd_file_export.cpp
   fileformats/ocd_file_format.cpp
   fileformats/ocd_file_import.cpp
+  fileformats/ocd_georef.cpp
   fileformats/ocd_types.cpp
   fileformats/xml_file_format.cpp
   

--- a/src/fileformats/ocd_file_import.cpp
+++ b/src/fileformats/ocd_file_import.cpp
@@ -23,6 +23,7 @@
 #include "ocd_file_import.h"
 
 #include <cmath>
+#include <list>
 #include <memory>
 
 #include <QBuffer>
@@ -46,6 +47,7 @@
 #include "core/symbols/text_symbol.h"
 #include "fileformats/file_format.h"
 #include "fileformats/ocad8_file_format_p.h"
+#include "fileformats/ocd_georef.h"
 #include "fileformats/ocd_types_v9.h"
 #include "fileformats/ocd_types_v10.h"
 #include "fileformats/ocd_types_v11.h"
@@ -248,43 +250,21 @@ void OcdFileImport::importGeoreferencing(const OcdFile< F >& file)
 
 void OcdFileImport::importGeoreferencing(const QString& param_string, int)
 {
-	const QChar* unicode = param_string.unicode();
-	
-	Georeferencing georef;
-	QString combined_grid_zone;
-	QPointF proj_ref_point;
-	bool x_ok = false, y_ok = false;
-	
-	int i = param_string.indexOf(QLatin1Char('\t'), 0);
-	; // skip first word for this entry type
-	while (i >= 0)
+	// si_ScalePar (type 1039) contains both georeferencing and map grid
+	// display parameters. Georeferencing is delegated to a dedicated class
+	// and grid parameters are processed below.
+	std::list<QString> warnings;
+	Georeferencing georef = OcdGeoref::georefFromString(param_string, warnings);
+	std::for_each(warnings.begin(), warnings.end(),
+	              std::bind(&OcdFileImport::addWarning,
+	                        this, std::placeholders::_1));
+
+	bool ok;
+	for (auto param : param_string.split(QString::fromLatin1("\t")).mid(1))
 	{
-		bool ok;
-		int next_i = param_string.indexOf(QLatin1Char('\t'), i+1);
-		int len = (next_i > 0 ? next_i : param_string.length()) - i - 2;
-		const QString param_value = QString::fromRawData(unicode+i+2, len); // no copying!
-		switch (param_string[i+1].toLatin1())
+		const QString param_value = param.remove(0, 1);
+		switch (param[0].unicode())
 		{
-		case 'm':
-			{
-				double scale = param_value.toDouble(&ok);
-				if (ok && scale >= 0)
-					georef.setScaleDenominator(qRound(scale));
-			}
-			break;
-		case 'a':
-			{
-				double angle = param_value.toDouble(&ok);
-				if (ok && qAbs(angle) >= 0.01)
-					georef.setGrivation(angle);
-			}
-			break;
-		case 'x':
-			proj_ref_point.setX(param_value.toDouble(&x_ok));
-			break;
-		case 'y':
-			proj_ref_point.setY(param_value.toDouble(&y_ok));
-			break;
 		case 'd':
 			{
 				auto spacing = param_value.toDouble(&ok);
@@ -298,104 +278,11 @@ void OcdFileImport::importGeoreferencing(const QString& param_string, int)
 				}
 			}
 			break;
-		case 'i':
-			combined_grid_zone = param_value;
-			break;
-		case '\t':
-			// empty item, fall through
-		default:
-			; // nothing
 		}
-		i = next_i;
 	}
-	
-	if (!combined_grid_zone.isEmpty())
-	{
-		applyGridAndZone(georef, combined_grid_zone);
-	}
-	
-	if (x_ok && y_ok)
-	{
-		georef.setProjectedRefPoint(proj_ref_point, false);
-	}
-	
+
 	map->setGeoreferencing(georef);
 }
-
-void OcdFileImport::applyGridAndZone(Georeferencing& georef, const QString& combined_grid_zone)
-{
-	bool zone_ok = false;
-	const CRSTemplate* crs_template = nullptr;
-	QString id;
-	QString spec;
-	std::vector<QString> values;
-	
-	if (combined_grid_zone.startsWith(QLatin1String("20")))
-	{
-		auto zone = combined_grid_zone.midRef(2).toUInt(&zone_ok);
-		zone_ok &= (zone >= 1 && zone <= 60);
-		if (zone_ok)
-		{
-			id = QLatin1String{"UTM"};
-			crs_template = CRSTemplateRegistry().find(id);
-			values.reserve(1);
-			values.push_back(QString::number(zone));
-		}
-	}
-	else if (combined_grid_zone.startsWith(QLatin1String("80")))
-	{
-		auto zone = combined_grid_zone.midRef(2).toUInt(&zone_ok);
-		if (zone_ok)
-		{
-			id = QLatin1String{"Gauss-Krueger, datum: Potsdam"};
-			crs_template = CRSTemplateRegistry().find(id);
-			values.reserve(1);
-			values.push_back(QString::number(zone));
-		}
-	}
-	else if (combined_grid_zone == QLatin1String("6005"))
-	{
-		id = QLatin1String{"EPSG"};
-		crs_template = CRSTemplateRegistry().find(id);
-		values.reserve(1);
-		values.push_back(QLatin1String{"3067"});
-	}
-	else if (combined_grid_zone == QLatin1String("14001"))
-	{
-		id = QLatin1String{"EPSG"};
-		crs_template = CRSTemplateRegistry().find(id);
-		values.reserve(1);
-		values.push_back(QLatin1String{"21781"});
-	}
-	else if (combined_grid_zone == QLatin1String("1000"))
-	{
-		return;
-	}
-	
-	if (crs_template)
-	{
-		spec = crs_template->specificationTemplate();
-		auto param = crs_template->parameters().begin();
-		for (const auto& value : values)
-		{
-			for (const auto& spec_value : (*param)->specValues(value))
-			{
-				spec = spec.arg(spec_value);
-			}
-			++param;
-		}
-	}
-	
-	if (spec.isEmpty())
-	{
-		addWarning(tr("Could not load the coordinate reference system '%1'.").arg(combined_grid_zone));
-	}
-	else
-	{
-		georef.setProjectedCRS(id, spec, std::move(values));
-	}
-}
-
 
 void OcdFileImport::importColors(const OcdFile<Ocd::FormatV8>& file)
 {

--- a/src/fileformats/ocd_georef.cpp
+++ b/src/fileformats/ocd_georef.cpp
@@ -1,0 +1,167 @@
+/*
+ *    Copyright 2013-2017 Kai Pastor
+ *    Copyright 2017 Libor Pecháček
+ *
+ *    This file is part of OpenOrienteering.
+ *
+ *    OpenOrienteering is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OpenOrienteering is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ocd_georef.h"
+
+#include <list>
+
+#include <QObject>
+
+#include "core/crs_template.h"
+
+Georeferencing OcdGeoref::georefFromString(const QString& param_string,
+                                           std::list<QString>& warnings)
+{
+	const QChar* unicode = param_string.unicode();
+
+	Georeferencing georef;
+	QString combined_grid_zone;
+	QPointF proj_ref_point;
+	bool x_ok = false, y_ok = false;
+
+	int i = param_string.indexOf(QLatin1Char('\t'), 0);
+	; // skip first word for this entry type
+	while (i >= 0)
+	{
+		bool ok;
+		int next_i = param_string.indexOf(QLatin1Char('\t'), i+1);
+		int len = (next_i > 0 ? next_i : param_string.length()) - i - 2;
+		const QString param_value = QString::fromRawData(unicode+i+2, len); // no copying!
+		switch (param_string[i+1].toLatin1())
+		{
+		case 'm':
+			{
+				double scale = param_value.toDouble(&ok);
+				if (ok && scale >= 0)
+					georef.setScaleDenominator(qRound(scale));
+			}
+			break;
+		case 'a':
+			{
+				double angle = param_value.toDouble(&ok);
+				if (ok && qAbs(angle) >= 0.01)
+					georef.setGrivation(angle);
+			}
+			break;
+		case 'x':
+			proj_ref_point.setX(param_value.toDouble(&x_ok));
+			break;
+		case 'y':
+			proj_ref_point.setY(param_value.toDouble(&y_ok));
+			break;
+		case 'i':
+			combined_grid_zone = param_value;
+			break;
+		case '\t':
+			// empty item, fall through
+		default:
+			; // nothing
+		}
+		i = next_i;
+	}
+
+	if (!combined_grid_zone.isEmpty())
+	{
+		applyGridAndZone(georef, combined_grid_zone, warnings);
+	}
+
+	if (x_ok && y_ok)
+	{
+		georef.setProjectedRefPoint(proj_ref_point, false);
+	}
+
+	return georef;
+}
+
+void OcdGeoref::applyGridAndZone(Georeferencing& georef,
+                                        const QString& combined_grid_zone,
+                                        std::list<QString>& warnings)
+{
+	bool zone_ok = false;
+	const CRSTemplate* crs_template = nullptr;
+	QString id;
+	QString spec;
+	std::vector<QString> values;
+
+	if (combined_grid_zone.startsWith(QLatin1String("20")))
+	{
+		auto zone = combined_grid_zone.midRef(2).toUInt(&zone_ok);
+		zone_ok &= (zone >= 1 && zone <= 60);
+		if (zone_ok)
+		{
+			id = QLatin1String{"UTM"};
+			crs_template = CRSTemplateRegistry().find(id);
+			values.reserve(1);
+			values.push_back(QString::number(zone));
+		}
+	}
+	else if (combined_grid_zone.startsWith(QLatin1String("80")))
+	{
+		auto zone = combined_grid_zone.midRef(2).toUInt(&zone_ok);
+		if (zone_ok)
+		{
+			id = QLatin1String{"Gauss-Krueger, datum: Potsdam"};
+			crs_template = CRSTemplateRegistry().find(id);
+			values.reserve(1);
+			values.push_back(QString::number(zone));
+		}
+	}
+	else if (combined_grid_zone == QLatin1String("6005"))
+	{
+		id = QLatin1String{"EPSG"};
+		crs_template = CRSTemplateRegistry().find(id);
+		values.reserve(1);
+		values.push_back(QLatin1String{"3067"});
+	}
+	else if (combined_grid_zone == QLatin1String("14001"))
+	{
+		id = QLatin1String{"EPSG"};
+		crs_template = CRSTemplateRegistry().find(id);
+		values.reserve(1);
+		values.push_back(QLatin1String{"21781"});
+	}
+	else if (combined_grid_zone == QLatin1String("1000"))
+	{
+		return;
+	}
+
+	if (crs_template)
+	{
+		spec = crs_template->specificationTemplate();
+		auto param = crs_template->parameters().begin();
+		for (const auto& value : values)
+		{
+			for (const auto& spec_value : (*param)->specValues(value))
+			{
+				spec = spec.arg(spec_value);
+			}
+			++param;
+		}
+	}
+
+	if (spec.isEmpty())
+	{
+		warnings.push_back(QObject::tr("Could not load the coordinate reference system '%1'.").arg(combined_grid_zone));
+	}
+	else
+	{
+		georef.setProjectedCRS(id, spec, std::move(values));
+	}
+}

--- a/src/fileformats/ocd_georef.h
+++ b/src/fileformats/ocd_georef.h
@@ -1,0 +1,40 @@
+/*
+ *    Copyright 2017 Libor Pecháček
+ *
+ *    This file is part of OpenOrienteering.
+ *
+ *    OpenOrienteering is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OpenOrienteering is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OCD_GEOREF_H
+#define OCD_GEOREF_H
+
+#include <vector>
+
+#include <QString>
+
+#include "core/georeferencing.h"
+
+class OcdGeoref
+{
+public:
+	static Georeferencing georefFromString(const QString& param_string,
+		                                       std::list<QString>& warnings);
+protected:
+	static void applyGridAndZone(Georeferencing& georef,
+	                             const QString& combined_grid_zone,
+	                             std::list<QString>& warnings);
+};
+
+#endif // OCD_GEOREF_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -127,6 +127,15 @@ include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 add_unit_test(tst_qglobal)
 add_unit_test(autosave_t MANUAL ../src/core/autosave ../src/settings ../src/util/util)
 add_unit_test(encoding_t ../src/util/encoding)
+add_unit_test(georef_ocd_mapping_t
+        ../src/gui/util_gui
+        ../src/gui/widgets/crs_param_widgets
+        ../src/core/georeferencing
+        ../src/core/crs_template
+        ../src/core/crs_template_implementation
+        ../src/fileformats/ocd_georef
+        ../src/fileformats/file_format
+)
 add_unit_test(georeferencing_t ../src/core/georeferencing ../src/gui/util_gui
 	../src/core/latlon
 	../src/core/crs_template

--- a/test/georef_ocd_mapping_t.cpp
+++ b/test/georef_ocd_mapping_t.cpp
@@ -1,0 +1,108 @@
+/*
+*    Copyright 2017 Libor Pecháček
+*
+*    This file is part of OpenOrienteering.
+*
+*    OpenOrienteering is free software: you can redistribute it and/or modify
+*    it under the terms of the GNU General Public License as published by
+*    the Free Software Foundation, either version 3 of the License, or
+*    (at your option) any later version.
+*
+*    OpenOrienteering is distributed in the hope that it will be useful,
+*    but WITHOUT ANY WARRANTY; without even the implied warranty of
+*    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*    GNU General Public License for more details.
+*
+*    You should have received a copy of the GNU General Public License
+*    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "georef_ocd_mapping_t.h"
+
+#include <list>
+
+#include <QBuffer>
+#include <QString>
+#include <QTest>
+
+#include "core/georeferencing.h"
+#include "fileformats/ocd_georef.h"
+#include "fileformats/xml_file_format.h"
+
+// mock stuff to satisfy link-time dependencies
+int XMLFileFormat::active_version = 6;
+
+void GeoreferenceMappingTest::initTestCase()
+{
+    // empty
+}
+
+
+void GeoreferenceMappingTest::testOcdToMapper_data()
+{
+	QTest::addColumn<QString>("si_ScalePar");
+	QTest::addColumn<int>("ocd_version"); // <Version><3 digit Subversion>
+	QTest::addColumn<QString>("georef_result");
+	QTest::addColumn<bool>("warnings_expected");
+
+	QTest::newRow("Sibelius Monumentti - Finland, TM35FIN, ETRS89/ETRS-TM35FIN")
+	        << QStringLiteral("\tm15000\tg50.0000\tr1\tx384268\ty6673512\ta10.70000000\td1000.000000\ti6005\tb0.00\tc0.00")
+	        << 11006
+	        << QStringLiteral("1;10.7;10.7;60.18202642,24.91341508;EPSG:3067")
+	        << false;
+	QTest::newRow("CERN - Switzerland, CH1903")
+	        << QStringLiteral("\tm15000\tg50.0000\tr1\tx495133\ty129609\ta2.72000000\td1000.000000\ti14001\tb0.00\tc0.00")
+	        << 11006
+	        << QStringLiteral("1;2.72;2.72;46.30967927,6.07729237;EPSG:21781")
+	        << false;
+	QTest::newRow("Aldasin - Czech Republic, S-JTSK/Krovak")
+	        << QStringLiteral("\tm10000\tg1000\tr1\tx-716000\ty-1061000\ta10.82000000\td1000\ti46001")
+	        << 10003
+	        << QStringLiteral("1;10.82;10.82;0.00000000,0.00000000;Local:")
+	        << true;
+	QTest::newRow("Launch Pad 39A - USA, Florida, WGS 84/UTM zone 17")
+	        << QStringLiteral("\tm15000\tg50.0000\tr1\tx538705\ty3164567\ta-7.06000000\td1000.000000\ti2017\tb0.00\tc0.00")
+	        << 11006
+	        << QStringLiteral("1;-7.06;-7.06;28.60751559,-80.60410576;UTM:17")
+	        << false;
+	QTest::newRow("Brandenburger Tor - Germany, DHDN/3-degree Gauss-Kruger zone 4")
+	        << QStringLiteral("\tm15000\tg50.0000\tr1\tx4571442\ty5807888\ta2.84\td1000\ti8004\tb0.00\tc0.00")
+	        << 11006
+	        << QStringLiteral("1;2.84;2.84;52.39964048,13.04810920;Gauss-Krueger, datum: Potsdam:4")
+	        << false;
+	QTest::newRow("Brandenburger Tor - Germany, WGS 84/UTM zone 33N")
+	        << QStringLiteral("\tm15000\tg50.0000\tr1\tx367205\ty5807281\ta5.22000000\td1000.000000\ti2033\tb0.00\tc0.00")
+	        << 11006
+	        << QStringLiteral("1;5.22;5.22;52.39963782,13.04811373;UTM:33")
+	        << false;
+}
+
+
+void GeoreferenceMappingTest::testOcdToMapper()
+{
+	QFETCH(QString, si_ScalePar);
+	QFETCH(QString, georef_result);
+	QFETCH(bool, warnings_expected);
+
+	std::list<QString> warnings;
+	auto gref = OcdGeoref::georefFromString(si_ScalePar, warnings);
+	QVERIFY(bool(warnings.size()) == warnings_expected);
+
+	QStringList crs_params;
+	for (auto s : gref.getProjectedCRSParameters())
+		crs_params.push_back(s);
+
+	auto georef_string = QString(QStringLiteral("%1;%2;%3;%4,%5;%6:%7"))
+	                     .arg(gref.getGridScaleFactor())
+	                     .arg(gref.getDeclination())
+	                     .arg(gref.getGrivation())
+	                     .arg(gref.getGeographicRefPoint().latitude(), 0, 'f', 8)
+	                     .arg(gref.getGeographicRefPoint().longitude(), 0, 'f', 8)
+	                     .arg(gref.getProjectedCRSId())
+	                     .arg(crs_params.join(QLatin1Char(',')));
+
+	//std::cout << georef_string;
+	QCOMPARE(georef_string, georef_result);
+}
+
+QTEST_GUILESS_MAIN(GeoreferenceMappingTest)

--- a/test/georef_ocd_mapping_t.h
+++ b/test/georef_ocd_mapping_t.h
@@ -1,0 +1,37 @@
+/*
+*    Copyright 2017 Libor Pecháček
+*
+*    This file is part of OpenOrienteering.
+*
+*    OpenOrienteering is free software: you can redistribute it and/or modify
+*    it under the terms of the GNU General Public License as published by
+*    the Free Software Foundation, either version 3 of the License, or
+*    (at your option) any later version.
+*
+*    OpenOrienteering is distributed in the hope that it will be useful,
+*    but WITHOUT ANY WARRANTY; without even the implied warranty of
+*    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*    GNU General Public License for more details.
+*
+*    You should have received a copy of the GNU General Public License
+*    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPENORIENTEERING_GEOREF_OCD_MAPPING_TEST_H
+#define OPENORIENTEERING_GEOREF_OCD_MAPPING_TEST_H
+
+#include <QObject>
+
+class GeoreferenceMappingTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+
+    void initTestCase();
+
+    void testOcdToMapper_data();
+    void testOcdToMapper();
+};
+
+#endif // OPENORIENTEERING_GEOREF_OCD_MAPPING_TEST_H


### PR DESCRIPTION
Laying ground for bi-directional translation between OCAD georeferencing parameters and OO Mapper ones. The plan is:

1) extract georeferencing translation into separate class to get clear interface and encapsulation
2) secure status quo with test cases
3) rewrite existing translations (applyGridAndZone) into a table and provide lookup functions
4) extend the lookup table with popular projections
5) implement OCAD v9 file format and save georeferencing

Currently step 2 has been ~60% implemented.

Comments on approach, code structure and coding style is welcome.