### PR TITLE
Review of file import/export

### DIFF
--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -629,12 +629,13 @@ bool Map::exportTo(const QString& path, const FileFormat& format, const MapView*
 	}
 	
 	QSaveFile file(path);
-	auto exporter = format.makeExporter(&file, this, view);
+	auto exporter = format.makeExporter(path, this, view);
 	bool success = false;
 	if (file.open(QIODevice::WriteOnly))
 	{
 		try
 		{
+			exporter->setDevice(&file);
 			exporter->doExport();
 		}
 		catch (std::exception &e)
@@ -953,17 +954,13 @@ QHash<const Symbol*, Symbol*> Map::importMap(
 
 
 bool Map::exportToIODevice(QIODevice& device) const
-try
 {
 	auto native_format = FileFormats.findFormat("XML");
-	device.open(QIODevice::WriteOnly);
-	native_format->makeExporter(&device, this, nullptr)->doExport();
+	auto exporter = native_format->makeExporter({}, this, nullptr);
+	exporter->setDevice(&device);
+	auto success = exporter->doExport();
 	device.close();
-	return true;
-}
-catch (std::exception& /*e*/)
-{
-	return false;
+	return success;
 }
 
 

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -36,13 +36,11 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QIODevice>
-#include <QLatin1String>
 #include <QLocale>
 #include <QMessageBox>
 #include <QPainter>
 #include <QPoint>
 #include <QPointF>
-#include <QStringList>
 #include <QTimer>
 #include <QTranslator>
 
@@ -615,38 +613,6 @@ void Map::setMapNotes(const QString& text)
 	map_notes = text;
 }
 
-
-bool Map::exportTo(const QString& path, const FileFormat& format, const MapView* view) const
-{
-	Q_ASSERT(view && "Saving a file without view information is not supported!");
-	
-	if (!format.supportsExport())
-	{
-		QMessageBox::warning(nullptr, tr("Error"), tr("Cannot export the map as\n\"%1\"\nbecause saving as %2 (.%3) is not supported.").
-		                     arg(path, format.description(), format.fileExtensions().join(QLatin1String(", "))));
-		return false;
-	}
-	
-	auto exporter = format.makeExporter(path, this, view);
-	if (!exporter->doExport())
-	{
-		QMessageBox::warning(nullptr,
-		                     tr("Error"),
-		                     tr("Cannot save file\n%1:\n%2")
-		                     .arg(path, exporter->warnings().back()) );
-		return false;
-	}
-	
-	if (!exporter->warnings().empty())
-	{
-		MainWindow::showMessageBox(nullptr,
-		                           tr("Warning"),
-		                           tr("The map export generated warnings."),
-		                           exporter->warnings() );
-	}
-	
-	return true;
-}
 
 bool Map::loadFrom(const QString& path, QWidget* dialog_parent, MapView* view, bool load_symbols_only, bool show_error_messages)
 {

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -32,9 +32,7 @@
 #include <QtGlobal>
 #include <QtMath>
 #include <QByteArray>
-#include <QCoreApplication>
 #include <QDebug>
-#include <QEventLoop>
 #include <QFile>
 #include <QFileInfo>
 #include <QIODevice>
@@ -46,7 +44,6 @@
 #include <QPointF>
 #include <QSaveFile>
 #include <QStringList>
-#include <QTextDocument>
 #include <QTimer>
 #include <QTranslator>
 
@@ -68,8 +65,8 @@
 #include "fileformats/file_format.h"
 #include "fileformats/file_format_registry.h"
 #include "fileformats/file_import_export.h"
+#include "gui/main_window.h"
 #include "gui/map/map_widget.h"
-#include "gui/text_browser_dialog.h"
 #include "templates/template.h"
 #include "undo/object_undo.h"
 #include "undo/undo.h"
@@ -119,26 +116,6 @@ struct MapColorSetMergeItem
 /** The mapping of all colors in a source MapColorSet
  *  to colors in a destination MapColorSet. */
 typedef std::vector<MapColorSetMergeItem> MapColorSetMergeList;
-
-
-/**
- * Shows a message box for a list of unformatted messages.
- */
-void showMessageBox(QWidget* parent, const QString& title, const QString& headline, const std::vector<QString>& messages)
-{
-	QString document;
-	if (!headline.isEmpty())
-		document += QLatin1String("<p><b>") + headline + QLatin1String("</b></p>");
-	for (const auto& message : messages)
-		document += Qt::convertFromPlainText(message, Qt::WhiteSpaceNormal);
-	
-	TextBrowserDialog dialog(document, parent);
-	dialog.setWindowTitle(title);
-	dialog.setWindowModality(Qt::WindowModal);
-	dialog.exec();
-	// Let Android update the screen.
-	qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
-}
 
 
 }  // namespace
@@ -681,10 +658,10 @@ bool Map::exportTo(const QString& path, const FileFormat& format, const MapView*
 	}
 	else if (!exporter->warnings().empty())
 	{
-		showMessageBox(nullptr,
-		               tr("Warning"),
-		               tr("The map export generated warnings."),
-		               exporter->warnings() );
+		MainWindow::showMessageBox(nullptr,
+		                           tr("Warning"),
+		                           tr("The map export generated warnings."),
+		                           exporter->warnings() );
 	}
 	
 	return success;
@@ -742,10 +719,10 @@ bool Map::loadFrom(const QString& path, QWidget* dialog_parent, MapView* view, b
 			// Display any warnings.
 			if (!importer->warnings().empty() && show_error_messages)
 			{
-				showMessageBox(nullptr,
-				               tr("Warning"),
-				               tr("The map import generated warnings."),
-				               importer->warnings() );
+				MainWindow::showMessageBox(nullptr,
+				                           tr("Warning"),
+				                           tr("The map import generated warnings."),
+				                           importer->warnings() );
 			}
 			
 			import_complete = true;

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -639,21 +639,6 @@ void Map::setMapNotes(const QString& text)
 	map_notes = text;
 }
 
-bool Map::saveTo(const QString& path, const FileFormat* format, MapView* view)
-{
-	bool success = exportTo(path, format, view);
-	if (success)
-	{
-		colors_dirty = false;
-		symbols_dirty = false;
-		templates_dirty = false;
-		objects_dirty = false;
-		other_dirty = false;
-		unsaved_changes = false;
-		undoManager().setClean();
-	}
-	return success;
-}
 
 bool Map::exportTo(const QString& path, const FileFormat* format, const MapView* view) const
 {

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -640,30 +640,19 @@ void Map::setMapNotes(const QString& text)
 }
 
 
-bool Map::exportTo(const QString& path, const FileFormat* format, const MapView* view) const
+bool Map::exportTo(const QString& path, const FileFormat& format, const MapView* view) const
 {
 	Q_ASSERT(view && "Saving a file without view information is not supported!");
 	
-	if (!format)
-		format = FileFormats.findFormatForFilename(path);
-
-	if (!format)
-		format = FileFormats.findFormat(FileFormats.defaultFormat());
-	
-	if (!format)
-	{
-		QMessageBox::warning(nullptr, tr("Error"), tr("Cannot export the map as\n\"%1\"\nbecause the format is unknown.").arg(path));
-		return false;
-	}
-	else if (!format->supportsExport())
+	if (!format.supportsExport())
 	{
 		QMessageBox::warning(nullptr, tr("Error"), tr("Cannot export the map as\n\"%1\"\nbecause saving as %2 (.%3) is not supported.").
-		                     arg(path, format->description(), format->fileExtensions().join(QLatin1String(", "))));
+		                     arg(path, format.description(), format.fileExtensions().join(QLatin1String(", "))));
 		return false;
 	}
 	
 	QSaveFile file(path);
-	auto exporter = format->makeExporter(&file, this, view);
+	auto exporter = format.makeExporter(&file, this, view);
 	bool success = false;
 	if (file.open(QIODevice::WriteOnly))
 	{

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -794,6 +794,13 @@ void Map::importMap(
 }
 
 
+bool Map::loadFrom(const QString& path, MapView* view)
+{
+	auto importer = FileFormats.makeImporter(path, *this, view);
+	return importer && importer->doImport();
+}
+
+
 QHash<const Symbol*, Symbol*> Map::importMap(
         const Map& imported_map,
         ImportMode mode,

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -655,7 +655,7 @@ bool Map::saveTo(const QString& path, const FileFormat* format, MapView* view)
 	return success;
 }
 
-bool Map::exportTo(const QString& path, const FileFormat* format, MapView* view)
+bool Map::exportTo(const QString& path, const FileFormat* format, const MapView* view) const
 {
 	Q_ASSERT(view && "Saving a file without view information is not supported!");
 	
@@ -1001,7 +1001,7 @@ QHash<const Symbol*, Symbol*> Map::importMap(
 
 
 
-bool Map::exportToIODevice(QIODevice* stream)
+bool Map::exportToIODevice(QIODevice* stream) const
 try
 {
 	auto native_format = FileFormats.findFormat("XML");

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -952,13 +952,13 @@ QHash<const Symbol*, Symbol*> Map::importMap(
 
 
 
-bool Map::exportToIODevice(QIODevice* stream) const
+bool Map::exportToIODevice(QIODevice& device) const
 try
 {
 	auto native_format = FileFormats.findFormat("XML");
-	stream->open(QIODevice::WriteOnly);
-	native_format->makeExporter(stream, this, nullptr)->doExport();
-	stream->close();
+	device.open(QIODevice::WriteOnly);
+	native_format->makeExporter(&device, this, nullptr)->doExport();
+	device.close();
 	return true;
 }
 catch (std::exception& /*e*/)
@@ -967,14 +967,14 @@ catch (std::exception& /*e*/)
 }
 
 
-bool Map::importFromIODevice(QIODevice* stream)
+bool Map::importFromIODevice(QIODevice& device)
 try
 {
 	auto native_format = FileFormats.findFormat("XML");
-	auto importer = native_format->makeImporter(stream, this, nullptr);
+	auto importer = native_format->makeImporter(&device, this, nullptr);
 	importer->doImport(false);
 	importer->finishImport();
-	stream->close();
+	device.close();
 	return true;
 }
 catch (std::exception& /*e*/)

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -650,7 +650,8 @@ bool Map::loadFrom(const QString& path, QWidget* dialog_parent, MapView* view, b
 			auto importer = format->makeImporter(&file, this, view);
 			
 			// Run the first pass.
-			importer->doImport(load_symbols_only, QFileInfo(path).absolutePath());
+			importer->setLoadSymbolsOnly(load_symbols_only);
+			importer->doImport(QFileInfo(path).absolutePath());
 			
 			// Finish the import.
 			importer->finishImport();
@@ -909,7 +910,7 @@ try
 {
 	auto native_format = FileFormats.findFormat("XML");
 	auto importer = native_format->makeImporter(&device, this, nullptr);
-	importer->doImport(false);
+	importer->doImport();
 	importer->finishImport();
 	device.close();
 	return true;

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -61,6 +61,7 @@
 #include "fileformats/file_format.h"
 #include "fileformats/file_format_registry.h"
 #include "fileformats/file_import_export.h"
+#include "fileformats/xml_file_format_p.h"
 #include "gui/main_window.h"
 #include "gui/map/map_widget.h"
 #include "templates/template.h"
@@ -906,10 +907,9 @@ QHash<const Symbol*, Symbol*> Map::importMap(
 
 bool Map::exportToIODevice(QIODevice& device) const
 {
-	auto native_format = FileFormats.findFormat("XML");
-	auto exporter = native_format->makeExporter({}, this, nullptr);
-	exporter->setDevice(&device);
-	auto success = exporter->doExport();
+	XMLFileExporter exporter({}, this, nullptr);
+	exporter.setDevice(&device);
+	auto success = exporter.doExport();
 	device.close();
 	return success;
 }
@@ -917,10 +917,9 @@ bool Map::exportToIODevice(QIODevice& device) const
 
 bool Map::importFromIODevice(QIODevice& device)
 {
-	auto native_format = FileFormats.findFormat("XML");
-	auto importer = native_format->makeImporter({}, this, nullptr);
-	importer->setDevice(&device);
-	auto success = importer->doImport();
+	XMLFileImporter importer {{}, this, nullptr};
+	importer.setDevice(&device);
+	auto success = importer.doImport();
 	device.close();
 	return success;
 }

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -652,12 +652,6 @@ bool Map::loadFrom(const QString& path, QWidget* dialog_parent, MapView* view, b
 			// Run the first pass.
 			importer->doImport(load_symbols_only, QFileInfo(path).absolutePath());
 			
-			// Are there any actions the user must take to complete the import?
-			if (!importer->actions().empty())
-			{
-				// TODO: prompt the user to resolve the action items. All-in-one dialog.
-			}
-			
 			// Finish the import.
 			importer->finishImport();
 			

--- a/src/core/map.h
+++ b/src/core/map.h
@@ -173,7 +173,7 @@ public:
 	 */
 	bool exportTo(const QString& path,
 	              const FileFormat* format = nullptr,
-	              MapView* view = nullptr);
+	              const MapView* view = nullptr) const;
 	
 	/**
 	 * Attempts to load the map from the specified path. Returns true on success.
@@ -237,7 +237,7 @@ public:
 	 * This can be imported again using importFromIODevice().
 	 * Returns true if successful.
 	 */
-	bool exportToIODevice(QIODevice* stream);
+	bool exportToIODevice(QIODevice* stream) const;
 	
 	/**
 	 * Loads the map directly from the given IO device,

--- a/src/core/map.h
+++ b/src/core/map.h
@@ -155,13 +155,6 @@ public:
 	
 	
 	/**
-	 * Saves the map to the given file.
-	 * 
-	 * If a MapView is given, is state will be saved.
-	 */
-	bool saveTo(const QString& path, const FileFormat* format, MapView *view);
-	
-	/**
 	 * Exports the map to the given file and format.
 	 * 
 	 * If a MapView is given, is state will be saved.

--- a/src/core/map.h
+++ b/src/core/map.h
@@ -165,7 +165,7 @@ public:
 	 * successful export.
 	 */
 	bool exportTo(const QString& path,
-	              const FileFormat* format = nullptr,
+	              const FileFormat& format,
 	              const MapView* view = nullptr) const;
 	
 	/**

--- a/src/core/map.h
+++ b/src/core/map.h
@@ -226,18 +226,21 @@ public:
 	
 	
 	/**
-	 * Serializes the map directly into the given IO device in a known format.
+	 * Serializes the map directly to the given IO device, in a fixed format.
+	 * 
 	 * This can be imported again using importFromIODevice().
 	 * Returns true if successful.
 	 */
-	bool exportToIODevice(QIODevice* stream) const;
+	bool exportToIODevice(QIODevice& device) const;
 	
 	/**
-	 * Loads the map directly from the given IO device,
-	 * where the data must have been written by exportToIODevice().
+	 * Loads the map directly from the given IO device.
+	 * 
+	 * The data must have been written by exportToIODevice() (or at least use
+	 * the same format.)
 	 * Returns true if successful.
 	 */
-	bool importFromIODevice(QIODevice* stream);
+	bool importFromIODevice(QIODevice& device);
 	
 	
 	/**

--- a/src/core/map.h
+++ b/src/core/map.h
@@ -54,7 +54,6 @@ class QWidget;
 namespace OpenOrienteering {
 
 class CombinedSymbol;
-class FileFormat;
 class Georeferencing;
 class LineSymbol;
 class MapColor;
@@ -153,20 +152,6 @@ public:
 	 */
 	void reset();
 	
-	
-	/**
-	 * Exports the map to the given file and format.
-	 * 
-	 * If a MapView is given, is state will be saved.
-	 * If a FileFormat is given, it will be used, otherwise the file format
-	 * is determined from the filename.
-	 * 
-	 * If the map was modified, it will still be considered modified after
-	 * successful export.
-	 */
-	bool exportTo(const QString& path,
-	              const FileFormat& format,
-	              const MapView* view = nullptr) const;
 	
 	/**
 	 * Attempts to load the map from the specified path. Returns true on success.

--- a/src/core/map.h
+++ b/src/core/map.h
@@ -168,6 +168,7 @@ public:
 	              QWidget* dialog_parent,
 	              MapView* view = nullptr,
 	              bool load_symbols_only = false, bool show_error_messages = true);
+	bool loadFrom(const QString& path, MapView* view = nullptr);
 	
 	/**
 	 * Imports the other map into this map with the following strategy:

--- a/src/core/map.h
+++ b/src/core/map.h
@@ -156,18 +156,12 @@ public:
 	/**
 	 * Attempts to load the map from the specified path. Returns true on success.
 	 * 
+	 * This is a convenience function used by tests. Normally, a importer should be
+	 * used explicitly.
+	 * 
 	 * @param path The file path to load the map from.
-	 * @param dialog_parent The parent widget for all dialogs.
-	 *     This should never be nullptr in a QWidgets application.
 	 * @param view If not nullptr, restores this map view.
-	 * @param load_symbols_only Loads only symbols from the chosen file.
-	 *     Useful to load symbol sets.
-	 * @param show_error_messages Whether to show import errors and warnings.
 	 */
-	bool loadFrom(const QString& path,
-	              QWidget* dialog_parent,
-	              MapView* view = nullptr,
-	              bool load_symbols_only = false, bool show_error_messages = true);
 	bool loadFrom(const QString& path, MapView* view = nullptr);
 	
 	/**

--- a/src/fileformats/file_format.cpp
+++ b/src/fileformats/file_format.cpp
@@ -74,7 +74,7 @@ std::unique_ptr<Importer> FileFormat::makeImporter(QIODevice* /*stream*/, Map* /
 	throw FileFormatException(QCoreApplication::translate("OpenOrienteering::Importer", "Format (%1) does not support import").arg(description()));
 }
 
-std::unique_ptr<Exporter> FileFormat::makeExporter(QIODevice* /*stream*/, Map* /*map*/, MapView* /*view*/) const
+std::unique_ptr<Exporter> FileFormat::makeExporter(QIODevice* /*stream*/, const Map* /*map*/, const MapView* /*view*/) const
 {
 	throw FileFormatException(QCoreApplication::translate("OpenOrienteering::Exporter", "Format (%1) does not support export").arg(description()));
 }

--- a/src/fileformats/file_format.cpp
+++ b/src/fileformats/file_format.cpp
@@ -74,7 +74,7 @@ std::unique_ptr<Importer> FileFormat::makeImporter(QIODevice* /*stream*/, Map* /
 	throw FileFormatException(QCoreApplication::translate("OpenOrienteering::Importer", "Format (%1) does not support import").arg(description()));
 }
 
-std::unique_ptr<Exporter> FileFormat::makeExporter(QIODevice* /*stream*/, const Map* /*map*/, const MapView* /*view*/) const
+std::unique_ptr<Exporter> FileFormat::makeExporter(const QString& /*path*/, const Map* /*map*/, const MapView* /*view*/) const
 {
 	throw FileFormatException(QCoreApplication::translate("OpenOrienteering::Exporter", "Format (%1) does not support export").arg(description()));
 }

--- a/src/fileformats/file_format.cpp
+++ b/src/fileformats/file_format.cpp
@@ -69,7 +69,7 @@ FileFormat::ImportSupportAssumption FileFormat::understands(const char* /*buffer
 }
 
 
-std::unique_ptr<Importer> FileFormat::makeImporter(QIODevice* /*stream*/, Map* /*map*/, MapView* /*view*/) const
+std::unique_ptr<Importer> FileFormat::makeImporter(const QString& /*path*/, Map* /*map*/, MapView* /*view*/) const
 {
 	throw FileFormatException(QCoreApplication::translate("OpenOrienteering::Importer", "Format (%1) does not support import").arg(description()));
 }

--- a/src/fileformats/file_format.h
+++ b/src/fileformats/file_format.h
@@ -31,8 +31,6 @@
 #include <QString>
 #include <QStringList>
 
-class QIODevice;
-
 namespace OpenOrienteering {
 
 class Exporter;
@@ -243,7 +241,7 @@ public:
 	 * If the Importer can not be created, a FileFormatException shall be
 	 * thrown. The default implementation does just that.
 	 */
-	virtual std::unique_ptr<Importer> makeImporter(QIODevice* stream, Map *map, MapView *view) const;
+	virtual std::unique_ptr<Importer> makeImporter(const QString& path, Map *map, MapView *view) const;
 	
 	/** 
 	 * Creates an Exporter that will save a map to the given path.

--- a/src/fileformats/file_format.h
+++ b/src/fileformats/file_format.h
@@ -251,7 +251,7 @@ public:
 	 * If the Exporter can not be created, a FileFormatException shall be
 	 * thrown. The default implementation does just that.
 	 */
-	virtual std::unique_ptr<Exporter> makeExporter(QIODevice* stream, Map *map, MapView *view) const;
+	virtual std::unique_ptr<Exporter> makeExporter(QIODevice* stream, const Map* map, const MapView* view) const;
 	
 private:
 	FileType file_type;

--- a/src/fileformats/file_format.h
+++ b/src/fileformats/file_format.h
@@ -246,12 +246,12 @@ public:
 	virtual std::unique_ptr<Importer> makeImporter(QIODevice* stream, Map *map, MapView *view) const;
 	
 	/** 
-	 * Creates an Exporter that will save A map into the given stream.
+	 * Creates an Exporter that will save a map to the given path.
 	 *
 	 * If the Exporter can not be created, a FileFormatException shall be
 	 * thrown. The default implementation does just that.
 	 */
-	virtual std::unique_ptr<Exporter> makeExporter(QIODevice* stream, const Map* map, const MapView* view) const;
+	virtual std::unique_ptr<Exporter> makeExporter(const QString& path, const Map* map, const MapView* view) const;
 	
 private:
 	FileType file_type;

--- a/src/fileformats/file_format_registry.h
+++ b/src/fileformats/file_format_registry.h
@@ -100,6 +100,16 @@ public:
 	 */
 	std::unique_ptr<FileFormat> unregisterFormat(const FileFormat *format);
 	
+	
+	/** Creates an importer for the given path, if possible.
+	 */
+	std::unique_ptr<Importer> makeImporter(const QString& path, Map& map, MapView* view = nullptr);
+	
+	/** Creates an exporter for the given path, if possible.
+	 */
+	std::unique_ptr<Exporter> makeExporter(const QString& path, const Map* map, const MapView* view);
+	
+	
 private:
 	std::vector<FileFormat *> fmts;
 	const char* default_format_id;

--- a/src/fileformats/file_format_registry.h
+++ b/src/fileformats/file_format_registry.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Pete Curtis
- *    Copyright 2013, 2016 Kai Pastor
+ *    Copyright 2013, 2016-2018 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -21,6 +21,7 @@
 #ifndef OPENORIENTEERING_FILE_FORMAT_REGISTRY_H
 #define OPENORIENTEERING_FILE_FORMAT_REGISTRY_H
 
+#include <functional>
 #include <memory>
 #include <vector>
 
@@ -51,6 +52,13 @@ public:
 	/** Returns an immutable list of the available file formats.
 	 */
 	inline const std::vector<FileFormat *> &formats() const { return fmts; }
+	
+	
+	/** Finds a file format with the given internal ID, or returns nullptr if no format
+	 *  is found.
+	 */
+	const FileFormat* findFormat(std::function<bool(const FileFormat*)> predicate) const;
+	
 	
 	/** Finds a file format with the given internal ID, or returns nullptr if no format
 	 *  is found.

--- a/src/fileformats/file_format_registry.h
+++ b/src/fileformats/file_format_registry.h
@@ -71,13 +71,17 @@ public:
 	 * Only the file format's filter string before the closing ')' is taken into
 	 * account for matching, i.e. the given parameter 'filter' may contain
 	 * additional extensions following the original ones.
+	 * 
+	 * The predicate is intented to select either import or export formats.
 	 */
-	const FileFormat *findFormatByFilter(const QString& filter) const;
+	const FileFormat *findFormatByFilter(const QString& filter, bool (FileFormat::*predicate)() const) const;
 	
 	/** Finds a file format whose file extension matches the file extension of the given
 	 *  path, or returns nullptr if no matching format is found.
+	 * 
+	 * The predicate is intented to select either import or export formats.
 	 */
-	const FileFormat *findFormatForFilename(const QString& filename) const;
+	const FileFormat *findFormatForFilename(const QString& filename, bool (FileFormat::*predicate)() const) const;
 	
 	/** Finds an import file format by looking at the existing data.
 	 */

--- a/src/fileformats/file_format_registry.h
+++ b/src/fileformats/file_format_registry.h
@@ -27,9 +27,9 @@
 
 #include <QString>
 
-namespace OpenOrienteering {
+#include "fileformats/file_format.h"
 
-class FileFormat;
+namespace OpenOrienteering {
 
 
 /** Provides a registry for file formats, and takes ownership of the supported format objects.
@@ -78,6 +78,11 @@ public:
 	 *  path, or returns nullptr if no matching format is found.
 	 */
 	const FileFormat *findFormatForFilename(const QString& filename) const;
+	
+	/** Finds an import file format by looking at the existing data.
+	 */
+	const FileFormat* findFormatForData(const QString& path, FileFormat::FileTypes types) const;
+	
 	
 	/** Returns the ID of default file format for this registry. This will automatically
 	 *  be set to the first registered format.

--- a/src/fileformats/file_import_export.cpp
+++ b/src/fileformats/file_import_export.cpp
@@ -1,7 +1,7 @@
 /*
  *    Copyright 2012, 2013 Pete Curtis
  *    Copyright 2013, 2014 Thomas Schöps
- *    Copyright 2013-2015 Kai Pastor
+ *    Copyright 2013-2018 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *

--- a/src/fileformats/file_import_export.cpp
+++ b/src/fileformats/file_import_export.cpp
@@ -42,6 +42,17 @@ namespace OpenOrienteering {
 ImportExport::~ImportExport() = default;
 
 
+bool ImportExport::supportsQIODevice() const noexcept
+{
+	return true;
+}
+
+void ImportExport::setDevice(QIODevice* device)
+{
+	device_ = device;
+}
+
+
 QVariant ImportExport::option(const QString& name) const
 {
 	if (!options.contains(name))

--- a/src/fileformats/file_import_export.cpp
+++ b/src/fileformats/file_import_export.cpp
@@ -68,6 +68,11 @@ QVariant ImportExport::option(const QString& name) const
 }
 
 
+void ImportExport::setOption(const QString& name, const QVariant& value)
+{
+	options[name] = value;
+}
+
 
 // ### Importer ###
 

--- a/src/fileformats/file_import_export.cpp
+++ b/src/fileformats/file_import_export.cpp
@@ -79,12 +79,18 @@ void ImportExport::setOption(const QString& name, const QVariant& value)
 Importer::~Importer() = default;
 
 
-void Importer::doImport(bool load_symbols_only, const QString& map_path)
+void Importer::setLoadSymbolsOnly(bool value)
+{
+	load_symbols_only = value;
+}
+
+
+void Importer::doImport(const QString& map_path)
 {
 	if (view)
 		view->setTemplateLoadingBlocked(true);
 	
-	import(load_symbols_only);
+	import();
 	
 	// Object post processing:
 	// - make sure that there is no object without symbol

--- a/src/fileformats/file_import_export.h
+++ b/src/fileformats/file_import_export.h
@@ -50,10 +50,11 @@ class ImportExport
 	Q_DECLARE_TR_FUNCTIONS(OpenOrienteering::ImportExport)
 	
 public:
-	/** Creates a new importer or exporter with the given IO stream.
+	/**
+	 * Creates a new importer or exporter with the given IO device.
 	 */
-	ImportExport(QIODevice* stream)
-	: stream(stream)
+	ImportExport(QIODevice* device = nullptr)
+	: device_(device)
 	{}
 	
 	ImportExport(const ImportExport&) = delete;
@@ -62,6 +63,31 @@ public:
 	/** Destroys an importer or exporter.
 	 */
 	virtual ~ImportExport();
+	
+	
+	/**
+	 * Returns true when the importer/exporter supports QIODevice.
+	 * 
+	 * The default implementation returns `true`. Some exporters or importers
+	 * might wish to use other ways of accessing the output/input path.
+	 * In these cases, the default implementation should be overwritten to
+	 * return `false`.
+	 */
+	virtual bool supportsQIODevice() const noexcept;
+	
+	/**
+	 * Returns the input device if it has been set or created.
+	 */
+	QIODevice* device() const noexcept { return device_; }
+	
+	/**
+	 * Sets a custom input device to be used for import.
+	 * 
+	 * Not all importers may be able to use such devices.
+	 * 
+	 * \see ImportExport::supportQIODevice()
+ 	 */
+	void setDevice(QIODevice* device);
 	
 	
 	/** Returns the current list of warnings collected by this object.
@@ -84,11 +110,11 @@ public:
 	 */
 	void addWarning(const QString& str);
 	
-protected:
-	/// The input / output stream
-	QIODevice* stream;
 	
 private:
+	/// The input / output device
+	QIODevice* device_;
+	
 	/// A list of options for the import/export
 	QHash<QString, QVariant> options;
 	
@@ -126,10 +152,11 @@ class Importer : public ImportExport
 	Q_DECLARE_TR_FUNCTIONS(OpenOrienteering::Importer)
 	
 public:
-	/** Creates a new Importer with the given input stream, map, and view.
+	/**
+	 * Creates a new Importer with the given input device, map, and view.
 	 */
-	Importer(QIODevice* stream, Map *map, MapView *view)
-	: ImportExport(stream), map(map), view(view)
+	Importer(QIODevice* device, Map *map, MapView *view)
+	: ImportExport(device), map(map), view(view)
 	{}
 	
 	/** Destroys this Importer.
@@ -192,10 +219,11 @@ class Exporter : public ImportExport
 	Q_DECLARE_TR_FUNCTIONS(OpenOrienteering::Exporter)
 	
 public:
-	/** Creates a new Exporter with the given output stream, map, and view.
+	/** 
+	 * Creates a new Exporter with the given output device, map, and view.
 	 */
-	Exporter(QIODevice* stream, const Map* map, const MapView* view)
-	: ImportExport(stream), map(map), view(view)
+	Exporter(QIODevice* device, const Map* map, const MapView* view)
+	: ImportExport(device), map(map), view(view)
 	{}
 	
 	/** Destroys the current Exporter.

--- a/src/fileformats/file_import_export.h
+++ b/src/fileformats/file_import_export.h
@@ -90,26 +90,32 @@ public:
 	void setDevice(QIODevice* device);
 	
 	
-	/** Returns the current list of warnings collected by this object.
-	 */
-	const std::vector<QString> &warnings() const;
-	
-	/** Sets an option in this importer or exporter.
+	/**
+	 * Sets an option in this importer or exporter.
 	 */
 	void setOption(const QString& name, const QVariant& value);
 	
-	/** Retrieves the value of an options in this importer or exporter. If the option does not have
-	 *  a value - either a default value assigned in the constructor, or a custom value assigned
-	 *  through setOption() - then a FormatException will be thrown.
+	/**
+	 * Retrieves the value of an option in this instance.
+	 * 
+	 * The option's value must have been set before this function is called,
+	 * either in the constructor, or later through setOption(). Otherwise a
+	 * FormatException will be thrown.
 	 */
 	QVariant option(const QString& name) const;
 	
-	protected:
-	/** Adds an import/export warning to the current list of warnings. The provided message
-	 *  should be translated.
-	 */
-	void addWarning(const QString& str);
 	
+	/**
+	 * Adds a string to the current list of warnings.
+	 * 
+	 * The provided message should be translated.
+	 */
+	void addWarning(const QString& str) { warnings_.emplace_back(str); }
+	
+	/**
+	 * Returns the current list of warnings collected by this object.
+	 */
+	const std::vector<QString>& warnings() const noexcept { return warnings_; }
 	
 private:
 	friend class Exporter;  // direct access to device_ in Exporter::doExport()
@@ -121,7 +127,7 @@ private:
 	QHash<QString, QVariant> options;
 	
 	/// A list of warnings
-	std::vector<QString> warn;
+	std::vector<QString> warnings_;
 };
 
 
@@ -161,7 +167,8 @@ public:
 	: ImportExport(device), map(map), view(view)
 	{}
 	
-	/** Destroys this Importer.
+	/**
+	 * Destroys this Importer.
 	 */
 	~Importer() override;
 	
@@ -282,28 +289,6 @@ protected:
 	const MapView* const view;
 	
 };
-
-
-// ### ImportExport inline code ###
-
-inline
-const std::vector< QString >& ImportExport::warnings() const
-{
-	return warn;
-}
-
-inline
-void ImportExport::addWarning(const QString& str)
-{
-	warn.push_back(str);
-}
-
-inline
-void ImportExport::setOption(const QString& name, const QVariant& value)
-{
-	options[name] = value;
-}
-
 
 
 

--- a/src/fileformats/file_import_export.h
+++ b/src/fileformats/file_import_export.h
@@ -162,6 +162,18 @@ public:
 	 */
 	~Importer() override;
 	
+	
+	/**
+	 * Returns true if only symbols (and colors) are to be imported.
+	 */
+	bool loadSymbolsOnly() const noexcept { return load_symbols_only; }
+	
+	/**
+	 * If set to true, importers shall import only symbols (and colors).
+	 */
+	void setLoadSymbolsOnly(bool value);
+	
+	
 	/** Begins the import process. The implementation of this method should read the file
 	 *  and populate the map and view from it. If a fatal error is encountered (such as a
 	 *  missing or corrupt file), than it should throw a FormatException. If the import can
@@ -171,7 +183,7 @@ public:
 	 *  generally an Importer should not succeed unless the map is populated sufficiently
 	 *  to be useful.
 	 */
-	void doImport(bool load_symbols_only, const QString& map_path = QString());
+	void doImport(const QString& map_path = QString());
 	
 	/** Once all action items are satisfied, this method should be called to complete the
 	 *  import process. This class defines a default implementation, that does nothing.
@@ -181,7 +193,7 @@ public:
 protected:
 	/** Implementation of doImport().
 	 */
-	virtual void import(bool load_symbols_only) = 0;
+	virtual void import() = 0;
 	
 	
 	/// The Map to import or export
@@ -189,6 +201,11 @@ protected:
 	
 	/// The MapView to import or export
 	MapView* const view;
+	
+	
+private:
+	/// A flag which controls whether only symbols and colors are imported.
+	bool load_symbols_only = false;
 	
 };
 

--- a/src/fileformats/file_import_export.h
+++ b/src/fileformats/file_import_export.h
@@ -131,16 +131,6 @@ private:
 };
 
 
-/**
- * Represents an action that the user must take to successfully complete an import.
- * TODO: Currently not fully implemented, as this should be done using the
- * planned ProblemWidget instead, which works independently of import / export.
- */
-class ImportAction
-{
-	// Nothing
-};
-
 
 /** Base class for all importers. An Importer has the following lifecycle:
  *  -# The Importer is constructed, with pointers to the map and view. The Importer
@@ -172,10 +162,6 @@ public:
 	 */
 	~Importer() override;
 	
-	/** Returns the current list of action items.
-	 */
-	inline const std::vector<ImportAction> &actions() const;
-	
 	/** Begins the import process. The implementation of this method should read the file
 	 *  and populate the map and view from it. If a fatal error is encountered (such as a
 	 *  missing or corrupt file), than it should throw a FormatException. If the import can
@@ -197,10 +183,6 @@ protected:
 	 */
 	virtual void import(bool load_symbols_only) = 0;
 	
-	/** Adds an action item to the current list.
-	 */
-	inline void addAction(const ImportAction &action);
-	
 	
 	/// The Map to import or export
 	Map* const map;
@@ -208,10 +190,6 @@ protected:
 	/// The MapView to import or export
 	MapView* const view;
 	
-	
-private:
-	/// A list of action items that must be resolved before the import can be completed
-	std::vector<ImportAction> act;
 };
 
 
@@ -289,22 +267,6 @@ protected:
 	const MapView* const view;
 	
 };
-
-
-
-// ### Importer inline code ###
-
-inline
-const std::vector< ImportAction >& Importer::actions() const
-{
-	return act;
-}
-
-inline
-void Importer::addAction(const ImportAction& action)
-{
-	act.push_back(action);
-}
 
 
 }  // namespace OpenOrienteering

--- a/src/fileformats/ocad8_file_format.cpp
+++ b/src/fileformats/ocad8_file_format.cpp
@@ -83,9 +83,9 @@ std::unique_ptr<Importer> OCAD8FileFormat::makeImporter(QIODevice* stream, Map *
 	return std::make_unique<OCAD8FileImport>(stream, map, view);
 }
 
-std::unique_ptr<Exporter> OCAD8FileFormat::makeExporter(QIODevice* stream, const Map* map, const MapView* view) const
+std::unique_ptr<Exporter> OCAD8FileFormat::makeExporter(const QString& path, const Map* map, const MapView* view) const
 {
-	return std::make_unique<OCAD8FileExport>(stream, map, view);
+	return std::make_unique<OCAD8FileExport>(path, map, view);
 }
 
 
@@ -1544,8 +1544,8 @@ double OCAD8FileImport::convertTemplateScale(double ocad_scale)
 
 // ### OCAD8FileExport ###
 
-OCAD8FileExport::OCAD8FileExport(QIODevice* stream, const Map* map, const MapView* view)
- : Exporter(stream, map, view),
+OCAD8FileExport::OCAD8FileExport(const QString& path, const Map* map, const MapView* view)
+ : Exporter(path, map, view),
    uses_registration_color(false),
    file(nullptr)
 {
@@ -1561,7 +1561,7 @@ OCAD8FileExport::~OCAD8FileExport()
 	delete origin_point_object;
 }
 
-void OCAD8FileExport::doExport()
+bool OCAD8FileExport::exportImplementation()
 {
 	uses_registration_color = map->isColorUsedByASymbol(map->getRegistrationColor());
 	if (map->getNumColors() > (uses_registration_color ? 255 : 256))
@@ -1879,6 +1879,7 @@ void OCAD8FileExport::doExport()
 	device()->write((char*)file->buffer, file->size);
 	
 	ocad_file_close(file);
+	return true;
 }
 
 

--- a/src/fileformats/ocad8_file_format.cpp
+++ b/src/fileformats/ocad8_file_format.cpp
@@ -116,7 +116,7 @@ bool OCAD8FileImport::isRasterImageFile(const QString &filename)
 	return QImageReader::supportedImageFormats().contains(extension.toLatin1());
 }
 
-void OCAD8FileImport::import(bool load_symbols_only)
+void OCAD8FileImport::import()
 {
     //qint64 start = QDateTime::currentMSecsSinceEpoch();
 	
@@ -293,7 +293,7 @@ void OCAD8FileImport::import(bool load_symbols_only)
         }
     }
 
-    if (!load_symbols_only)
+    if (!loadSymbolsOnly())
 	{
 		// Load objects
 

--- a/src/fileformats/ocad8_file_format.cpp
+++ b/src/fileformats/ocad8_file_format.cpp
@@ -1543,7 +1543,7 @@ double OCAD8FileImport::convertTemplateScale(double ocad_scale)
 
 // ### OCAD8FileExport ###
 
-OCAD8FileExport::OCAD8FileExport(QIODevice* stream, Map* map, MapView* view)
+OCAD8FileExport::OCAD8FileExport(QIODevice* stream, const Map* map, const MapView* view)
  : Exporter(stream, map, view),
    uses_registration_color(false),
    file(nullptr)
@@ -1907,7 +1907,7 @@ MapCoord OCAD8FileExport::calculateAreaOffset()
 			{
 				addWarning(tr("Coordinates are adjusted to fit into the OCAD 8 drawing area (-2 m ... 2 m)."));
 				std::size_t count = 0;
-				auto calculate_average_center = [&area_offset, &count](Object* object)
+				auto calculate_average_center = [&area_offset, &count](const Object* object)
 				{
 					area_offset *= qreal(count)/qreal(count+1);
 					++count;

--- a/src/fileformats/ocad8_file_format.cpp
+++ b/src/fileformats/ocad8_file_format.cpp
@@ -83,7 +83,7 @@ std::unique_ptr<Importer> OCAD8FileFormat::makeImporter(QIODevice* stream, Map *
 	return std::make_unique<OCAD8FileImport>(stream, map, view);
 }
 
-std::unique_ptr<Exporter> OCAD8FileFormat::makeExporter(QIODevice* stream, Map* map, MapView* view) const
+std::unique_ptr<Exporter> OCAD8FileFormat::makeExporter(QIODevice* stream, const Map* map, const MapView* view) const
 {
 	return std::make_unique<OCAD8FileExport>(stream, map, view);
 }

--- a/src/fileformats/ocad8_file_format.cpp
+++ b/src/fileformats/ocad8_file_format.cpp
@@ -120,6 +120,7 @@ void OCAD8FileImport::import(bool load_symbols_only)
 {
     //qint64 start = QDateTime::currentMSecsSinceEpoch();
 	
+	auto stream = device();
 	u32 size = stream->bytesAvailable();
 	u8* buffer = (u8*)malloc(size);
 	if (!buffer)
@@ -1875,7 +1876,7 @@ void OCAD8FileExport::doExport()
 		}
 	}
 	
-	stream->write((char*)file->buffer, file->size);
+	device()->write((char*)file->buffer, file->size);
 	
 	ocad_file_close(file);
 }

--- a/src/fileformats/ocad8_file_format.h
+++ b/src/fileformats/ocad8_file_format.h
@@ -44,7 +44,7 @@ public:
 	
 	ImportSupportAssumption understands(const char* buffer, int size) const override;
 	std::unique_ptr<Importer> makeImporter(QIODevice* stream, Map *map, MapView *view) const override;
-	std::unique_ptr<Exporter> makeExporter(QIODevice* stream, const Map* map, const MapView* view) const override;
+	std::unique_ptr<Exporter> makeExporter(const QString& path, const Map* map, const MapView* view) const override;
 };
 
 

--- a/src/fileformats/ocad8_file_format.h
+++ b/src/fileformats/ocad8_file_format.h
@@ -44,7 +44,7 @@ public:
 	
 	ImportSupportAssumption understands(const char* buffer, int size) const override;
 	std::unique_ptr<Importer> makeImporter(QIODevice* stream, Map *map, MapView *view) const override;
-	std::unique_ptr<Exporter> makeExporter(QIODevice* stream, Map* map, MapView* view) const override;
+	std::unique_ptr<Exporter> makeExporter(QIODevice* stream, const Map* map, const MapView* view) const override;
 };
 
 

