### PR TITLE
transform_t: Avoid hitting a Qt bug

### DIFF
--- a/test/transform_t.cpp
+++ b/test/transform_t.cpp
@@ -365,10 +365,19 @@ void TransformTest::testEstimateSimilarityTransformation()
 		QCOMPARE(t2.template_scale_x, 1.0);
 		QCOMPARE(t2.template_scale_y, 1.0);
 		
+// Qt 5.11.1 has a regression in QPointF::operator==
+// References:
+// https://bugreports.qt.io/browse/QTBUG-69368
+// https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=903237
+// https://github.com/OpenOrienteering/mapper/issues/1116
+#if QT_VERSION != 0x050B01
 		QCOMPARE(QPointF(passpoints[0].calculated_coords), QPointF(passpoints[0].dest_coords));
 		QVERIFY(passpoints[0].error < min_distance);
 		QCOMPARE(QPointF(passpoints[1].calculated_coords), QPointF(passpoints[1].dest_coords));
 		QVERIFY(passpoints[1].error < min_distance);
+#else
+		QWARN("Parts of test skipped to avoid hitting QTBUG-69368");
+#endif // QT_VERSION != 0x050B01
 		
 		QTransform q2;
 		QVERIFY(passpoints.estimateSimilarityTransformation(&q2));
@@ -377,10 +386,12 @@ void TransformTest::testEstimateSimilarityTransformation()
 		QCOMPARE(q2.dx(), qreal(0));
 		QCOMPARE(q2.dy(), qreal(0));
 		
+#if QT_VERSION != 0x050B01
 		QCOMPARE(QPointF(passpoints[0].calculated_coords), QPointF(passpoints[0].dest_coords));
 		QVERIFY(passpoints[0].error < min_distance);
 		QCOMPARE(QPointF(passpoints[1].calculated_coords), QPointF(passpoints[1].dest_coords));
 		QVERIFY(passpoints[1].error < min_distance);
+#endif // QT_VERSION != 0x050B01
 		
 		QCOMPARE(TemplateTransform::fromQTransform(q2), t2);
 	}


### PR DESCRIPTION
This is the minimal change to skip tests failing with Qt 5.11.1. Use of QEXPECT_FAIL would require modification at four places or definition of a new inline function. Given the importance of this issue I opted for minimal code footprint.