### PR TITLE
Allow position change of a georeferenced template

### DIFF
--- a/src/gui/widgets/template_list_widget.h
+++ b/src/gui/widgets/template_list_widget.h
@@ -102,6 +102,7 @@ protected slots:
 	//void groupClicked();
 	void positionClicked(bool checked);
 	void importClicked();
+	void releaseGeorefClicked();
 	void moreActionClicked(QAction* action);
 	
 	void templateAdded(int pos, const Template* temp);
@@ -140,6 +141,7 @@ private:
 	QAction* move_by_hand_action;
 	QAction* position_action;
 	QAction* import_action;
+	QAction* georef_action;
 	
 	// Buttons
 	QWidget* list_buttons_group;

--- a/src/templates/template.cpp
+++ b/src/templates/template.cpp
@@ -604,6 +604,18 @@ void Template::unloadTemplateFile()
 	emit templateStateChanged();
 }
 
+void Template::releaseGeoreference()
+{
+	// Calling this method on an unloaded template results in
+	// the template position being set to (0, 0, 1, 1, 0).
+	// XXX This assert is insufficient. FIXME!!!
+	Q_ASSERT(template_state == Loaded);
+
+	is_georeferenced = false;
+
+	setHasUnsavedChanges(true);
+}
+
 void Template::applyTemplateTransform(QPainter* painter) const
 {
 	painter->translate(transform.template_x / 1000.0, transform.template_y / 1000.0);

--- a/src/templates/template.h
+++ b/src/templates/template.h
@@ -308,6 +308,11 @@ public:
 	 */
 	void unloadTemplateFile();
 	
+	/**
+	 * Release georeferencing flag for the template file.
+	 * Must not be called before the original georeferencing information is available.
+	 */
+	void releaseGeoreference();
 	
 	/** 
 	 * Draws the template using the given painter with the given opacity.


### PR DESCRIPTION
When using georeferenced images, e.g., from Google Maps (Satellite), sometimes
different images do not line up properly. It is therefore useful to be able to
move a template after it has been opened as a georeferenced one.