### PR TITLE
Android: Show recent files, browse folders

### DIFF
--- a/src/core/storage_location.cpp
+++ b/src/core/storage_location.cpp
@@ -285,7 +285,7 @@ QString StorageLocation::fileHintTextTemplate(Hint hint)
 	switch (hint)
 	{
 	case HintNormal:
-		return tr("'%1' is stored in a regular location.");
+		return {};  // No text for a regular location.
 		
 	case HintApplication:
 		return tr("'%1' is located in app storage. The files will be removed when uninstalling the app.");
@@ -298,6 +298,12 @@ QString StorageLocation::fileHintTextTemplate(Hint hint)
 	}
 	
 	Q_UNREACHABLE();
+}
+
+
+QString OpenOrienteering::StorageLocation::hintText() const
+{
+	return hint() == HintNormal ? QString{} : fileHintTextTemplate(hint()).arg(path());
 }
 
 

--- a/src/core/storage_location.h
+++ b/src/core/storage_location.h
@@ -65,13 +65,21 @@ public:
 	/** Returns the path of this location. */
 	QString path() const;
 	
-	/** Returns the hint for this location. */
+	/**
+	 * Returns the hint for this location.
+	 * 
+	 * This function returns an empty string for HintNormal.
+	 */
 	Hint hint() const;
 	
 	/** Returns the text representing the hint for this location. */
 	QString hintText() const;
 	
-	/** Returns a text template for giving the hint for the given path. */
+	/**
+	 * Returns a text template for giving the hint for the given path.
+	 * 
+	 * This function returns an empty string for HintNormal.
+	 */
 	static QString fileHintTextTemplate(Hint hint);
 	
 	
@@ -112,12 +120,6 @@ inline
 StorageLocation::Hint StorageLocation::hint() const
 {
 	return m_hint;
-}
-
-inline
-QString StorageLocation::hintText() const
-{
-	return fileHintTextTemplate(hint()).arg(path());
 }
 
 

--- a/src/gui/widgets/home_screen_widget.h
+++ b/src/gui/widgets/home_screen_widget.h
@@ -23,6 +23,7 @@
 
 #include <vector>
 
+#include <QIcon>
 #include <QObject>
 #include <QPixmap>
 #include <QString>
@@ -31,6 +32,7 @@
 
 class QAbstractButton;
 class QCheckBox;
+class QFileInfo;
 class QIcon;
 class QLabel;
 class QListWidget;
@@ -43,6 +45,7 @@ class QStackedLayout;
 namespace OpenOrienteering {
 
 class HomeScreenController;
+class StorageLocation;
 
 
 /**
@@ -88,6 +91,8 @@ protected:
 	 *  for triggering a top level activity in the home screen. */
 	QAbstractButton* makeButton(const QString& text, const QIcon& icon, QWidget* parent = nullptr) const;
 	
+	/** Returns the role to be used for storing paths. */
+	constexpr static int pathRole() { return Qt::UserRole; }
 	
 	HomeScreenController* controller;
 };
@@ -175,18 +180,13 @@ public slots:
 	 *  sets the "checked" state of the control for displaying the tip. */
 	void setTipsVisible(bool state) override;
 	
-	/** Adds the examples to the list of files
-	 *  if they are not already there. */
-	void showExamples();
-	
 	/** Shows the settings dialog, adjusted for small screens. */
 	void showSettings();
 	
-protected slots:
+protected:
 	/** Opens a file when its is list item is clicked. */
 	void fileClicked(QListWidgetItem* item);
 	
-protected:
 	/** Triggers title image adjustment on resize events. */
 	void resizeEvent(QResizeEvent* event) override;
 	
@@ -194,17 +194,25 @@ protected:
 	void adjustTitlePixmapSize();
 	
 	/** Creates the file list widget. */
-	QWidget* makeFileListWidget(HomeScreenController* controller, QWidget* parent = nullptr);
+	QListWidget* makeFileListWidget();
 	
-	/** Iterates over all files at the given path and adds all map files to the list */
-	void addFilesToFileList(QListWidget* file_list, const QString& path);
+	/** Updates the file list widget. */
+	void updateFileListWidget();
+	
+	/** Add a single file or dir item to the file list. */
+	void addItemToFileList(const QFileInfo& file_info, int hint = 0, const QIcon& icon = {});
+	
+	/** Add a single item to the file list, using a custom display name. */
+	void addItemToFileList(const QString& label, const QFileInfo& file_info, int hint = 0, const QIcon& icon = {});
+	
+	/** Returns the role to be used for storing hints (number or text). */
+	constexpr static int hintRole() { return Qt::UserRole + 1; }
 	
 private:
 	QPixmap title_pixmap;
 	QLabel* title_label;
-	QStackedLayout* file_list_stack;
-	QListWidget* file_list;
-	QPushButton* examples_button;
+	QListWidget* file_list_widget;
+	std::vector<StorageLocation> history;
 };
 
 


### PR DESCRIPTION
With this change, the mobile UI no longer show a single list of all maps in known locations, but:
1. Lists most recently used maps first (as on desktop).
2. If there are no such maps, show a link to the manual page.
3. List the known storage locations (unique full path).
4. Show a link to the examples folder.
    
When clicking on a folder, the folder contents will be displayed as follows:
1. Show ".." entry which navigates back.
2. List map files in this directory.
3. List subdirectories.
    
This change does not allow browsing to other locations.
    
Geospatial vector files will no longer be listed when they are handled by GDAL/OGR.
The "File list" headline and the redundant "Examples" button are removed.
    
This change at resolves or at least mitigates #904. However, this change does not add custom filtering or sorting, but just changes the way file types and folder structure are exposed to the user.

## Initial Home screen (no recent files)
![home-screen-initial](https://user-images.githubusercontent.com/13567791/46581062-1b98b100-ca31-11e8-9ff9-622471de15bc.png)

## Home screen after clicking the "Examples" folder
![home-screen-examples](https://user-images.githubusercontent.com/13567791/46581074-64e90080-ca31-11e8-9c8b-49e98ac8be39.png)

## Home screen with recent files (read-only examples here)
![home-screen-recent](https://user-images.githubusercontent.com/13567791/46581067-27847300-ca31-11e8-8846-fafb9e29f46d.png)

