### PR TITLE
Fix GPX record time stamp

### DIFF
--- a/src/sensors/gps_track.cpp
+++ b/src/sensors/gps_track.cpp
@@ -57,7 +57,7 @@ void TrackPoint::save(QXmlStreamWriter* stream) const
 	stream->writeAttribute(QStringLiteral("lon"), QString::number(gps_coord.longitude(), 'f', 12));
 	
 	if (datetime.isValid())
-		stream->writeTextElement(QStringLiteral("time"), datetime.toString(Qt::ISODate) + QLatin1Char('Z'));
+		stream->writeTextElement(QStringLiteral("time"), datetime.toString(Qt::ISODate));
 	if (elevation > -9999)
 		stream->writeTextElement(QStringLiteral("ele"), QString::number(elevation, 'f', 3));
 	if (num_satellites >= 0)

--- a/src/sensors/gps_track_recorder.cpp
+++ b/src/sensors/gps_track_recorder.cpp
@@ -54,7 +54,7 @@ void GPSTrackRecorder::newPosition(double latitude, double longitude, double alt
 {
 	TrackPoint new_point(
 		LatLon(latitude, longitude),
-		QDateTime::currentDateTime(),
+		QDateTime::currentDateTimeUtc(),
 		altitude,
 		-1,
 		accuracy


### PR DESCRIPTION
While trying to merge GPX files from Mapper and another source, I noticed that Mapper records times in local time zone.