--- a/src/fileformats/ocad8_file_format.h
+++ b/src/fileformats/ocad8_file_format.h
@@ -43,7 +43,7 @@ public:
 	OCAD8FileFormat();
 	
 	ImportSupportAssumption understands(const char* buffer, int size) const override;
-	std::unique_ptr<Importer> makeImporter(QIODevice* stream, Map *map, MapView *view) const override;
+	std::unique_ptr<Importer> makeImporter(const QString& path, Map *map, MapView *view) const override;
 	std::unique_ptr<Exporter> makeExporter(const QString& path, const Map* map, const MapView* view) const override;
 };
 

--- a/src/fileformats/ocad8_file_format_p.h
+++ b/src/fileformats/ocad8_file_format_p.h
@@ -153,13 +153,12 @@ class OCAD8FileExport : public Exporter
 	Q_DECLARE_TR_FUNCTIONS(OpenOrienteering::OCAD8FileExport)
 	
 public:
-	OCAD8FileExport(QIODevice* stream, const Map* map, const MapView* view);
+	OCAD8FileExport(const QString& path, const Map* map, const MapView* view);
 	~OCAD8FileExport() override;
 	
-	void doExport() override;
-	
-	
 protected:
+	bool exportImplementation() override;
+	
 	// Determines an offset for moving objects to the OCD drawing area.
 	MapCoord calculateAreaOffset();
 	

