### PR TITLE
Android: Trigger MediaScanner after saving

### DIFF
--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -78,6 +78,10 @@
 
 // IWYU pragma: no_forward_declare QRectF
 
+#ifdef Q_OS_ANDROID
+#include "core/storage_location.h"
+#endif
+
 
 namespace OpenOrienteering {
 
@@ -694,6 +698,15 @@ bool Map::exportTo(const QString& path, MapView* view, const FileFormat* format)
 		}
 		
 		success = file.commit();
+#ifdef Q_OS_ANDROID
+		if (success)
+		{
+			// Make the MediaScanner aware of the *updated* file. This is an
+			// attempt to resolve issues with files being transferred
+			// incompletely to the PC (#1115).
+			Android::mediaScannerScanFile(path);
+		}
+#endif
 	}
 	
 	if (!success)

--- a/src/core/storage_location.cpp
+++ b/src/core/storage_location.cpp
@@ -48,12 +48,8 @@ namespace Android {
  */
 static std::shared_ptr<const std::vector<StorageLocation>> locations_cache;
 
-/**
- * Tells the media scanner to register the given file or folder.
- * 
- * This is required to make files quickly available for transfer via MTP.
- */
-void mediaScannerScanFile(const QString path)
+
+void mediaScannerScanFile(const QString& path)
 {
 	static const auto ACTION_MEDIA_SCANNER_SCAN_FILE = 
 	        QAndroidJniObject::getStaticObjectField<jstring>("android/content/Intent",

--- a/src/core/storage_location.h
+++ b/src/core/storage_location.h
@@ -31,6 +31,18 @@
 
 namespace OpenOrienteering {
 
+namespace Android {
+
+/**
+ * Tells the media scanner to register the given file or folder.
+ * 
+ * This is required to make files quickly available for transfer via MTP.
+ */
+void mediaScannerScanFile(const QString& path);
+
+}
+
+
 // noexcept since Qt 5.5
 constexpr bool qstring_is_nothrow_copy_constructible = std::is_nothrow_copy_constructible<QString>::value;
 constexpr bool qstring_is_nothrow_move_constructible = std::is_nothrow_move_constructible<QString>::value;


### PR DESCRIPTION
This is an attempt to resolve #1115.

In several cases, the files had correct but incomplete data, and/or transfers after an Android reboot were complete. This reboot effect was observed before for README files put into the data folders, and solved by Android::mediaScannerScanFile(). So there is a chance that using the same pattern might eventually resolve #1115, by forcing the media scanner to take immediate notice of the changed file.

(Note that we use QSaveFile which does actually not update the existing file but replace it with a new file by renaming.)