--- a/src/fileformats/ocad8_file_format_p.h
+++ b/src/fileformats/ocad8_file_format_p.h
@@ -73,13 +73,13 @@ private:
 	};
 	
 public:
-	OCAD8FileImport(QIODevice* stream, Map *map, MapView *view);
+	OCAD8FileImport(const QString& path, Map *map, MapView *view);
 	~OCAD8FileImport() override;
 
 	void setStringEncodings(const char *narrow, const char *wide = "UTF-16LE");
 
 protected:
-	void import() override;
+	bool importImplementation() override;
 	
 	// Symbol import
 	Symbol *importPointSymbol(const OCADPointSymbol *ocad_symbol);

--- a/src/fileformats/ocad8_file_format_p.h
+++ b/src/fileformats/ocad8_file_format_p.h
@@ -153,7 +153,7 @@ class OCAD8FileExport : public Exporter
 	Q_DECLARE_TR_FUNCTIONS(OpenOrienteering::OCAD8FileExport)
 	
 public:
-	OCAD8FileExport(QIODevice* stream, Map *map, MapView *view);
+	OCAD8FileExport(QIODevice* stream, const Map* map, const MapView* view);
 	~OCAD8FileExport() override;
 	
 	void doExport() override;

--- a/src/fileformats/ocad8_file_format_p.h
+++ b/src/fileformats/ocad8_file_format_p.h
@@ -79,7 +79,7 @@ public:
 	void setStringEncodings(const char *narrow, const char *wide = "UTF-16LE");
 
 protected:
-	void import(bool load_symbols_only) override;
+	void import() override;
 	
 	// Symbol import
 	Symbol *importPointSymbol(const OCADPointSymbol *ocad_symbol);

--- a/src/fileformats/ocd_file_export.cpp
+++ b/src/fileformats/ocd_file_export.cpp
@@ -27,7 +27,7 @@
 
 namespace OpenOrienteering {
 
-OcdFileExport::OcdFileExport(QIODevice* stream, Map* map, MapView* view)
+OcdFileExport::OcdFileExport(QIODevice* stream, const Map* map, const MapView* view)
 : Exporter { stream, map, view }
 {
 	// nothing else

--- a/src/fileformats/ocd_file_export.cpp
+++ b/src/fileformats/ocd_file_export.cpp
@@ -39,7 +39,7 @@ OcdFileExport::~OcdFileExport() = default;
 
 void OcdFileExport::doExport()
 {
-	OCAD8FileExport delegate { stream, map, view };
+	OCAD8FileExport delegate { device(), map, view };
 	delegate.doExport();
 	for (auto&& w : delegate.warnings())
 	{

--- a/src/fileformats/ocd_file_export.cpp
+++ b/src/fileformats/ocd_file_export.cpp
@@ -41,12 +41,12 @@ bool OcdFileExport::exportImplementation()
 {
 	OCAD8FileExport delegate { path, map, view };
 	delegate.setDevice(device());
-	delegate.doExport();
+	auto success = delegate.doExport();
 	for (auto&& w : delegate.warnings())
 	{
 		addWarning(w);
 	}
-	return true;
+	return success;
 }
 
 

--- a/src/fileformats/ocd_file_export.cpp
+++ b/src/fileformats/ocd_file_export.cpp
@@ -27,8 +27,8 @@
 
 namespace OpenOrienteering {
 
-OcdFileExport::OcdFileExport(QIODevice* stream, const Map* map, const MapView* view)
-: Exporter { stream, map, view }
+OcdFileExport::OcdFileExport(const QString& path, const Map* map, const MapView* view)
+: Exporter { path, map, view }
 {
 	// nothing else
 }
@@ -37,14 +37,16 @@ OcdFileExport::OcdFileExport(QIODevice* stream, const Map* map, const MapView* v
 OcdFileExport::~OcdFileExport() = default;
 
 
-void OcdFileExport::doExport()
+bool OcdFileExport::exportImplementation()
 {
-	OCAD8FileExport delegate { device(), map, view };
+	OCAD8FileExport delegate { path, map, view };
+	delegate.setDevice(device());
 	delegate.doExport();
 	for (auto&& w : delegate.warnings())
 	{
 		addWarning(w);
 	}
+	return true;
 }
 
 

--- a/src/fileformats/ocd_file_export.h
+++ b/src/fileformats/ocd_file_export.h
@@ -24,10 +24,9 @@
 #define OPENORIENTEERING_OCD_FILE_EXPORT_H
 
 #include <QCoreApplication>
+#include <QString>
 
 #include "fileformats/file_import_export.h"
-
-class QIODevice;
 
 namespace OpenOrienteering {
 
@@ -43,16 +42,17 @@ class OcdFileExport : public Exporter
 	Q_DECLARE_TR_FUNCTIONS(OpenOrienteering::OcdFileExport)
 	
 public:
-	OcdFileExport(QIODevice* stream, const Map* map, const MapView* view);
+	OcdFileExport(const QString& path, const Map* map, const MapView* view);
 	
 	~OcdFileExport() override;
 	
+protected:
 	/**
 	 * Exports an OCD file.
 	 * 
 	 * For now, this simply uses the OCAD8FileExport class.
 	 */
-	void doExport() override;
+	bool exportImplementation() override;
 	
 };
 

--- a/src/fileformats/ocd_file_export.h
+++ b/src/fileformats/ocd_file_export.h
@@ -43,7 +43,7 @@ class OcdFileExport : public Exporter
 	Q_DECLARE_TR_FUNCTIONS(OpenOrienteering::OcdFileExport)
 	
 public:
-	OcdFileExport(QIODevice* stream, Map *map, MapView *view);
+	OcdFileExport(QIODevice* stream, const Map* map, const MapView* view);
 	
 	~OcdFileExport() override;
 	

--- a/src/fileformats/ocd_file_format.cpp
+++ b/src/fileformats/ocd_file_format.cpp
@@ -63,9 +63,9 @@ std::unique_ptr<Importer> OcdFileFormat::makeImporter(QIODevice* stream, Map *ma
 	return std::make_unique<OcdFileImport>(stream, map, view);
 }
 
-std::unique_ptr<Exporter> OcdFileFormat::makeExporter(QIODevice* stream, const Map* map, const MapView* view) const
+std::unique_ptr<Exporter> OcdFileFormat::makeExporter(const QString& path, const Map* map, const MapView* view) const
 {
-	return std::make_unique<OcdFileExport>(stream, map, view);
+	return std::make_unique<OcdFileExport>(path, map, view);
 }
 
 

--- a/src/fileformats/ocd_file_format.cpp
+++ b/src/fileformats/ocd_file_format.cpp
@@ -63,7 +63,7 @@ std::unique_ptr<Importer> OcdFileFormat::makeImporter(QIODevice* stream, Map *ma
 	return std::make_unique<OcdFileImport>(stream, map, view);
 }
 
-std::unique_ptr<Exporter> OcdFileFormat::makeExporter(QIODevice* stream, Map* map, MapView* view) const
+std::unique_ptr<Exporter> OcdFileFormat::makeExporter(QIODevice* stream, const Map* map, const MapView* view) const
 {
 	return std::make_unique<OcdFileExport>(stream, map, view);
 }

--- a/src/fileformats/ocd_file_format.cpp
+++ b/src/fileformats/ocd_file_format.cpp
@@ -58,9 +58,9 @@ FileFormat::ImportSupportAssumption OcdFileFormat::understands(const char* buffe
 }
 
 
-std::unique_ptr<Importer> OcdFileFormat::makeImporter(QIODevice* stream, Map *map, MapView *view) const
+std::unique_ptr<Importer> OcdFileFormat::makeImporter(const QString& path, Map *map, MapView *view) const
 {
-	return std::make_unique<OcdFileImport>(stream, map, view);
+	return std::make_unique<OcdFileImport>(path, map, view);
 }
 
 std::unique_ptr<Exporter> OcdFileFormat::makeExporter(const QString& path, const Map* map, const MapView* view) const

--- a/src/fileformats/ocd_file_format.h
+++ b/src/fileformats/ocd_file_format.h
@@ -59,7 +59,7 @@ public:
 	std::unique_ptr<Importer> makeImporter(QIODevice* stream, Map* map, MapView* view) const override;
 	
 	/// \copydoc FileFormat::createExporter()
-	std::unique_ptr<Exporter> makeExporter(QIODevice* stream, Map* map, MapView* view) const override;
+	std::unique_ptr<Exporter> makeExporter(QIODevice* stream, const Map* map, const MapView* view) const override;
 	
 };
 

--- a/src/fileformats/ocd_file_format.h
+++ b/src/fileformats/ocd_file_format.h
@@ -22,6 +22,8 @@
 
 #include <memory>
 
+#include <QString>
+
 #include "fileformats/file_format.h"
 
 class QIODevice;
@@ -59,7 +61,7 @@ public:
 	std::unique_ptr<Importer> makeImporter(QIODevice* stream, Map* map, MapView* view) const override;
 	
 	/// \copydoc FileFormat::createExporter()
-	std::unique_ptr<Exporter> makeExporter(QIODevice* stream, const Map* map, const MapView* view) const override;
+	std::unique_ptr<Exporter> makeExporter(const QString& path, const Map* map, const MapView* view) const override;
 	
 };
 

--- a/src/fileformats/ocd_file_format.h
+++ b/src/fileformats/ocd_file_format.h
@@ -26,8 +26,6 @@
 
 #include "fileformats/file_format.h"
 
-class QIODevice;
-
 namespace OpenOrienteering {
 
 class Exporter;
@@ -58,7 +56,7 @@ public:
 	
 	
 	/// \copydoc FileFormat::createImporter()
-	std::unique_ptr<Importer> makeImporter(QIODevice* stream, Map* map, MapView* view) const override;
+	std::unique_ptr<Importer> makeImporter(const QString& path, Map* map, MapView* view) const override;
 	
 	/// \copydoc FileFormat::createExporter()
 	std::unique_ptr<Exporter> makeExporter(const QString& path, const Map* map, const MapView* view) const override;

--- a/src/fileformats/ocd_file_import.cpp
+++ b/src/fileformats/ocd_file_import.cpp
@@ -195,13 +195,13 @@ qint64 OcdFileImport::convertLength< quint32 >(quint32 ocd_length) const
 #endif // !NDEBUG
 
 
-void OcdFileImport::importImplementationLegacy(bool load_symbols_only)
+void OcdFileImport::importImplementationLegacy()
 {
 	QBuffer new_stream(&buffer);
 	new_stream.open(QIODevice::ReadOnly);
 	delegate.reset(new OCAD8FileImport(&new_stream, map, view));
 	
-	delegate->import(load_symbols_only);
+	delegate->import();
 	
 	for (auto&& w : delegate->warnings())
 	{
@@ -210,7 +210,7 @@ void OcdFileImport::importImplementationLegacy(bool load_symbols_only)
 }
 
 template< class F >
-void OcdFileImport::importImplementation(bool load_symbols_only)
+void OcdFileImport::importImplementation()
 {
 	const OcdFile<F> file(buffer);
 #ifdef MAPPER_DEVELOPMENT_BUILD
@@ -228,7 +228,7 @@ void OcdFileImport::importImplementation(bool load_symbols_only)
 	importGeoreferencing(file);
 	importColors(file);
 	importSymbols(file);
-	if (!load_symbols_only)
+	if (!loadSymbolsOnly())
 	{
 		importExtras(file);
 		importObjects(file);
@@ -2077,7 +2077,7 @@ void OcdFileImport::setFraming(OcdFileImport::OcdImportedTextSymbol* symbol, con
 	}
 }
 
-void OcdFileImport::import(bool load_symbols_only)
+void OcdFileImport::import()
 {
 	Q_ASSERT(buffer.isEmpty());
 	
@@ -2103,21 +2103,21 @@ void OcdFileImport::import(bool load_symbols_only)
 		//       handled in the version 8 implementation by looking up the
 		//       actual format version in the file header.
 		if (Settings::getInstance().getSetting(Settings::General_NewOcd8Implementation).toBool())
-			importImplementation< Ocd::FormatV8 >(load_symbols_only);
+			importImplementation<Ocd::FormatV8>();
 		else
-			importImplementationLegacy(load_symbols_only);
+			importImplementationLegacy();
 		break;
 	case 9:
 	case 10:
 		using FormatV10Assumption = std::is_same<Ocd::FormatV10, Ocd::FormatV9>;
 		Q_STATIC_ASSERT(FormatV10Assumption::value);
-		importImplementation< Ocd::FormatV9 >(load_symbols_only);
+		importImplementation<Ocd::FormatV9>();
 		break;
 	case 11:
-		importImplementation< Ocd::FormatV11 >(load_symbols_only);
+		importImplementation<Ocd::FormatV11>();
 		break;
 	case 12:
-		importImplementation< Ocd::FormatV12 >(load_symbols_only);
+		importImplementation<Ocd::FormatV12>();
 		break;
 	default:
 		throw FileFormatException(

--- a/src/fileformats/ocd_file_import.cpp
+++ b/src/fileformats/ocd_file_import.cpp
@@ -207,11 +207,6 @@ void OcdFileImport::importImplementationLegacy(bool load_symbols_only)
 	{
 		addWarning(w);
 	}
-	
-	for (auto&& a : delegate->actions())
-	{
-		addAction(a);
-	}
 }
 
 template< class F >
@@ -2138,13 +2133,11 @@ void OcdFileImport::finishImport()
 	{
 		// The current warnings and actions are already propagated.
 		auto warnings_size = ptrdiff_t(delegate->warnings().size());
-		auto actions_size = ptrdiff_t(delegate->actions().size());
 		
 		delegate->finishImport();
 		
 		// Propagate new warnings and actions from the delegate to this importer.
 		std::for_each(begin(delegate->warnings()) + warnings_size, end(delegate->warnings()), [this](const QString& w) { addWarning(w); });
-		std::for_each(begin(delegate->actions()) + actions_size, end(delegate->actions()), [this](const ImportAction& a) { addAction(a); });
 	}
 }
 

--- a/src/fileformats/ocd_file_import.cpp
+++ b/src/fileformats/ocd_file_import.cpp
@@ -2087,9 +2087,9 @@ void OcdFileImport::import(bool load_symbols_only)
 	Q_ASSERT(buffer.isEmpty());
 	
 	buffer.clear();
-	buffer.append(stream->readAll());
+	buffer.append(device()->readAll());
 	if (buffer.isEmpty())
-		throw FileFormatException(::OpenOrienteering::Importer::tr("Could not read file: %1").arg(stream->errorString()));
+		throw FileFormatException(::OpenOrienteering::Importer::tr("Could not read file: %1").arg(device()->errorString()));
 	
 	if (size_t(buffer.size()) < sizeof(Ocd::FormatGeneric::FileHeader))
 		throw FileFormatException(::OpenOrienteering::Importer::tr("Could not read file: %1").arg(tr("Invalid data.")));

--- a/src/fileformats/ocd_file_import.h
+++ b/src/fileformats/ocd_file_import.h
@@ -171,12 +171,12 @@ public:
 	void finishImport() override;
 	
 protected:
-	void import(bool load_symbols_only) override;
+	void import() override;
 	
-	void importImplementationLegacy(bool load_symbols_only);
+	void importImplementationLegacy();
 	
 	template< class F >
-	void importImplementation(bool load_symbols_only);
+	void importImplementation();
 	
 	
 	struct StringHandler

--- a/src/fileformats/ocd_file_import.h
+++ b/src/fileformats/ocd_file_import.h
@@ -33,7 +33,6 @@
 #include <QCoreApplication>
 #include <QHash>
 #include <QLocale>
-#include <QScopedPointer>
 #include <QString>
 #include <QTextCodec>
 
@@ -49,7 +48,6 @@
 #include "fileformats/ocd_types_v8.h" // IWYU pragma: keep
 
 class QChar;
-class QIODevice;
 
 namespace OpenOrienteering {
 
@@ -59,7 +57,6 @@ class Map;
 class MapColor;
 class MapPart;
 class MapView;
-class OCAD8FileImport;
 class Symbol;
 
 
@@ -124,7 +121,7 @@ protected:
 	};
 	
 public:
-	OcdFileImport(QIODevice* stream, Map *map, MapView *view);
+	OcdFileImport(const QString& path, Map *map, MapView *view);
 	
 	~OcdFileImport() override;
 	
@@ -168,12 +165,11 @@ public:
 	
 	void addSymbolWarning(const TextSymbol* symbol, const QString& warning);
 	
-	void finishImport() override;
 	
 protected:
-	void import() override;
+	bool importImplementation() override;
 	
-	void importImplementationLegacy();
+	void importImplementationLegacy(QByteArray& buffer);
 	
 	template< class F >
 	void importImplementation();
@@ -331,8 +327,6 @@ protected:
 	QLocale locale;
 	
 	QByteArray buffer;
-	
-	QScopedPointer< OCAD8FileImport > delegate;
 	
 	/// Character encoding to use for 1-byte (narrow) strings
 	QTextCodec *custom_8bit_encoding;

--- a/src/fileformats/xml_file_format.cpp
+++ b/src/fileformats/xml_file_format.cpp
@@ -413,7 +413,7 @@ void XMLFileExporter::exportTemplates()
 {
 	QDir map_dir;
 	const QDir* map_dir_ptr = nullptr;
-	if (auto file = qobject_cast<const QFileDevice*>(stream))
+	if (auto file = qobject_cast<const QFileDevice*>(device()))
 	{
 		auto filename = file->fileName();
 		if (!filename.isEmpty())
@@ -515,10 +515,10 @@ void XMLFileImporter::import(bool load_symbols_only)
 {
 	if (!xml.readNextStartElement() || xml.name() != literal::map)
 	{
-		if (stream->seek(0))
+		if (device()->seek(0))
 		{
 			char data[4] = {};
-			stream->read(data, 4);
+			device()->read(data, 4);
 			if (qstrncmp(reinterpret_cast<const char*>(data), "OMAP", 4) == 0)
 			{
 				throw FileFormatException(::OpenOrienteering::Importer::tr(

--- a/src/fileformats/xml_file_format.cpp
+++ b/src/fileformats/xml_file_format.cpp
@@ -31,7 +31,6 @@
 #include <QCoreApplication>
 #include <QDir>
 #include <QExplicitlySharedDataPointer>
-#include <QFileDevice>
 #include <QFileInfo>
 #include <QFlags>
 #include <QIODevice>
@@ -121,9 +120,9 @@ FileFormat::ImportSupportAssumption XMLFileFormat::understands(const char* buffe
 }
 
 
-std::unique_ptr<Importer> XMLFileFormat::makeImporter(QIODevice* stream, Map* map, MapView* view) const
+std::unique_ptr<Importer> XMLFileFormat::makeImporter(const QString& path, Map* map, MapView* view) const
 {
-	return std::make_unique<XMLFileImporter>(stream, map, view);
+	return std::make_unique<XMLFileImporter>(path, map, view);
 }
 
 std::unique_ptr<Exporter> XMLFileFormat::makeExporter(const QString& path, const Map* map, const MapView* view) const
@@ -493,9 +492,8 @@ void XMLFileExporter::exportRedo()
 
 // ### XMLFileImporter definition ###
 
-XMLFileImporter::XMLFileImporter(QIODevice* stream, Map *map, MapView *view)
-: Importer(stream, map, view),
-  xml(stream)
+XMLFileImporter::XMLFileImporter(const QString& path, Map *map, MapView *view)
+: Importer(path, map, view)
 {
 	//NOP
 }
@@ -509,8 +507,9 @@ void XMLFileImporter::addWarningUnsupportedElement()
 	);
 }
 
-void XMLFileImporter::import()
+bool XMLFileImporter::importImplementation()
 {
+	xml.setDevice(device());
 	if (!xml.readNextStartElement() || xml.name() != literal::map)
 	{
 		if (device()->seek(0))
@@ -572,6 +571,7 @@ void XMLFileImporter::import()
 			map->setGeoreferencing(georef);
 		}
 	}
+	return true;
 }
 
 void XMLFileImporter::importElements()

--- a/src/fileformats/xml_file_format.cpp
+++ b/src/fileformats/xml_file_format.cpp
@@ -411,26 +411,19 @@ void XMLFileExporter::exportMapParts()
 
 void XMLFileExporter::exportTemplates()
 {
-	// Update the relative paths of templates
+	QDir map_dir;
+	const QDir* map_dir_ptr = nullptr;
 	if (auto file = qobject_cast<const QFileDevice*>(stream))
 	{
 		auto filename = file->fileName();
-		auto map_dir = QFileInfo(filename).absoluteDir();
-		if (!filename.isEmpty() && map_dir.exists())
+		if (!filename.isEmpty())
 		{
-			for (int i = 0; i < map->getNumTemplates(); ++i)
-			{
-				auto temp = map->getTemplate(i);
-				if (temp->getTemplateState() != Template::Invalid)
-					temp->setTemplateRelativePath(map_dir.relativeFilePath(temp->getTemplatePath()));
-			}
-			for (int i = 0; i < map->getNumClosedTemplates(); ++i)
-			{
-				auto temp = map->getClosedTemplate(i);
-				if (temp->getTemplateState() != Template::Invalid)
-					temp->setTemplateRelativePath(map_dir.relativeFilePath(temp->getTemplatePath()));
-			}
+			map_dir = QFileInfo(filename).absoluteDir();
+			map_dir_ptr = &map_dir;
 		}
+		/// \todo Update the relative paths in memory when saving to another directory.
+		///       Otherwise opening templates in the reloaded saved map may
+		///       behave different from the current map in memory.
 	}
 	
 	XmlElementWriter templates_element(xml, literal::templates);
@@ -441,12 +434,12 @@ void XMLFileExporter::exportTemplates()
 	for (int i = 0; i < map->getNumTemplates(); ++i)
 	{
 		writeLineBreak(xml);
-		map->getTemplate(i)->saveTemplateConfiguration(xml, true);
+		map->getTemplate(i)->saveTemplateConfiguration(xml, true, map_dir_ptr);
 	}
 	for (int i = 0; i < map->getNumClosedTemplates(); ++i)
 	{
 		writeLineBreak(xml);
-		map->getClosedTemplate(i)->saveTemplateConfiguration(xml, false);
+		map->getClosedTemplate(i)->saveTemplateConfiguration(xml, false, map_dir_ptr);
 	}
 	
 	{

--- a/src/fileformats/xml_file_format.cpp
+++ b/src/fileformats/xml_file_format.cpp
@@ -126,7 +126,7 @@ std::unique_ptr<Importer> XMLFileFormat::makeImporter(QIODevice* stream, Map* ma
 	return std::make_unique<XMLFileImporter>(stream, map, view);
 }
 
-std::unique_ptr<Exporter> XMLFileFormat::makeExporter(QIODevice* stream, Map* map, MapView* view) const
+std::unique_ptr<Exporter> XMLFileFormat::makeExporter(QIODevice* stream, const Map* map, const MapView* view) const
 {
 	return std::make_unique<XMLFileExporter>(stream, map, view);
 }

--- a/src/fileformats/xml_file_format.cpp
+++ b/src/fileformats/xml_file_format.cpp
@@ -205,7 +205,7 @@ namespace literal
 
 // ### XMLFileExporter definition ###
 
-XMLFileExporter::XMLFileExporter(QIODevice* stream, Map *map, MapView *view)
+XMLFileExporter::XMLFileExporter(QIODevice* stream, const Map* map, const MapView* view)
 : Exporter(stream, map, view),
   xml(stream)
 {

--- a/src/fileformats/xml_file_format.cpp
+++ b/src/fileformats/xml_file_format.cpp
@@ -509,7 +509,7 @@ void XMLFileImporter::addWarningUnsupportedElement()
 	);
 }
 
-void XMLFileImporter::import(bool load_symbols_only)
+void XMLFileImporter::import()
 {
 	if (!xml.readNextStartElement() || xml.name() != literal::map)
 	{
@@ -540,10 +540,10 @@ void XMLFileImporter::import(bool load_symbols_only)
 	QScopedValueRollback<MapCoord::BoundsOffset> rollback { MapCoord::boundsOffset() };
 	MapCoord::boundsOffset().reset(true);
 	georef_offset_adjusted = false;
-	importElements(load_symbols_only);
+	importElements();
 	
 	auto offset = MapCoord::boundsOffset();
-	if (!load_symbols_only && !offset.isZero())
+	if (!loadSymbolsOnly() && !offset.isZero())
 	{
 		addWarning(tr("Some coordinates were out of bounds for printing. Map content was adjusted."));
 		
@@ -574,7 +574,7 @@ void XMLFileImporter::import(bool load_symbols_only)
 	}
 }
 
-void XMLFileImporter::importElements(bool load_symbols_only)
+void XMLFileImporter::importElements()
 {
 	while (xml.readNextStartElement())
 	{
@@ -585,7 +585,7 @@ void XMLFileImporter::importElements(bool load_symbols_only)
 		else if (name == literal::symbols)
 			importSymbols();
 		else if (name == literal::georeferencing)
-			importGeoreferencing(load_symbols_only);
+			importGeoreferencing();
 		else if (name == literal::view)
 			importView();
 		else if (name == literal::barrier)
@@ -601,10 +601,10 @@ void XMLFileImporter::importElements(bool load_symbols_only)
 			}
 			else
 			{
-				importElements(load_symbols_only);
+				importElements();
 			}
 		}
-		else if (load_symbols_only)
+		else if (loadSymbolsOnly())
 			xml.skipCurrentElement();
 		/******************************************************
 		* The remainder is skipped when loading a symbol set! *
@@ -647,14 +647,14 @@ void XMLFileImporter::importMapNotes()
 	}
 }
 
-void XMLFileImporter::importGeoreferencing(bool load_symbols_only)
+void XMLFileImporter::importGeoreferencing()
 {
 	Q_ASSERT(xml.name() == literal::georeferencing);
 	
 	bool check_for_offset = MapCoord::boundsOffset().check_for_offset;
 	
 	Georeferencing georef;
-	georef.load(xml, load_symbols_only);
+	georef.load(xml, loadSymbolsOnly());
 	map->setGeoreferencing(georef);
 	if (!georef.isValid())
 	{

--- a/src/fileformats/xml_file_format.h
+++ b/src/fileformats/xml_file_format.h
@@ -23,6 +23,8 @@
 
 #include <memory>
 
+#include <QString>
+
 #include "fileformats/file_format.h"
 
 class QIODevice;
@@ -56,7 +58,7 @@ public:
 	
 	/** @brief Creates an exporter for XML files.
 	 */
-	std::unique_ptr<Exporter> makeExporter(QIODevice* stream, const Map* map, const MapView* view) const override;
+	std::unique_ptr<Exporter> makeExporter(const QString& path, const Map* map, const MapView* view) const override;
 	
 	
 	/** @brief The minimum XML file format version supported by this implementation.

--- a/src/fileformats/xml_file_format.h
+++ b/src/fileformats/xml_file_format.h
@@ -27,8 +27,6 @@
 
 #include "fileformats/file_format.h"
 
-class QIODevice;
-
 namespace OpenOrienteering {
 
 class Exporter;
@@ -54,7 +52,7 @@ public:
 	
 	/** @brief Creates an importer for XML files.
 	 */
-	std::unique_ptr<Importer> makeImporter(QIODevice* stream, Map* map, MapView* view) const override;
+	std::unique_ptr<Importer> makeImporter(const QString& path, Map* map, MapView* view) const override;
 	
 	/** @brief Creates an exporter for XML files.
 	 */

--- a/src/fileformats/xml_file_format.h
+++ b/src/fileformats/xml_file_format.h
@@ -56,7 +56,7 @@ public:
 	
 	/** @brief Creates an exporter for XML files.
 	 */
-	std::unique_ptr<Exporter> makeExporter(QIODevice* stream, Map* map, MapView* view) const override;
+	std::unique_ptr<Exporter> makeExporter(QIODevice* stream, const Map* map, const MapView* view) const override;
 	
 	
 	/** @brief The minimum XML file format version supported by this implementation.

--- a/src/fileformats/xml_file_format_p.h
+++ b/src/fileformats/xml_file_format_p.h
@@ -36,7 +36,7 @@ class XMLFileExporter : public Exporter
 	Q_DECLARE_TR_FUNCTIONS(OpenOrienteering::XMLFileExporter)
 	
 public:
-	XMLFileExporter(QIODevice* stream, Map *map, MapView *view);
+	XMLFileExporter(QIODevice* stream, const Map* map, const MapView* view);
 	~XMLFileExporter() override {}
 	
 	void doExport() override;

--- a/src/fileformats/xml_file_format_p.h
+++ b/src/fileformats/xml_file_format_p.h
@@ -36,12 +36,12 @@ class XMLFileExporter : public Exporter
 	Q_DECLARE_TR_FUNCTIONS(OpenOrienteering::XMLFileExporter)
 	
 public:
-	XMLFileExporter(QIODevice* stream, const Map* map, const MapView* view);
+	XMLFileExporter(const QString& path, const Map* map, const MapView* view);
 	~XMLFileExporter() override {}
 	
-	void doExport() override;
-	
 protected:
+	bool exportImplementation() override;
+	
 	void exportGeoreferencing();
 	void exportColors();
 	void exportSymbols();

--- a/src/fileformats/xml_file_format_p.h
+++ b/src/fileformats/xml_file_format_p.h
@@ -67,13 +67,13 @@ public:
 	~XMLFileImporter() override {}
 
 protected:
-	void import(bool load_symbols_only) override;
+	void import() override;
 	
-	void importElements(bool load_symbols_only);
+	void importElements();
 	
 	void addWarningUnsupportedElement();
 	void importMapNotes();
-	void importGeoreferencing(bool load_symbols_only);
+	void importGeoreferencing();
 	void importColors();
 	void importSymbols();
 	void importMapParts();

--- a/src/fileformats/xml_file_format_p.h
+++ b/src/fileformats/xml_file_format_p.h
@@ -63,11 +63,11 @@ class XMLFileImporter : public Importer
 	Q_DECLARE_TR_FUNCTIONS(OpenOrienteering::XMLFileImporter)
 	
 public:
-	XMLFileImporter(QIODevice* stream, Map *map, MapView *view);
+	XMLFileImporter(const QString& path, Map *map, MapView *view);
 	~XMLFileImporter() override {}
-
+	
 protected:
-	void import() override;
+	bool importImplementation() override;
 	
 	void importElements();
 	

--- a/src/gdal/ogr_file_format.cpp
+++ b/src/gdal/ogr_file_format.cpp
@@ -399,7 +399,7 @@ ogr::unique_srs OgrFileImport::srsFromMap()
 
 void OgrFileImport::import(bool load_symbols_only)
 {
-	auto file = qobject_cast<QFile*>(stream);
+	auto file = qobject_cast<QFile*>(device());
 	if (!file)
 	{
 		throw FileFormatException("Internal error"); /// \todo Review design and/or message

--- a/src/gdal/ogr_file_format.cpp
+++ b/src/gdal/ogr_file_format.cpp
@@ -300,17 +300,17 @@ OgrFileFormat::OgrFileFormat()
 }
 
 
-std::unique_ptr<Importer> OgrFileFormat::makeImporter(QIODevice* stream, Map* map, MapView* view) const
+std::unique_ptr<Importer> OgrFileFormat::makeImporter(const QString& path, Map* map, MapView* view) const
 {
-	return std::make_unique<OgrFileImport>(stream, map, view);
+	return std::make_unique<OgrFileImport>(path, map, view);
 }
 
 
 
 // ### OgrFileImport ###
 
-OgrFileImport::OgrFileImport(QIODevice* stream, Map* map, MapView* view, UnitType unit_type)
- : Importer(stream, map, view)
+OgrFileImport::OgrFileImport(const QString& path, Map* map, MapView* view, UnitType unit_type)
+ : Importer(path, map, view)
  , manager{ OGR_SM_Create(nullptr) }
  , unit_type{ unit_type }
  , georeferencing_import_enabled{ true }
@@ -397,7 +397,7 @@ ogr::unique_srs OgrFileImport::srsFromMap()
 
 
 
-void OgrFileImport::import()
+bool OgrFileImport::importImplementation()
 {
 	auto file = qobject_cast<QFile*>(device());
 	if (!file)
@@ -517,6 +517,8 @@ void OgrFileImport::import()
 		addWarning(tr("Unable to load %n objects, reason: %1", nullptr, too_few_coordinates)
 		           .arg(tr("Not enough coordinates.")));
 	}
+	
+	return true;
 }
 
 

--- a/src/gdal/ogr_file_format.cpp
+++ b/src/gdal/ogr_file_format.cpp
@@ -397,7 +397,7 @@ ogr::unique_srs OgrFileImport::srsFromMap()
 
 
 
-void OgrFileImport::import(bool load_symbols_only)
+void OgrFileImport::import()
 {
 	auto file = qobject_cast<QFile*>(device());
 	if (!file)
@@ -435,7 +435,7 @@ void OgrFileImport::import(bool load_symbols_only)
 	
 	importStyles(data_source.get());
 
-	if (!load_symbols_only)
+	if (!loadSymbolsOnly())
 	{
 		QScopedValueRollback<MapCoord::BoundsOffset> rollback { MapCoord::boundsOffset() };
 		MapCoord::boundsOffset().reset(true);

--- a/src/gdal/ogr_file_format.h
+++ b/src/gdal/ogr_file_format.h
@@ -22,9 +22,9 @@
 
 #include <memory>
 
-#include "fileformats/file_format.h"
+#include <QString>
 
-class QIODevice;
+#include "fileformats/file_format.h"
 
 namespace OpenOrienteering {
 
@@ -53,7 +53,7 @@ public:
 	/**
 	 * Creates an importer for files supported by OGR.
 	 */
-	std::unique_ptr<Importer> makeImporter(QIODevice* stream, Map* map, MapView* view) const override;
+	std::unique_ptr<Importer> makeImporter(const QString& path, Map* map, MapView* view) const override;
 };
 
 

--- a/src/gdal/ogr_file_format_p.h
+++ b/src/gdal/ogr_file_format_p.h
@@ -136,6 +136,9 @@ public:
 	~OgrFileImport() override;
 	
 	
+	bool supportsQIODevice() const noexcept override;
+	
+	
 	/**
 	 * Enables the import of georeferencing from the geospatial data.
 	 * 
@@ -152,12 +155,12 @@ public:
 	 * transformed to the spatial reference systems represented by georef.
 	 * It will always return false for a local or invalid Georeferencing.
 	 */
-	static bool checkGeoreferencing(QFile& file, const Georeferencing& georef);
+	static bool checkGeoreferencing(const QString& path, const Georeferencing& georef);
 	
 	/**
 	 * Calculates the average geographic coordinates (WGS84) of the file.
 	 */
-	static LatLon calcAverageLatLon(QFile& file);
+	static LatLon calcAverageLatLon(const QString& path);
 	
 	
 protected:

--- a/src/gdal/ogr_file_format_p.h
+++ b/src/gdal/ogr_file_format_p.h
@@ -172,7 +172,7 @@ protected:
 	 */
 	static bool checkGeoreferencing(OGRDataSourceH data_source, const Georeferencing& georef);
 	
-	void import(bool load_symbols_only) override;
+	void import() override;
 	
 	ogr::unique_srs importGeoreferencing(OGRDataSourceH data_source);
 	

--- a/src/gdal/ogr_file_format_p.h
+++ b/src/gdal/ogr_file_format_p.h
@@ -131,7 +131,7 @@ public:
 	/**
 	 * Constructs a new importer.
 	 */
-	OgrFileImport(QIODevice* stream, Map *map, MapView *view, UnitType unit_type = UnitOnGround);
+	OgrFileImport(const QString& path, Map *map, MapView *view, UnitType unit_type = UnitOnGround);
 	
 	~OgrFileImport() override;
 	
@@ -172,7 +172,7 @@ protected:
 	 */
 	static bool checkGeoreferencing(OGRDataSourceH data_source, const Georeferencing& georef);
 	
-	void import() override;
+	bool importImplementation() override;
 	
 	ogr::unique_srs importGeoreferencing(OGRDataSourceH data_source);
 	

--- a/src/gdal/ogr_template.cpp
+++ b/src/gdal/ogr_template.cpp
@@ -70,7 +70,8 @@ namespace {
 		tmp_map.setGeoreferencing(initial_georef);
 		OgrFileImport importer{ &file, &tmp_map, nullptr, OgrFileImport::UnitOnGround};
 		importer.setGeoreferencingImportEnabled(true);
-		importer.doImport(true);
+		importer.setLoadSymbolsOnly(true);
+		importer.doImport();
 		
 		return std::make_unique<Georeferencing>(tmp_map.getGeoreferencing());
 	}
@@ -345,7 +346,7 @@ try
 	
 	const auto pp0 = new_template_map->getGeoreferencing().getProjectedRefPoint();
 	importer.setGeoreferencingImportEnabled(false);
-	importer.doImport(false, template_path);
+	importer.doImport(template_path);
 	
 	// MapCoord bounds handling may have moved the paper position of the
 	// template data during import. The template position might need to be

--- a/src/gdal/ogr_template.cpp
+++ b/src/gdal/ogr_template.cpp
@@ -27,7 +27,6 @@
 #include <QtGlobal>
 #include <QByteArray>
 #include <QDialog>
-#include <QFile>
 #include <QLatin1String>
 #include <QPoint>
 #include <QPointF>
@@ -64,11 +63,11 @@ namespace {
 	}
 	
 	
-	std::unique_ptr<Georeferencing> getDataGeoreferencing(QFile& file, const Georeferencing& initial_georef)
+	std::unique_ptr<Georeferencing> getDataGeoreferencing(const QString& path, const Georeferencing& initial_georef)
 	{
 		Map tmp_map;
 		tmp_map.setGeoreferencing(initial_georef);
-		OgrFileImport importer{ file.fileName(), &tmp_map, nullptr, OgrFileImport::UnitOnGround};
+		OgrFileImport importer{ path, &tmp_map, nullptr, OgrFileImport::UnitOnGround};
 		importer.setGeoreferencingImportEnabled(true);
 		importer.setLoadSymbolsOnly(true);
 		if (!importer.doImport())
@@ -135,16 +134,16 @@ const char* OgrTemplate::getTemplateType() const
 
 
 
-std::unique_ptr<Georeferencing> OgrTemplate::makeOrthographicGeoreferencing(QFile& file)
+std::unique_ptr<Georeferencing> OgrTemplate::makeOrthographicGeoreferencing(const QString& path)
 {
 	// Is the template's SRS orthographic, or can it be converted?
 	/// \todo Use the template's datum etc. instead of WGS84?
 	auto georef = std::make_unique<Georeferencing>();
 	georef->setScaleDenominator(int(map->getGeoreferencing().getScaleDenominator()));
 	georef->setProjectedCRS(QString{}, QStringLiteral("+proj=ortho +datum=WGS84 +ellps=WGS84 +units=m +no_defs"));
-	if (OgrFileImport::checkGeoreferencing(file, *georef))
+	if (OgrFileImport::checkGeoreferencing(path, *georef))
 	{
-		auto center = OgrFileImport::calcAverageLatLon(file);
+		auto center = OgrFileImport::calcAverageLatLon(path);
 		georef->setProjectedCRS(QString{},
 		                             QString::fromLatin1("+proj=ortho +datum=WGS84 +ellps=WGS84 +units=m +lat_0=%1 +lon_0=%2 +no_defs")
 		                             .arg(center.latitude()).arg(center.longitude()));
@@ -175,20 +174,11 @@ try
 	};
 	template_track_compatibility = ends_with_any_of(template_path, TemplateTrack::supportedExtensions());
 	
-	QFile file{ template_path };
-	
 	auto data_georef = std::unique_ptr<Georeferencing>();
 	auto& initial_georef = map->getGeoreferencing();
 	if (!initial_georef.isValid() || initial_georef.isLocal())
 	{
-		// The map doesn't have a proper georeferencing.
-		// Is there a good SRS in the data?
-		try {
-			data_georef = getDataGeoreferencing(file, initial_georef);
-		}
-		catch (FileFormatException&)
-		{}
-		
+		data_georef = getDataGeoreferencing(template_path, initial_georef);
 		if (data_georef && data_georef->isValid() && !data_georef->isLocal())
 		{
 			// If yes, does the user want to use this for the map?
@@ -211,7 +201,7 @@ try
 	{
 		// The map has got a proper georeferencing.
 		// Can the template's SRS be converted to the map's CRS?
-		if (OgrFileImport::checkGeoreferencing(file, map->getGeoreferencing()))
+		if (OgrFileImport::checkGeoreferencing(template_path, map->getGeoreferencing()))
 		{
 			is_georeferenced = true;
 			return true;
@@ -225,7 +215,7 @@ try
 	}
 	if (!data_georef)
 	{
-		data_georef = makeOrthographicGeoreferencing(file);
+		data_georef = makeOrthographicGeoreferencing(template_path);
 	}
 	if (data_georef)
 	{
@@ -259,10 +249,9 @@ catch (FileFormatException& e)
 bool OgrTemplate::loadTemplateFileImpl(bool configuring)
 try
 {
-	QFile file{ template_path };
 	auto new_template_map = std::make_unique<Map>();
 	auto unit_type = use_real_coords ? OgrFileImport::UnitOnGround : OgrFileImport::UnitOnPaper;
-	OgrFileImport importer{ template_path, new_template_map.get(), nullptr, unit_type };
+	OgrFileImport importer{template_path, new_template_map.get(), nullptr, unit_type };
 	
 	const auto& map_georef = map->getGeoreferencing();
 	
@@ -319,7 +308,7 @@ try
 					else
 					{
 						// If the TemplateTrack approach failed, use local approach.
-						explicit_georef = makeOrthographicGeoreferencing(file);
+						explicit_georef = makeOrthographicGeoreferencing(template_path);
 						projected_crs_spec = explicit_georef->getProjectedCRSSpec();
 					}
 				}

--- a/src/gdal/ogr_template.h
+++ b/src/gdal/ogr_template.h
@@ -29,7 +29,6 @@
 #include "templates/template_map.h"
 
 class QByteArray;
-class QFile;
 class QWidget;
 class QXmlStreamReader;
 class QXmlStreamWriter;
@@ -58,7 +57,7 @@ public:
 	
 	const char* getTemplateType() const override;
 	
-	std::unique_ptr<Georeferencing> makeOrthographicGeoreferencing(QFile& file);
+	std::unique_ptr<Georeferencing> makeOrthographicGeoreferencing(const QString& path);
 	
 	bool preLoadConfiguration(QWidget* dialog_parent) override;
 	

--- a/src/gui/main_window.cpp
+++ b/src/gui/main_window.cpp
@@ -51,6 +51,7 @@
 #include "core/symbols/symbol.h"
 #include "fileformats/file_format.h"
 #include "fileformats/file_format_registry.h"
+#include "fileformats/file_import_export.h"
 #include "gui/about_dialog.h"
 #include "gui/autosave_dialog.h"
 #include "gui/file_dialog.h"
@@ -219,13 +220,13 @@ void MainWindow::setHomeScreenDisabled(bool disabled)
 void MainWindow::setController(MainWindowController* new_controller)
 {
 	setController(new_controller, false);
-	setCurrentPath({});
+	setCurrentFile({}, nullptr);
 }
 
-void MainWindow::setController(MainWindowController* new_controller, const QString& path)
+void MainWindow::setController(MainWindowController* new_controller, const QString& path, const FileFormat* format)
 {
 	setController(new_controller, true);
-	setCurrentPath(path);
+	setCurrentFile(path, format);
 }
 
 void MainWindow::setController(MainWindowController* new_controller, bool has_file)
@@ -440,7 +441,7 @@ void MainWindow::createHelpMenu()
 	}
 }
 
-void MainWindow::setCurrentPath(const QString& path)
+void MainWindow::setCurrentFile(const QString& path, const FileFormat* format)
 {
 	Q_ASSERT(has_opened_file || path.isEmpty());
 	
@@ -448,13 +449,19 @@ void MainWindow::setCurrentPath(const QString& path)
 	{
 		QString window_file_path;
 		current_path.clear();
+		current_format = nullptr;
 		if (has_opened_file)
 		{
 			window_file_path = QFileInfo(path).canonicalFilePath();
 			if (window_file_path.isEmpty())
+			{
 				window_file_path = tr("Unsaved file");
+			}
 			else
+			{
 				current_path = window_file_path;
+				current_format = format;
+			}
 		}
 		setWindowFilePath(window_file_path);
 	}
@@ -730,9 +737,20 @@ void MainWindow::showNewMapWizard()
 	{
 		new_map->setScaleDenominator(newMapDialog.getSelectedScale());
 	}
-	else
+	else if (auto importer = FileFormats.makeImporter(symbol_set_path, *new_map, nullptr))
 	{
-		new_map->loadFrom(symbol_set_path, this, &tmp_view, true);
+		importer->setLoadSymbolsOnly(true);
+		if (!importer->doImport())
+		{
+			QMessageBox::warning(this, tr("Error"),
+			                     tr("Cannot open file:\n%1\n\n%2").
+			                     arg(symbol_set_path, importer->warnings().back()));
+			delete new_map;
+			return;
+		}
+		if (!importer->warnings().empty())
+			showMessageBox(this, tr("Warning"), tr("The symbol set import generated warnings."), importer->warnings());
+		
 		if (new_map->getScaleDenominator() != newMapDialog.getSelectedScale())
 		{
 			if (QMessageBox::question(this, tr("Warning"), tr("The selected map scale is 1:%1, but the chosen symbol set has a nominal scale of 1:%2.\n\nDo you want to scale the symbols to the selected scale?").arg(newMapDialog.getSelectedScale()).arg(new_map->getScaleDenominator()),  QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes)
@@ -755,6 +773,10 @@ void MainWindow::showNewMapWizard()
 			}
 		}
 	}
+	else
+	{
+		;  /// \todo error message, cleanup
+	}
 	
 	auto map_view = new MapView { new_map };
 	map_view->setGridVisible(tmp_view.isGridVisible());
@@ -764,7 +786,7 @@ void MainWindow::showNewMapWizard()
 	
 	MainWindow* new_window = hasOpenedFile() ? new MainWindow() : this;
 	new_window->setWindowFilePath(tr("Unsaved file"));
-	new_window->setController(new MapEditorController(MapEditorController::MapEditor, new_map, map_view), QString());
+	new_window->setController(new MapEditorController(MapEditorController::MapEditor, new_map, map_view), QString(), nullptr);
 	
 	new_window->show();
 	new_window->raise();
@@ -774,12 +796,21 @@ void MainWindow::showNewMapWizard()
 
 void MainWindow::showOpenDialog()
 {
-	QString path = getOpenFileName(this, tr("Open file"), FileFormat::AllFiles);
-	if (!path.isEmpty())
-		openPath(path);
+	if (auto selected = getOpenFileName(this, tr("Open file"), FileFormat::AllFiles))
+	{
+		openPath(selected.filePath(), selected.fileFormat());
+	}
 }
 
 bool MainWindow::openPath(const QString &path)
+{
+	auto format = FileFormats.findFormatForFilename(path);
+	if (!format)
+		format = FileFormats.findFormatForData(path, FileFormat::AllFiles);
+	return openPath(path, format);
+}
+
+bool MainWindow::openPath(const QString& path, const FileFormat* format)
 {
 	// Empty path does nothing. This also helps with the single instance application code.
 	if (path.isEmpty())
@@ -797,6 +828,11 @@ bool MainWindow::openPath(const QString &path)
 		return true;
 	}
 #endif
+	
+	if (!format)
+		QMessageBox::warning(this, tr("Error"),
+		                     tr("Cannot open file:\n%1\n\n%2").
+		                     arg(path, tr("Invalid file type.")));
 	
 	// Check a blocker that prevents immediate re-opening of crashing files.
 	// Needed for stopping auto-loading a crashing file on startup.
@@ -828,6 +864,7 @@ bool MainWindow::openPath(const QString &path)
 	}
 	
 	QString new_actual_path = path;
+	const FileFormat* new_actual_format = format;
 	QString autosave_path = Autosave::autosavePath(path);
 	bool new_autosave_conflict = QFileInfo::exists(autosave_path);
 	if (new_autosave_conflict)
@@ -837,14 +874,16 @@ bool MainWindow::openPath(const QString &path)
 		AutosaveDialog* autosave_dialog = new AutosaveDialog(path, autosave_path, autosave_path, this);
 		int result = autosave_dialog->exec();
 		new_actual_path = (result == QDialog::Accepted) ? autosave_dialog->selectedPath() : QString();
+		new_actual_format = (new_actual_path == path) ? format : FileFormats.findFormat(FileFormats.defaultFormat());
 		delete autosave_dialog;
 #else
 		// Assuming large screen, dialog will be shown while the autosaved file is open
 		new_actual_path = autosave_path;
+		new_actual_format = FileFormats.findFormat(FileFormats.defaultFormat());
 #endif
 	}
 	
-	if (new_actual_path.isEmpty() || !new_controller->loadFrom(new_actual_path, this))
+	if (new_actual_path.isEmpty() || !new_controller->loadFrom(new_actual_path, *format, this))
 	{
 		delete new_controller;
 		settings.remove(reopen_blocker);
@@ -857,7 +896,7 @@ bool MainWindow::openPath(const QString &path)
 		open_window = new MainWindow();
 #endif
 	
-	open_window->setController(new_controller, path);
+	open_window->setController(new_controller, path, format);
 	open_window->actual_path = new_actual_path;
 	open_window->setHasAutosaveConflict(new_autosave_conflict);
 	open_window->setHasUnsavedChanges(false);
@@ -908,9 +947,10 @@ void MainWindow::switchActualPath(const QString& path)
 	{
 		const QString& current_path = currentPath();
 		MainWindowController* const new_controller = MainWindowController::controllerForFile(current_path);
-		if (new_controller && new_controller->loadFrom(path, this))
+		auto format = (path == current_path) ? current_format : FileFormats.findFormat(FileFormats.defaultFormat());
+		if (new_controller && new_controller->loadFrom(path, *format, this))
 		{
-			setController(new_controller, current_path);
+			setController(new_controller, current_path, format);
 			actual_path = path;
 			setHasUnsavedChanges(false);
 		}
@@ -1015,7 +1055,7 @@ Autosave::AutosaveResult MainWindow::autosave()
 
 bool MainWindow::save()
 {
-	return saveTo(currentPath());
+	return saveTo(currentPath(), currentFormat());
 }
 
 bool MainWindow::saveTo(const QString &path, const FileFormat* format)
@@ -1056,7 +1096,7 @@ bool MainWindow::saveTo(const QString &path, const FileFormat* format)
 	
 	if (path != currentPath())
 	{
-		setCurrentPath(path);
+		setCurrentFile(path, format);
 		removeAutosaveFile();
 	}
 	
@@ -1065,7 +1105,8 @@ bool MainWindow::saveTo(const QString &path, const FileFormat* format)
 	return true;
 }
 
-QString MainWindow::getOpenFileName(QWidget* parent, const QString& title, FileFormat::FileTypes types)
+// static
+MainWindow::FileInfo MainWindow::getOpenFileName(QWidget* parent, const QString& title, FileFormat::FileTypes types)
 {
 	// Get the saved directory to start in, defaulting to the user's home directory.
 	QSettings settings;
@@ -1074,7 +1115,7 @@ QString MainWindow::getOpenFileName(QWidget* parent, const QString& title, FileF
 	// Build the list of supported file filters based on the file format registry
 	QString filters, extensions;
 	
-	if (types.testFlag(FileFormat::MapFile))
+	if (types.testFlag(FileFormat::MapFile) || types.testFlag(FileFormat::OgrFile))
 	{
 		for (auto format : FileFormats.formats())
 		{
@@ -1099,9 +1140,20 @@ QString MainWindow::getOpenFileName(QWidget* parent, const QString& title, FileF
 	
 	filters += tr("All files") + QLatin1String(" (*.*)");
 	
-	QString path = FileDialog::getOpenFileName(parent, title, open_directory, filters);
-	QFileInfo info(path);
-	return info.canonicalFilePath();
+	QString filter; // will be set to the selected filter by QFileDialog
+	QString path = FileDialog::getOpenFileName(parent, title, open_directory, filters, &filter);
+	
+	const FileFormat* format = nullptr;
+	if (!path.isEmpty())
+	{
+		path = QFileInfo(path).canonicalFilePath();
+		format = FileFormats.findFormatByFilter(filter);
+		if (!format)
+			format = FileFormats.findFormatForFilename(path);
+		if (!format)
+			format = FileFormats.findFormatForData(path, types);
+	}
+	return { path, format };
 }
 
 

--- a/src/gui/main_window.cpp
+++ b/src/gui/main_window.cpp
@@ -1046,7 +1046,7 @@ bool MainWindow::saveTo(const QString &path, const FileFormat* format)
 			return showSaveAsDialog();
 	}
 	
-	if (!controller->saveTo(path, format))
+	if (!controller->saveTo(path, *format))
 		return false;
 	
 	setMostRecentlyUsedFile(path);

--- a/src/gui/main_window.cpp
+++ b/src/gui/main_window.cpp
@@ -1104,6 +1104,27 @@ QString MainWindow::getOpenFileName(QWidget* parent, const QString& title, FileF
 	return info.canonicalFilePath();
 }
 
+
+
+// static
+void MainWindow::showMessageBox(QWidget* parent, const QString& title, const QString& headline, const std::vector<QString>& messages)
+{
+	QString document;
+	if (!headline.isEmpty())
+		document += QLatin1String("<p><b>") + headline + QLatin1String("</b></p>");
+	for (const auto& message : messages)
+		document += Qt::convertFromPlainText(message, Qt::WhiteSpaceNormal);
+	
+	TextBrowserDialog dialog(document, parent);
+	dialog.setWindowTitle(title);
+	dialog.setWindowModality(Qt::WindowModal);
+	dialog.exec();
+	// Let Android update the screen.
+	qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
+}
+
+
+
 bool MainWindow::showSaveAsDialog()
 {
 	if (!controller)

--- a/src/gui/main_window.cpp
+++ b/src/gui/main_window.cpp
@@ -844,7 +844,7 @@ bool MainWindow::openPath(const QString &path)
 #endif
 	}
 	
-	if (new_actual_path.isEmpty() || !new_controller->load(new_actual_path, this))
+	if (new_actual_path.isEmpty() || !new_controller->loadFrom(new_actual_path, this))
 	{
 		delete new_controller;
 		settings.remove(reopen_blocker);
@@ -908,7 +908,7 @@ void MainWindow::switchActualPath(const QString& path)
 	{
 		const QString& current_path = currentPath();
 		MainWindowController* const new_controller = MainWindowController::controllerForFile(current_path);
-		if (new_controller && new_controller->load(path, this))
+		if (new_controller && new_controller->loadFrom(path, this))
 		{
 			setController(new_controller, current_path);
 			actual_path = path;

--- a/src/gui/main_window.cpp
+++ b/src/gui/main_window.cpp
@@ -804,7 +804,7 @@ void MainWindow::showOpenDialog()
 
 bool MainWindow::openPath(const QString &path)
 {
-	auto format = FileFormats.findFormatForFilename(path);
+	auto format = FileFormats.findFormatForFilename(path, &FileFormat::supportsImport);
 	if (!format)
 		format = FileFormats.findFormatForData(path, FileFormat::AllFiles);
 	return openPath(path, format);
@@ -1067,7 +1067,7 @@ bool MainWindow::saveTo(const QString &path, const FileFormat* format)
 		return showSaveAsDialog();
 	
 	if (!format)
-		format = FileFormats.findFormatForFilename(path);
+		format = FileFormats.findFormatForFilename(path, &FileFormat::supportsExport);
 	
 	if (!format)
 	{
@@ -1147,9 +1147,9 @@ MainWindow::FileInfo MainWindow::getOpenFileName(QWidget* parent, const QString&
 	if (!path.isEmpty())
 	{
 		path = QFileInfo(path).canonicalFilePath();
-		format = FileFormats.findFormatByFilter(filter);
+		format = FileFormats.findFormatByFilter(filter, &FileFormat::supportsImport);
 		if (!format)
-			format = FileFormats.findFormatForFilename(path);
+			format = FileFormats.findFormatForFilename(path, &FileFormat::supportsImport);
 		if (!format)
 			format = FileFormats.findFormatForData(path, types);
 	}
@@ -1223,7 +1223,7 @@ bool MainWindow::showSaveAsDialog()
 	if (path.isEmpty())
 		return false;
 	
-	const FileFormat *format = FileFormats.findFormatByFilter(filter);
+	const FileFormat *format = FileFormats.findFormatByFilter(filter, &FileFormat::supportsExport);
 	if (!format)
 	{
 		QMessageBox::information(this, tr("Error"), 
@@ -1247,7 +1247,7 @@ bool MainWindow::showSaveAsDialog()
 	// Ensure that the file name matches the format.
 	Q_ASSERT(format->fileExtensions().contains(QFileInfo(path).suffix()));
 	// Fails when using different formats for import and export:
-	//	Q_ASSERT(FileFormats.findFormatForFilename(path) == format);
+	//	Q_ASSERT(FileFormats.findFormatForFilename(path, ***) == format);
 	
 	return saveTo(path, format);
 }

--- a/src/gui/main_window.h
+++ b/src/gui/main_window.h
@@ -205,6 +205,13 @@ public:
 	 */
 	static QString getOpenFileName(QWidget* parent, const QString& title, FileFormat::FileTypes types);
 	
+	
+	/**
+	 * Shows a message box for a list of unformatted messages.
+	 */
+	static void showMessageBox(QWidget* parent, const QString& title, const QString& headline, const std::vector<QString>& messages);
+	
+	
 	/**
 	 * Sets the MainWindow's effective central widget.
 	 * 

--- a/src/gui/main_window.h
+++ b/src/gui/main_window.h
@@ -57,6 +57,22 @@ class MainWindow : public QMainWindow, private Autosave
 {
 Q_OBJECT
 public:
+	struct FileInfo
+	{
+		// To be used with aggregate initialization
+		QString file_path;
+		const FileFormat* file_format;
+		
+		// cf. QFileInfo::filePath
+		QString filePath() const { return file_path; }
+		
+		const FileFormat* fileFormat() const noexcept { return file_format; }
+		
+		operator bool() const noexcept { return !file_path.isEmpty(); }
+		
+	};
+	
+		
 	/**
 	 * Creates a new main window.
 	 */
@@ -113,7 +129,7 @@ public:
 	 * The new controller edits the file with the given path.
 	 * The path may be empty for a new (unnamed) file.
 	 */
-	void setController(MainWindowController* new_controller, const QString& path);
+	void setController(MainWindowController* new_controller, const QString& path, const FileFormat* format);
 	
 private:
 	void setController(MainWindowController* new_controller, bool has_file);
@@ -123,10 +139,21 @@ public:
 	MainWindowController* getController() const;
 	
 	
-	/** Returns the canonical path of the currently open file or 
-	 *  an empty string if no file is open.
+	/**
+	 * Returns the canonical path of the currently open file.
+	 * 
+	 * It no file is open, returns an empty string.
 	 */
-	const QString& currentPath() const;
+	const QString& currentPath() const { return current_path; }
+	
+	/**
+	 * Returns the file format of the currently open file.
+	 * 
+	 * It no file is open or the format is unknown, returns nullptr.
+	 */
+	const FileFormat* currentFormat() const { return current_format; }
+	
+	
 	
 	/** Registers the given path as most recently used file.
 	 * 
@@ -203,7 +230,7 @@ public:
 	/** Shows the open file dialog for the given file type(s) and returns the chosen file
 	 *  or an empty string if the dialog is aborted.
 	 */
-	static QString getOpenFileName(QWidget* parent, const QString& title, FileFormat::FileTypes types);
+	static MainWindow::FileInfo getOpenFileName(QWidget* parent, const QString& title, FileFormat::FileTypes types);
 	
 	
 	/**
@@ -291,6 +318,8 @@ public slots:
 	 * @return true if loading was succesful, false otherwise
 	 */
 	bool openPath(const QString &path);
+	
+	bool openPath(const QString &path, const FileFormat* format);
 	
 	/**
 	 * Open the file specified in the sending action's data.
@@ -411,7 +440,7 @@ protected:
 	 * If the controller was not set as having an opened file,
 	 * the path must be empty.
 	 */
-	void setCurrentPath(const QString& path);
+	void setCurrentFile(const QString& path, const FileFormat* format);
 	
 	/**
 	 * Notifies the windows of autosave conflicts.
@@ -483,6 +512,8 @@ private:
 	
 	/// Canonical path to the currently open file or an empty string if the file was not saved yet ("untitled")
 	QString current_path;
+	/// The current file's format, as determined during opening the file.
+	const FileFormat* current_format;
 	/// The actual path loaded by the editor. @see switchActualPath()
 	QString actual_path;
 	/// Does the main window display a file? If yes, new controllers will be opened in new main windows instead of replacing the active controller of this one
@@ -516,11 +547,7 @@ MainWindowController* MainWindow::getController() const
 	return controller;
 }
 
-inline
-const QString& MainWindow::currentPath() const
-{
-	return current_path;
-}
+
 
 inline
 bool MainWindow::hasOpenedFile() const

--- a/src/gui/main_window_controller.cpp
+++ b/src/gui/main_window_controller.cpp
@@ -42,7 +42,7 @@ bool MainWindowController::saveTo(const QString& /*path*/, const FileFormat& /*f
 
 bool MainWindowController::exportTo(const QString& path)
 {
-	auto format = FileFormats.findFormatForFilename(path);
+	auto format = FileFormats.findFormatForFilename(path, &FileFormat::supportsExport);
 	if (!format)
 		format = FileFormats.findFormat(FileFormats.defaultFormat());
 	if (!format)
@@ -100,8 +100,7 @@ bool MainWindowController::keyReleaseEventFilter(QKeyEvent* event)
 
 MainWindowController* MainWindowController::controllerForFile(const QString& filename)
 {
-	const FileFormat* format = FileFormats.findFormatForFilename(filename);
-	if (format && format->supportsImport()) 
+	if (FileFormats.findFormatForFilename(filename, &FileFormat::supportsImport))
 		return new MapEditorController(MapEditorController::MapEditor);
 	
 	return nullptr;

--- a/src/gui/main_window_controller.cpp
+++ b/src/gui/main_window_controller.cpp
@@ -71,7 +71,7 @@ bool MainWindowController::exportTo(const QString& /*path*/, const FileFormat& /
 	return false;
 }
 
-bool MainWindowController::loadFrom(const QString& /*path*/, QWidget* /*dialog_parent*/)
+bool MainWindowController::loadFrom(const QString& /*path*/, const FileFormat& /*format*/, QWidget* /*dialog_parent*/)
 {
 	return false;
 }

--- a/src/gui/main_window_controller.cpp
+++ b/src/gui/main_window_controller.cpp
@@ -71,10 +71,8 @@ bool MainWindowController::exportTo(const QString& /*path*/, const FileFormat& /
 	return false;
 }
 
-bool MainWindowController::load(const QString& path, QWidget* dialog_parent)
+bool MainWindowController::loadFrom(const QString& /*path*/, QWidget* /*dialog_parent*/)
 {
-	Q_UNUSED(path);
-	Q_UNUSED(dialog_parent);
 	return false;
 }
 

--- a/src/gui/main_window_controller.h
+++ b/src/gui/main_window_controller.h
@@ -47,6 +47,7 @@ public:
 	
 	/** Save to a file.
 	 *  @param path the path to save to
+	 *  @param format the file format
 	 *  @return true if saving was sucessful, false on errors
 	 */
 	virtual bool saveTo(const QString& path, const FileFormat& format);
@@ -72,7 +73,7 @@ public:
 	 *      If nullptr, implementations should use MainWindowController::window.
 	 *  @return true if loading was sucessful, false on errors
 	 */
-	virtual bool loadFrom(const QString& path, QWidget* dialog_parent = nullptr);
+	virtual bool loadFrom(const QString& path, const FileFormat& format, QWidget* dialog_parent = nullptr);
 	
 	/** Attach the controller to a main window. 
 	 *  The controller should create its user interface here.

--- a/src/gui/main_window_controller.h
+++ b/src/gui/main_window_controller.h
@@ -72,7 +72,7 @@ public:
 	 *      If nullptr, implementations should use MainWindowController::window.
 	 *  @return true if loading was sucessful, false on errors
 	 */
-	virtual bool load(const QString& path, QWidget* dialog_parent = nullptr);
+	virtual bool loadFrom(const QString& path, QWidget* dialog_parent = nullptr);
 	
 	/** Attach the controller to a main window. 
 	 *  The controller should create its user interface here.

--- a/src/gui/main_window_controller.h
+++ b/src/gui/main_window_controller.h
@@ -49,15 +49,22 @@ public:
 	 *  @param path the path to save to
 	 *  @return true if saving was sucessful, false on errors
 	 */
-	virtual bool saveTo(const QString& path, const FileFormat* format = nullptr);
+	virtual bool saveTo(const QString& path, const FileFormat& format);
+	
+	/** Export to a file, but don't change modified state
+	 *  with regard to the original file.
+	 *  @param path the path to export to
+	 *  @return true if saving was sucessful, false on errors
+	 */
+	bool exportTo(const QString& path);
 
 	/** Export to a file, but don't change modified state
 	 *  with regard to the original file.
 	 *  @param path the path to export to
-	 *  @param format the file format (automatically determined if nullptr)
+	 *  @param format the file format
 	 *  @return true if saving was sucessful, false on errors
 	 */
-	virtual bool exportTo(const QString& path, const FileFormat* format = nullptr);
+	virtual bool exportTo(const QString& path, const FileFormat& format);
 
 	/** Load from a file.
 	 *  @param path the path to load from

--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -542,7 +542,7 @@ void MapEditorController::deletePopupWidget(QWidget* child_widget)
 	}
 }
 
-bool MapEditorController::saveTo(const QString& path, const FileFormat* format)
+bool MapEditorController::saveTo(const QString& path, const FileFormat& format)
 {
 	if (map)
 	{
@@ -564,7 +564,7 @@ bool MapEditorController::saveTo(const QString& path, const FileFormat* format)
 		return false;
 }
 
-bool MapEditorController::exportTo(const QString& path, const FileFormat* format)
+bool MapEditorController::exportTo(const QString& path, const FileFormat& format)
 {
 	if (map && !editing_in_progress)
 	{

--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -1686,7 +1686,7 @@ void MapEditorController::copy()
 	
 	// Save map to memory
 	QBuffer buffer;
-	if (!copy_map.exportToIODevice(&buffer))
+	if (!copy_map.exportToIODevice(buffer))
 	{
 		QMessageBox::warning(nullptr, tr("Error"), tr("An internal error occurred, sorry!"));
 		return;
@@ -1719,7 +1719,7 @@ void MapEditorController::paste()
 	
 	// Create map from buffer
 	Map paste_map;
-	if (!paste_map.importFromIODevice(&buffer))
+	if (!paste_map.importFromIODevice(buffer))
 	{
 		QMessageBox::warning(nullptr, tr("Error"), tr("An internal error occurred, sorry!"));
 		return;

--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -604,7 +604,7 @@ bool MapEditorController::exportTo(const QString& path, const FileFormat& format
 }
 
 
-bool MapEditorController::load(const QString& path, QWidget* dialog_parent)
+bool MapEditorController::loadFrom(const QString& path, QWidget* dialog_parent)
 {
 	if (!dialog_parent)
 		dialog_parent = window;

--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -3942,7 +3942,7 @@ void MapEditorController::importClicked()
 	settings.setValue(QString::fromLatin1("importFileDirectory"), QFileInfo(filename).canonicalPath());
 	
 	bool success = false;
-	auto map_format = FileFormats.findFormatForFilename(filename);
+	auto map_format = FileFormats.findFormatForFilename(filename, &FileFormat::supportsImport);
 	if (map_format)
 	{
 		// Map format recognized by filename extension

--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -551,9 +551,13 @@ bool MapEditorController::saveTo(const QString& path, const FileFormat* format)
 			QMessageBox::warning(window, tr("Editing in progress"), tr("The map is currently being edited. Please finish the edit operation before saving."));
 			return false;
 		}
-		bool success = map->saveTo(path, format, main_view);
+		bool success = map->exportTo(path, format, main_view);
 		if (success)
+		{
+			map->setHasUnsavedChanges(false);
+			map->undoManager().setClean();
 			window->showStatusBarMessage(tr("Map saved"), 1000);
+		}
 		return success;
 	}
 	else

--- a/src/gui/map/map_editor.h
+++ b/src/gui/map/map_editor.h
@@ -233,7 +233,7 @@ public:
 	/** Override from MainWindowController */
 	bool exportTo(const QString& path, const FileFormat& format) override;
 	/** Override from MainWindowController */
-	bool load(const QString& path, QWidget* dialog_parent = nullptr) override;
+	bool loadFrom(const QString& path, QWidget* dialog_parent = nullptr) override;
 	
 	/** Override from MainWindowController */
 	void attach(MainWindow* window) override;

--- a/src/gui/map/map_editor.h
+++ b/src/gui/map/map_editor.h
@@ -233,7 +233,7 @@ public:
 	/** Override from MainWindowController */
 	bool exportTo(const QString& path, const FileFormat& format) override;
 	/** Override from MainWindowController */
-	bool loadFrom(const QString& path, QWidget* dialog_parent = nullptr) override;
+	bool loadFrom(const QString& path, const FileFormat& format, QWidget* dialog_parent = nullptr) override;
 	
 	/** Override from MainWindowController */
 	void attach(MainWindow* window) override;

--- a/src/gui/map/map_editor.h
+++ b/src/gui/map/map_editor.h
@@ -229,9 +229,9 @@ public:
 	QAction* getAction(const char* id);
 	
 	/** Override from MainWindowController */
-	bool saveTo(const QString& path, const FileFormat* format) override;
+	bool saveTo(const QString& path, const FileFormat& format) override;
 	/** Override from MainWindowController */
-	bool exportTo(const QString& path, const FileFormat* format = nullptr) override;
+	bool exportTo(const QString& path, const FileFormat& format) override;
 	/** Override from MainWindowController */
 	bool load(const QString& path, QWidget* dialog_parent = nullptr) override;
 	

--- a/src/gui/widgets/home_screen_widget.cpp
+++ b/src/gui/widgets/home_screen_widget.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2017 Kai Pastor
+ *    Copyright 2012-2018 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -514,7 +514,7 @@ QWidget* HomeScreenWidgetMobile::makeFileListWidget(HomeScreenController* contro
 		QDirIterator it(location.path(), QDir::Files | QDir::NoDotAndDotDot, QDirIterator::Subdirectories);
 		while (it.hasNext()) {
 			it.next();
-			auto format = FileFormats.findFormatForFilename(it.filePath());
+			auto format = FileFormats.findFormatForFilename(it.filePath(), &FileFormat::supportsImport);
 			if (!format || !format->supportsExport())
 				continue;
 			
@@ -563,7 +563,7 @@ void HomeScreenWidgetMobile::addFilesToFileList(QListWidget* file_list, const QS
 	QDirIterator it(path, QDir::Files | QDir::NoDotAndDotDot, QDirIterator::Subdirectories);
 	while (it.hasNext()) {
 		it.next();
-		if (FileFormats.findFormatForFilename(it.filePath()) == nullptr)
+		if (!FileFormats.findFormatForFilename(it.filePath(), &FileFormat::supportsImport))
 			continue;
 		
 		QListWidgetItem* new_item = new QListWidgetItem(it.fileInfo().fileName());

--- a/src/gui/widgets/symbol_render_widget.cpp
+++ b/src/gui/widgets/symbol_render_widget.cpp
@@ -870,7 +870,7 @@ void SymbolRenderWidget::copySymbols()
 	
 	// Save map to memory
 	QBuffer buffer;
-	if (!copy_map->exportToIODevice(&buffer))
+	if (!copy_map->exportToIODevice(buffer))
 	{
 		delete copy_map;
 		QMessageBox::warning(nullptr, tr("Error"), tr("An internal error occurred, sorry!"));
@@ -899,7 +899,7 @@ void SymbolRenderWidget::pasteSymbols()
 	
 	// Create map from buffer
 	Map* paste_map = new Map();
-	if (!paste_map->importFromIODevice(&buffer))
+	if (!paste_map->importFromIODevice(buffer))
 	{
 		QMessageBox::warning(nullptr, tr("Error"), tr("An internal error occurred, sorry!"));
 		return;

--- a/src/gui/widgets/template_list_widget.cpp
+++ b/src/gui/widgets/template_list_widget.cpp
@@ -40,6 +40,8 @@
 #include "core/georeferencing.h"
 #include "core/map.h"
 #include "core/objects/object.h"
+#include "fileformats/file_format_registry.h"
+#include "fileformats/file_import_export.h"
 #include "gui/file_dialog.h"
 #include "gui/main_window.h"
 #include "gui/util_gui.h"
@@ -962,7 +964,6 @@ void TemplateListWidget::importClicked()
 		prototype->getTransform(transform);
 	
 	Map template_map;
-	
 	bool ok = true;
 	if (qstrcmp(prototype->getTemplateType(), "OgrTemplate") == 0)
 	{
@@ -979,9 +980,24 @@ void TemplateListWidget::importClicked()
 			template_map.scaleAllSymbols(template_scale);
 		}
 	}
-	else if (qstrcmp(prototype->getTemplateType(), "TemplateMap") == 0
-	         && template_map.loadFrom(prototype->getTemplatePath(), this, nullptr, false, true))
+	else if (qstrcmp(prototype->getTemplateType(), "TemplateMap") == 0)
 	{
+		auto importer = FileFormats.makeImporter(prototype->getTemplatePath(), template_map, nullptr);
+		if (!importer)
+		{
+			QMessageBox::warning(this, tr("Error"), tr("Cannot load map file, aborting."));
+			return;
+		}
+		if (!importer->doImport())
+		{
+			QMessageBox::warning(this, tr("Error"), importer->warnings().back());
+			return;
+		}
+		if (!importer->warnings().empty())
+		{
+			MainWindow::showMessageBox(this, tr("Warning"), tr("The map import generated warnings."), importer->warnings());
+		}
+		
 		if (!prototype->isTemplateGeoreferenced())
 			template_map.applyOnAllObjects(ApplyTemplateTransform{transform});
 		
@@ -1015,39 +1031,36 @@ void TemplateListWidget::importClicked()
 	}
 	else
 	{
-		Q_UNREACHABLE();
-		ok = false;
+		QMessageBox::warning(this, tr("Error"), tr("Cannot load map file, aborting."));
+		return;
 	}
 
-	if (ok)
+	map->importMap(template_map, Map::MinimalObjectImport);
+	deleteTemplate();
+	
+	if (main_view->isOverprintingSimulationEnabled()
+	    && !template_map.hasSpotColors())
 	{
-		map->importMap(template_map, Map::MinimalObjectImport);
-		deleteTemplate();
-		
-		if (main_view->isOverprintingSimulationEnabled()
-		    && !template_map.hasSpotColors())
+		auto answer = QMessageBox::question(
+		                  window(),
+		                  tr("Template import"),
+		                  tr("The template will be invisible in the overprinting simulation. "
+		                     "Switch to normal view?"),
+		                  QMessageBox::StandardButtons(QMessageBox::Yes | QMessageBox::No), 
+		                  QMessageBox::Yes );
+		if (answer == QMessageBox::Yes)
 		{
-			auto answer = QMessageBox::question(
-			                  window(),
-			                  tr("Template import"),
-			                  tr("The template will be invisible in the overprinting simulation. "
-			                     "Switch to normal view?"),
-			                  QMessageBox::StandardButtons(QMessageBox::Yes | QMessageBox::No), 
-			                  QMessageBox::Yes );
-			if (answer == QMessageBox::Yes)
-			{
-				if (auto action = controller->getAction("overprintsimulation"))
-					action->trigger();
-			}
+			if (auto action = controller->getAction("overprintsimulation"))
+				action->trigger();
 		}
-		
-		
-		auto map_visibility = main_view->getMapVisibility();
-		if (!map_visibility.visible)
-		{
-			map_visibility.visible = true;
-			updateRow(map->getNumTemplates() - map->getFirstFrontTemplate());
-		}
+	}
+	
+	
+	auto map_visibility = main_view->getMapVisibility();
+	if (!map_visibility.visible)
+	{
+		map_visibility.visible = true;
+		updateRow(map->getNumTemplates() - map->getFirstFrontTemplate());
 	}
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,7 +87,7 @@ void resetActivationWindow()
 			{
 				app->setActivationWindow(new_window);
 				QObject::connect(new_window, &QObject::destroyed, &resetActivationWindow);
-				QObject::connect(app, &QtSingleApplication::messageReceived, new_window, &MainWindow::openPath);
+				QObject::connect(app, &QtSingleApplication::messageReceived, new_window, QOverload<const QString&>::of(&MainWindow::openPath));
 				break;
 			}
 		}

--- a/src/templates/template.h
+++ b/src/templates/template.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2017 Kai Pastor
+ *    Copyright 2012-2018 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -36,6 +36,7 @@
 
 class QByteArray;
 class QColor;
+class QDir;
 class QPainter;
 class QRectF;
 class QTransform;
@@ -174,11 +175,14 @@ public:
 	/**
 	 * Saves template parameters.
 	 * 
-	 * This method saves as common properties such as filename, transformation,
+	 * This method saves common properties such as filename, transformation,
 	 * adjustment, etc., and it calls saveTypeSpecificTemplateConfiguration for
 	 * saving type-specific parameters (e.g. filtering mode for images).
+	 * 
+	 * If a target directory is given via `map_dir`, the relative template
+	 * path is determined for this directory.
 	 */
-	void saveTemplateConfiguration(QXmlStreamWriter& xml, bool open);
+	void saveTemplateConfiguration(QXmlStreamWriter& xml, bool open, const QDir* map_dir = nullptr) const;
 	
 	/**
 	 * Creates and returns a template from the configuration in the XML stream.
@@ -522,12 +526,15 @@ public:
 	static std::unique_ptr<Template> templateForFile(const QString& path, Map* map);
 	
 	/**
-	 * The function which is used to save paths of template files.
+	 * A flag which disables the writing of absolute paths for template files.
 	 * 
 	 * By default, class Template saves absolute paths. This behavior can be
-	 * changed by setting this variable to &Template::getTemplateRelativePath.
+	 * changed by setting this flag to true. This allows to hide local (or
+	 * private) directory names.
+	 * 
+	 * This flag defaults to false.
 	 */
-	static const QString& (Template::* pathForSaving)() const;
+	static bool suppressAbsolutePaths;
 	
 	
 signals:

--- a/src/undo/undo_manager.cpp
+++ b/src/undo/undo_manager.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2014-2017 Kai Pastor
+ *    Copyright 2014-2018 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -42,20 +42,6 @@
 namespace OpenOrienteering {
 
 Q_STATIC_ASSERT(UndoManager::max_undo_steps < std::numeric_limits<int>::max());
-
-
-namespace
-{
-
-template <class iterator>
-void saveSteps(QXmlStreamWriter& xml, iterator first, iterator last)
-{
-	for (auto step = first; step != last; ++step)
-		(*step)->save(xml);
-}
-
-}  // namespace
-
 
 
 // ### UndoManager::State ###
@@ -388,25 +374,46 @@ void UndoManager::emitChangedSignals(const UndoManager::State& old_state)
 
 
 
-void UndoManager::saveUndo(QXmlStreamWriter& xml)
+void UndoManager::saveUndo(QXmlStreamWriter& xml) const
 {
-	XmlElementWriter undo_element(xml, QLatin1String("undo"));
-	
-	validateUndoSteps();
+	auto count = undoStepCount();
 	auto first = begin(undo_steps);
-	auto last  = first + StepList::difference_type(undoStepCount());
-	first = std::find_if(first, last, [](auto&& undo_step) { return undo_step->isValid(); });
-	saveSteps(xml, first, last);
+	auto last  = first + count;
+	
+	// limit number of saved steps
+	first += qMax(0, count - int(max_undo_steps));
+	// limit to valid steps
+	auto first_valid = last;
+	for (auto prev = first_valid; first_valid != first; first_valid = prev)
+	{
+		--prev;
+		if (!(*prev)->isValid())
+			break;
+	}
+	
+	XmlElementWriter undo_element(xml, QLatin1String("undo"));
+	std::for_each(first_valid, last, [&xml](auto& step) { step->save(xml); });
 }
 
-void UndoManager::saveRedo(QXmlStreamWriter& xml)
+void UndoManager::saveRedo(QXmlStreamWriter& xml) const
 {
-	XmlElementWriter redo_element(xml, QLatin1String("redo"));
-	
-	validateRedoSteps();
+	auto count = redoStepCount();
 	auto first = undo_steps.rbegin();
-	auto last  = undo_steps.rbegin() + StepList::difference_type(redoStepCount());
-	saveSteps(xml, first, last);
+	auto last  = first + count;
+	
+	// limit number of saved steps
+	first += qMax(0, count - int(max_undo_steps));
+	// limit to valid steps
+	auto first_valid = last;
+	for (auto prev = first_valid; first_valid != first; first_valid = prev)
+	{
+		--prev;
+		if (!(*prev)->isValid())
+			break;
+	}
+	
+	XmlElementWriter redo_element(xml, QLatin1String("redo"));
+	std::for_each(first_valid, last, [&xml](auto& step) { step->save(xml); });
 }
 
 

--- a/src/undo/undo_manager.h
+++ b/src/undo/undo_manager.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2014, 2017 Kai Pastor
+ *    Copyright 2014, 2017, 2018 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -172,12 +172,12 @@ public:
 	/**
 	 * Saves the undo steps to the file in xml format.
 	 */
-	void saveUndo(QXmlStreamWriter& xml);
+	void saveUndo(QXmlStreamWriter& xml) const;
 	
 	/**
 	 * Saves the undo steps to the file in xml format.
 	 */
-	void saveRedo(QXmlStreamWriter& xml);
+	void saveRedo(QXmlStreamWriter& xml) const;
 	
 	/**
 	 * Loads the undo steps from the file in xml format.

--- a/test/duplicate_equals_t.cpp
+++ b/test/duplicate_equals_t.cpp
@@ -133,7 +133,7 @@ void DuplicateEqualsTest::symbols()
 {
 	QFETCH(QString, map_filename);
 	Map map {};
-	map.loadFrom(map_filename, nullptr, nullptr, false, false);
+	map.loadFrom(map_filename);
 	
 	for (int symbol = 0; symbol < map.getNumSymbols(); ++symbol)
 	{
@@ -184,7 +184,7 @@ void DuplicateEqualsTest::objects()
 {
 	QFETCH(QString, map_filename);
 	Map map {};
-	map.loadFrom(map_filename, nullptr, nullptr, false, false);
+	map.loadFrom(map_filename);
 	
 	for (int part_number = 0; part_number < map.getNumParts(); ++part_number)
 	{

--- a/test/file_format_t.cpp
+++ b/test/file_format_t.cpp
@@ -334,10 +334,11 @@ namespace
 			QBuffer buffer;
 			buffer.open(QIODevice::ReadWrite);
 			
-			auto exporter = format->makeExporter(&buffer, &input, nullptr);
+			auto exporter = format->makeExporter({}, &input, nullptr);
 			auto importer = format->makeImporter(&buffer, out.get(), nullptr);
 			if (exporter && importer)
 			{
+				exporter->setDevice(&buffer);
 				exporter->doExport();
 				buffer.seek(0);
 			

--- a/test/file_format_t.cpp
+++ b/test/file_format_t.cpp
@@ -517,7 +517,7 @@ void FileFormatTest::issue_513_high_coordinates()
 	
 	// Load the test map
 	Map map {};
-	QVERIFY(map.loadFrom(filename, nullptr, nullptr, false, false));
+	QVERIFY(map.loadFrom(filename));
 	
 	// The map's single object must exist. Otherwise it may have been deleted
 	// for being irregular, indicating failure to handle high coordinates.
@@ -580,8 +580,7 @@ void FileFormatTest::saveAndLoad()
 	
 	// Load the test map
 	auto original = std::make_unique<Map>();
-	QVERIFY(original->loadFrom(map_filename, nullptr, nullptr, false, false));
-	QVERIFY(!original->hasUnsavedChanges());
+	QVERIFY(original->loadFrom(map_filename));
 	
 	// Fix precision of grid rotation
 	MapGrid grid = original->getGrid();

--- a/test/file_format_t.cpp
+++ b/test/file_format_t.cpp
@@ -342,7 +342,7 @@ namespace
 				exporter->doExport();
 				buffer.seek(0);
 			
-				importer->doImport(false);
+				importer->doImport();
 				importer->finishImport();
 			}
 			else

--- a/test/file_format_t.cpp
+++ b/test/file_format_t.cpp
@@ -327,7 +327,7 @@ namespace
 		return true;
 	}
 	
-	std::unique_ptr<Map> saveAndLoadMap(Map& input, const FileFormat* format)
+	std::unique_ptr<Map> saveAndLoadMap(const Map& input, const FileFormat* format)
 	{
 		auto out = std::make_unique<Map>();
 		try {

--- a/test/file_format_t.h
+++ b/test/file_format_t.h
@@ -25,7 +25,7 @@
 
 
 /**
- * @test Tests concerning the file formats, import and export.
+ * @test Tests concerning the file formats, registry, import and export.
  * 
  */
 class FileFormatTest : public QObject
@@ -45,6 +45,12 @@ private slots:
 	 */
 	void understandsTest();
 	void understandsTest_data();
+	
+	/**
+	 * Tests FileFormatRegistry::formatForData().
+	 */
+	void formatForDataTest();
+	void formatForDataTest_data();
 	
 	/**
 	 * Tests that high coordinates are correctly moved to the central region

--- a/test/map_t.cpp
+++ b/test/map_t.cpp
@@ -59,12 +59,6 @@ void MapTest::initTestCase()
 	
 	// Static map initializations
 	Map map;
-	
-	// Accept any message boxes
-	connect(qApp, &QApplication::focusChanged, [](QWidget*, QWidget* w) {
-		if (w && qobject_cast<QMessageBox*>(w->window()))
-			QTimer::singleShot(0, w->window(), SLOT(accept()));  // clazy:exclude=old-style-connect (needs Qt 5.4)
-	});
 }
 
 
@@ -195,7 +189,8 @@ void MapTest::importTest()
 	QString first_path = examples_dir.absoluteFilePath(first_file);
 	Map map;
 	MapView view{ &map };
-	QVERIFY(map.loadFrom(first_path, nullptr, &view, false, false));
+	QVERIFY(map.loadFrom(first_path, &view));
+	QVERIFY(map.getNumSymbols() > 0);
 	
 	auto original_size = map.getNumObjects();
 	auto original_num_colors = map.getNumColors();
@@ -214,7 +209,7 @@ void MapTest::importTest()
 	
 	QString imported_path = examples_dir.absoluteFilePath(imported_file);
 	Map imported_map;
-	QVERIFY(imported_map.loadFrom(imported_path, nullptr, nullptr, false, false));
+	QVERIFY(imported_map.loadFrom(imported_path));
 	QVERIFY(imported_map.getNumSymbols() > 0);
 	
 	original_size = map.getNumObjects();
@@ -229,7 +224,7 @@ void MapTest::crtFileTest()
 {
 	auto original =  symbol_set_dir.absoluteFilePath(QString::fromLatin1("15000/ISOM2000_15000.omap"));
 	Map original_map;
-	original_map.loadFrom(original, nullptr, nullptr, false, false);
+	QVERIFY(original_map.loadFrom(original));
 	QVERIFY(original_map.getNumSymbols() > 100);
 	
 	auto crt_data = QByteArray{
@@ -304,7 +299,7 @@ void MapTest::matchQuerySymbolNumberTest()
 	QFETCH(int, matching);
 	
 	Map original_map;
-	original_map.loadFrom(original, nullptr, nullptr, false, false);
+	QVERIFY(original_map.loadFrom(original));
 	QVERIFY(original_map.getNumSymbols() > 0);
 	
 	auto r = SymbolRuleSet::forOriginalSymbols(original_map);
@@ -316,7 +311,7 @@ void MapTest::matchQuerySymbolNumberTest()
 	QCOMPARE(r.squeezed().size(), std::size_t(original_map.getNumSymbols()));
 	
 	Map replacement_map;
-	replacement_map.loadFrom(replacement, nullptr, nullptr, false, false);
+	QVERIFY(replacement_map.loadFrom(replacement));
 	QVERIFY(replacement_map.getNumSymbols() > 100);
 	
 	r = SymbolRuleSet::forOriginalSymbols(original_map);

--- a/test/symbol_set_t.cpp
+++ b/test/symbol_set_t.cpp
@@ -196,6 +196,7 @@ TranslationEntries readTsFile(QIODevice& device, const QString& language)
 }  // namespace
 
 
+
 void SymbolSetTool::TranslationEntry::write(QXmlStreamWriter& xml, const QString& language)
 {
 	if (source.isEmpty())
@@ -357,7 +358,7 @@ void SymbolSetTool::processSymbolSet()
 	
 	Map map;
 	MapView view{ &map };
-	map.loadFrom(source_path, nullptr, &view, false, false);
+	map.loadFrom(source_path, &view);
 	QCOMPARE(map.getScaleDenominator(), source_scale);
 	QCOMPARE(map.getNumClosedTemplates(), 0);
 	
@@ -786,7 +787,7 @@ void SymbolSetTool::processExamples()
 	
 	Map map;
 	MapView view{ &map };
-	map.loadFrom(source_path, nullptr, &view, false, false);
+	map.loadFrom(source_path, &view);
 	
 	const int num_symbols = map.getNumSymbols();
 	QStringList previous_numbers;
@@ -828,7 +829,7 @@ void SymbolSetTool::processTestData()
 	
 	Map map;
 	MapView view{ &map };
-	map.loadFrom(source_path, nullptr, &view, false, false);
+	map.loadFrom(source_path, &view);
 	
 	map.undoManager().clear();
 	saveIfDifferent(source_path, &map, &view);

--- a/test/symbol_set_t.cpp
+++ b/test/symbol_set_t.cpp
@@ -288,7 +288,7 @@ void SymbolSetTool::initTestCase()
 	translations_dir.cd(QDir(QString::fromUtf8(MAPPER_TEST_SOURCE_DIR)).absoluteFilePath(QStringLiteral("../translations")));
 	QVERIFY(translations_dir.exists());
 	
-	Template::pathForSaving = &Template::getTemplateRelativePath;
+	Template::suppressAbsolutePaths = true;
 	
 	translations_complete = false;
 }

--- a/test/symbol_set_t.cpp
+++ b/test/symbol_set_t.cpp
@@ -245,17 +245,18 @@ void saveIfDifferent(const QString& path, Map* map, MapView* view = nullptr)
 		new_data.reserve(existing_data.size()*2);
 	}
 	
-	QBuffer buffer(&new_data);
-	buffer.open(QFile::WriteOnly);
-	XMLFileExporter exporter(&buffer, map, view);
+	XMLFileExporter exporter({}, map, view);
 	auto is_src_format = path.contains(QLatin1String(".xmap"));
 	exporter.setOption(QString::fromLatin1("autoFormatting"), is_src_format);
 	auto retain_compatibility = is_src_format && map->getNumParts() == 1
 	                            && !path.contains(QLatin1String("ISOM2017"));
 	Settings::getInstance().setSetting(Settings::General_RetainCompatiblity, retain_compatibility);
+	
+	QBuffer buffer(&new_data);
+	exporter.setDevice(&buffer);
 	exporter.doExport();
-	QVERIFY(exporter.warnings().empty());
 	buffer.close();
+	QVERIFY(exporter.warnings().empty());
 	
 	if (new_data != existing_data)
 	{

--- a/test/symbol_t.cpp
+++ b/test/symbol_t.cpp
@@ -201,7 +201,7 @@ private slots:
 		QFETCH(QString, map_filename);
 		
 		Map map;
-		QVERIFY(map.loadFrom(map_filename, nullptr, nullptr, false, false));
+		QVERIFY(map.loadFrom(map_filename));
 		
 		const auto extent = map.calculateExtent().toAlignedRect().adjusted(-1, -1, +1, +1);
 		constexpr auto pixel_per_mm = 50;
@@ -252,7 +252,7 @@ private slots:
 	{
 		QFETCH(QString, map_filename);
 		Map map {};
-		QVERIFY(map.loadFrom(map_filename, nullptr, nullptr, false, false));
+		QVERIFY(map.loadFrom(map_filename));
 		
 		for (int i = 0; i < map.getNumSymbols(); ++i)
 		{

--- a/test/template_t.cpp
+++ b/test/template_t.cpp
@@ -125,8 +125,9 @@ private slots:
 		// This results in a warning.
 		QBuffer buffer{ &original_data };
 		buffer.open(QIODevice::ReadOnly);
-		XMLFileImporter importer{ &buffer, &map, &view };
-		importer.doImport();
+		XMLFileImporter importer{ {}, &map, &view };
+		importer.setDevice(&buffer);
+		QVERIFY(importer.doImport());
 		QCOMPARE(importer.warnings().size(), std::size_t(1));
 		
 		// The image is in Invalid state, but path attributes are intact.

--- a/test/template_t.cpp
+++ b/test/template_t.cpp
@@ -126,7 +126,7 @@ private slots:
 		QBuffer buffer{ &original_data };
 		buffer.open(QIODevice::ReadOnly);
 		XMLFileImporter importer{ &buffer, &map, &view };
-		importer.doImport(false);
+		importer.doImport();
 		QCOMPARE(importer.warnings().size(), std::size_t(1));
 		
 		// The image is in Invalid state, but path attributes are intact.

--- a/test/template_t.cpp
+++ b/test/template_t.cpp
@@ -140,8 +140,9 @@ private slots:
 		
 		QBuffer out_buffer;
 		QVERIFY(out_buffer.open(QIODevice::WriteOnly));
-		XMLFileExporter exporter{ &out_buffer, &map, &view };
+		XMLFileExporter exporter{ {}, &map, &view };
 		exporter.setOption(QStringLiteral("autoFormatting"), true);
+		exporter.setDevice(&out_buffer);
 		exporter.doExport();
 		out_buffer.close();
 		QCOMPARE(exporter.warnings().size(), std::size_t(0));

--- a/test/template_t.cpp
+++ b/test/template_t.cpp
@@ -93,7 +93,7 @@ private slots:
 	{
 		Map map;
 		MapView view{ &map };
-		QVERIFY(map.loadFrom(QStringLiteral("testdata:templates/world-file.xmap"), nullptr, &view, false, false));
+		QVERIFY(map.loadFrom(QStringLiteral("testdata:templates/world-file.xmap"), &view));
 		
 		const auto& georef = map.getGeoreferencing();
 		QVERIFY(georef.isValid());


### PR DESCRIPTION
- Export is now operating on const Map and MapView.
- The FileFormat of edited files is identified early, passed on and remembered for saving. This should help with pairing generic importers with specialized exporters, e.g. for OCD versions.
- Importers and Exporters may now work on file paths directly, or continue to use QIODevice. This should help with GDAL.