### PR TITLE
Review printing

### DIFF
--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -40,6 +40,7 @@
 #include <QLatin1String>
 #include <QLocale>
 #include <QMessageBox>
+#include <QPaintEngine>
 #include <QPainter>
 #include <QPoint>
 #include <QPointF>
@@ -1100,20 +1101,22 @@ void Map::drawTemplates(QPainter* painter, const QRectF& bounding_box, int first
 	for (int i = first_template; i <= last_template; ++i)
 	{
 		const Template* temp = getTemplate(i);
-		bool visible  = temp->getTemplateState() == Template::Loaded;
+		if (temp->getTemplateState() != Template::Loaded)
+			continue;
+		
 		double scale  = std::max(temp->getTemplateScaleX(), temp->getTemplateScaleY());
-		float opacity = 1.0f;
+		auto visibility = TemplateVisibility{ 1, true };
 		if (view)
 		{
-			auto visibility = view->getTemplateVisibility(temp);
-			visible &= visibility.visible;
-			opacity  = visibility.opacity;
-			scale   *= view->getZoom();
+			visibility = view->getTemplateVisibility(temp);
+			visibility.visible &= visibility.opacity > 0;
+			scale *= view->getZoom();
 		}
-		if (visible)
+		if (visibility.visible)
 		{
+			Q_ASSERT(visibility.opacity == 1 || painter->paintEngine()->hasFeature(QPaintEngine::ConstantOpacity));
 			painter->save();
-			temp->drawTemplate(painter, bounding_box, scale, on_screen, opacity);
+			temp->drawTemplate(painter, bounding_box, scale, on_screen, visibility.opacity);
 			painter->restore();
 		}
 	}

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -1091,9 +1091,9 @@ void Map::drawColorSeparation(QPainter* painter, const RenderConfig& config, con
 	renderables->drawColorSeparation(painter, config, spot_color, use_color);
 }
 
-void Map::drawGrid(QPainter* painter, const QRectF& bounding_box, bool on_screen)
+void Map::drawGrid(QPainter* painter, const QRectF& bounding_box)
 {
-	grid.draw(painter, bounding_box, this, on_screen);
+	grid.draw(painter, bounding_box, this);
 }
 
 void Map::drawTemplates(QPainter* painter, const QRectF& bounding_box, int first_template, int last_template, const MapView* view, bool on_screen) const

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -1653,6 +1653,19 @@ bool Map::hasSpotColors() const
 	return false;
 }
 
+bool Map::hasAlpha() const
+{
+	return std::any_of(begin(color_set->colors), end(color_set->colors), [this](const MapColor* color) {
+		const auto opacity = color->getOpacity();
+		return opacity > 0 && opacity < 1
+		       && std::any_of(begin(symbols), end(symbols), [this, color](const Symbol* symbol) {
+			return !symbol->isHidden()
+			       && symbol->containsColor(color)
+			       && this->existsObjectWithSymbol(symbol);
+		});
+	});
+}
+
 
 void Map::setSymbolSetId(const QString& id)
 {

--- a/src/core/map.h
+++ b/src/core/map.h
@@ -503,6 +503,11 @@ public:
 	/** Returns true if the map contains spot colors. */
 	bool hasSpotColors() const;
 	
+	/**
+	 * Returns true if any visible object uses a non-opaque color.
+	 */
+	bool hasAlpha() const;
+	
 	
 	// Symbols
 	

--- a/src/core/map.h
+++ b/src/core/map.h
@@ -288,10 +288,8 @@ public:
 	 * 
 	 * @param painter The QPainter used for drawing.
 	 * @param bounding_box Bounding box of area to draw, given in map coordinates.
-	 * @param on_screen If true, uses a cosmetic pen (one pixel wide),
-	 *                  otherwise uses a 0.1 mm wide pen.
 	 */
-	void drawGrid(QPainter* painter, const QRectF& bounding_box, bool on_screen);
+	void drawGrid(QPainter* painter, const QRectF& bounding_box);
 	
 	/**
 	 * Draws the templates with indices first_template until last_template which

--- a/src/core/map_grid.cpp
+++ b/src/core/map_grid.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2014, 2015 Kai Pastor
+ *    Copyright 2014-2018 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -130,7 +130,7 @@ const MapGrid& MapGrid::load(QXmlStreamReader& xml)
 	return *this;
 }
 
-void MapGrid::draw(QPainter* painter, const QRectF& bounding_box, Map* map, bool on_screen) const
+void MapGrid::draw(QPainter* painter, const QRectF& bounding_box, Map* map, qreal scale_adjustment) const
 {
 	double final_horz_spacing, final_vert_spacing;
 	double final_horz_offset, final_vert_offset;
@@ -138,7 +138,7 @@ void MapGrid::draw(QPainter* painter, const QRectF& bounding_box, Map* map, bool
 	calculateFinalParameters(final_horz_spacing, final_vert_spacing, final_horz_offset, final_vert_offset, final_rotation, map);
 	
 	QPen pen(color);
-	if (on_screen)
+	if (qIsNull(scale_adjustment))
 	{
 		// zero-width cosmetic pen (effectively one pixel)
 		pen.setWidth(0);
@@ -147,7 +147,7 @@ void MapGrid::draw(QPainter* painter, const QRectF& bounding_box, Map* map, bool
 	else
 	{
 		// 0.1 mm wide non-cosmetic pen
-		pen.setWidthF(0.1f);
+		pen.setWidthF(qreal(0.1) / scale_adjustment);
 	}
 	painter->setPen(pen);
 	painter->setBrush(Qt::NoBrush);

--- a/src/core/map_grid.cpp
+++ b/src/core/map_grid.cpp
@@ -204,6 +204,14 @@ MapCoordF MapGrid::getClosestPointOnGrid(MapCoordF position, Map* map) const
 }
 
 
+bool MapGrid::hasAlpha() const
+{
+	return [](auto alpha) {
+		return alpha > 0 && alpha < 255;
+	}(qAlpha(color));
+}
+
+
 
 bool operator==(const MapGrid& lhs, const MapGrid& rhs)
 {

--- a/src/core/map_grid.h
+++ b/src/core/map_grid.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2014 Kai Pastor
+ *    Copyright 2014, 2015, 2017, 2018 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -41,6 +41,9 @@ class MapCoordF;
  * 
  * Each map has an instance of this class which can be retrieved with map->getGrid().
  * The grid's visibility is defined per MapView.
+ * 
+ * Grid lines are thin. They are either drawn using a cosmetic pen (usually on
+ * screen) or with 0.1 mm (usually on paper).
  */
 class MapGrid
 {
@@ -87,10 +90,11 @@ public:
 	 * @param bounding_box Bounding box of the area to draw the grid for, in
 	 *     map coordinates.
 	 * @param map Map to draw the grid for.
-	 * @param on_screen If true, uses a cosmetic pen (one pixel wide),
-	 *                  otherwise uses a 0.1 mm wide pen.
+	 * @param scale_adjustment If zero, uses a cosmetic pen (one pixel wide),
+	 *        otherwise this is the divisor used to create a 0.1 mm wide pen.
 	 */
-	void draw(QPainter* painter, const QRectF& bounding_box, Map* map, bool on_screen) const;
+	void draw(QPainter* painter, const QRectF& bounding_box, Map* map, qreal scale_adjustment = 0) const;
+	void draw(QPainter* painter, const QRectF& bounding_box, Map* map, bool) const = delete;
 	
 	/**
 	 * Calculates the "final" parameters with the following properties:

--- a/src/core/map_grid.h
+++ b/src/core/map_grid.h
@@ -113,6 +113,11 @@ public:
 	inline QRgb getColor() const {return color;}
 	inline void setColor(QRgb color) {this->color = color;}
 	
+	/**
+	 * Returns true if the grid is not opaque.
+	 */
+	bool hasAlpha() const;
+	
 	inline DisplayMode getDisplayMode() const {return display;}
 	inline void setDisplayMode(DisplayMode mode) {display = mode;}
 	

--- a/src/core/map_printer.cpp
+++ b/src/core/map_printer.cpp
@@ -877,26 +877,20 @@ void MapPrinter::drawPage(QPainter* device_painter, const QRectF& page_extent, Q
 	bool use_buffer_for_foreground = use_buffer_for_map && options.show_templates;
 	if (view && options.show_templates)
 	{
-		if (!use_buffer_for_background)
+		for (int i = 0; i < map.getFirstFrontTemplate() && !use_buffer_for_background; ++i)
 		{
-			for (int i = 0; i < map.getFirstFrontTemplate() && !use_buffer_for_background; ++i)
+			if (map.getTemplate(i)->isRasterGraphics())
 			{
-				if (map.getTemplate(i)->isRasterGraphics())
-				{
-					auto visibility = view->getTemplateVisibility(map.getTemplate(i));
-					use_buffer_for_background = visibility.visible && visibility.opacity < 1.0f;
-				}
+				auto visibility = view->getTemplateVisibility(map.getTemplate(i));
+				use_buffer_for_background = visibility.visible && visibility.opacity < 1;
 			}
 		}
-		if (!use_buffer_for_foreground)
+		for (int i = map.getFirstFrontTemplate(); i < map.getNumTemplates() && !use_buffer_for_foreground; ++i)
 		{
-			for (int i = map.getFirstFrontTemplate(); i < map.getNumTemplates() && !use_buffer_for_foreground; ++i)
+			if (map.getTemplate(i)->isRasterGraphics())
 			{
-				if (map.getTemplate(i)->isRasterGraphics())
-				{
-					auto visibility = view->getTemplateVisibility(map.getTemplate(i));
-					use_buffer_for_foreground = visibility.visible && visibility.opacity < 1.0f;
-				}
+				auto visibility = view->getTemplateVisibility(map.getTemplate(i));
+				use_buffer_for_foreground = visibility.visible && visibility.opacity < 1;
 			}
 		}
 	}

--- a/src/core/map_printer.cpp
+++ b/src/core/map_printer.cpp
@@ -838,8 +838,7 @@ void MapPrinter::drawPage(QPainter* device_painter, const QRectF& page_extent, b
 	
 	// Logical units per mm
 	const qreal units_per_mm = options.resolution / 25.4;
-	// The current painter's resolution
-	qreal scale = units_per_mm;
+	
 	
 	/*
 	 * Analyse need for page buffer
@@ -896,8 +895,8 @@ void MapPrinter::drawPage(QPainter* device_painter, const QRectF& page_extent, b
 	QImage scoped_buffer;
 	if (use_page_buffer && !page_buffer)
 	{
-		int w = qCeil(page_format.paper_dimensions.width() * scale);
-		int h = qCeil(page_format.paper_dimensions.height() * scale);
+		int w = qCeil(page_format.paper_dimensions.width() * units_per_mm);
+		int h = qCeil(page_format.paper_dimensions.height() * units_per_mm);
 #if defined (Q_OS_MACOS)
 		if (device_painter->device()->physicalDpiX() == 0)
 		{
@@ -906,8 +905,8 @@ void MapPrinter::drawPage(QPainter* device_painter, const QRectF& page_extent, b
 			// the corresponding QPaintEngine must handle the resolution mapping"
 			// which doesn't seem to happen here.
 			qreal corr = device_painter->device()->logicalDpiX() / 72.0;
-			w = qCeil(page_format.paper_dimensions.width() * scale * corr);
-			h = qCeil(page_format.paper_dimensions.height() * scale * corr);
+			w = qCeil(page_format.paper_dimensions.width() * units_per_mm * corr);
+			h = qCeil(page_format.paper_dimensions.height() * units_per_mm * corr);
 		}
 #endif
 		
@@ -941,13 +940,12 @@ void MapPrinter::drawPage(QPainter* device_painter, const QRectF& page_extent, b
 	 * One-time setup of transformation and clipping
 	 */
 	// Translate for top left page margin 
-	painter->scale(scale, scale);
+	painter->scale(units_per_mm, units_per_mm);
 	painter->translate(page_format.page_rect.left(), page_format.page_rect.top());
 	
 	// Convert native map scale to print scale
 	if (scale_adjustment != 1.0)
 	{
-		scale *= scale_adjustment;
 		painter->scale(scale_adjustment, scale_adjustment);
 	}
 	
@@ -1012,7 +1010,7 @@ void MapPrinter::drawPage(QPainter* device_painter, const QRectF& page_extent, b
 			map_painter->setTransform(painter->transform());
 		}
 		
-		RenderConfig config = { map, page_region_used, scale, RenderConfig::NoOptions, 1.0 };
+		RenderConfig config = { map, page_region_used, units_per_mm * scale_adjustment, RenderConfig::NoOptions, 1.0 };
 		
 		if (rasterModeSelected() && options.simulate_overprinting)
 		{

--- a/src/core/map_printer.cpp
+++ b/src/core/map_printer.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2016  Kai Pastor
+ *    Copyright 2012-2018  Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -1222,7 +1222,8 @@ bool MapPrinter::printMap(QPrinter* printer)
 			SetWindowExtEx(dc, hires_width, hires_height, nullptr);
 			SetViewportExtEx(dc, phys_width, phys_height, nullptr);
 			SetViewportOrgEx(dc, -phys_off_x, -phys_off_y, nullptr);
-			resolution *= ((double)hires_width / phys_width);
+			const auto hires_scale = static_cast<qreal>(hires_width) / phys_width;
+			painter.scale(hires_scale, hires_scale);
 		}
 	}
 	else if (printer->paintEngine()->type() == QPaintEngine::Picture)

--- a/src/core/map_printer.cpp
+++ b/src/core/map_printer.cpp
@@ -817,12 +817,11 @@ void MapPrinter::takePrinterSettings(const QPrinter* printer)
 }
 
 // local
-void drawBuffer(QPainter* device_painter, const QImage* page_buffer, qreal pixel2units)
+void drawBuffer(QPainter* device_painter, const QImage* page_buffer)
 {
 	Q_ASSERT(page_buffer);
 	
 	device_painter->save();
-	device_painter->scale(pixel2units, pixel2units);
 	device_painter->setRenderHint(QPainter::SmoothPixmapTransform, false);
 	device_painter->drawImage(0, 0, *page_buffer);
 	device_painter->restore();
@@ -839,10 +838,6 @@ void MapPrinter::drawPage(QPainter* device_painter, const QRectF& page_extent, b
 	
 	// Logical units per mm
 	const qreal units_per_mm = options.resolution / 25.4;
-	// Image pixels per mm
-	const qreal pixel_per_mm = options.resolution / 25.4;
-	// Scaling from pixels to logical units
-	const qreal pixel2units = 1;
 	// The current painter's resolution
 	qreal scale = units_per_mm;
 	
@@ -901,7 +896,6 @@ void MapPrinter::drawPage(QPainter* device_painter, const QRectF& page_extent, b
 	QImage scoped_buffer;
 	if (use_page_buffer && !page_buffer)
 	{
-		scale = pixel_per_mm;
 		int w = qCeil(page_format.paper_dimensions.width() * scale);
 		int h = qCeil(page_format.paper_dimensions.height() * scale);
 #if defined (Q_OS_MACOS)
@@ -985,7 +979,7 @@ void MapPrinter::drawPage(QPainter* device_painter, const QRectF& page_extent, b
 	{
 		// Flush the buffer, reset painter
 		delete painter;
-		drawBuffer(device_painter, page_buffer, pixel2units);
+		drawBuffer(device_painter, page_buffer);
 		
 		painter = device_painter;
 		painter->setTransform(transform);
@@ -1090,7 +1084,7 @@ void MapPrinter::drawPage(QPainter* device_painter, const QRectF& page_extent, b
 		delete painter;
 		painter = nullptr;
 		device_painter->resetTransform();
-		drawBuffer(device_painter, page_buffer, pixel2units);
+		drawBuffer(device_painter, page_buffer);
 	}
 	device_painter->restore();
 }

--- a/src/core/map_printer.cpp
+++ b/src/core/map_printer.cpp
@@ -940,18 +940,20 @@ void MapPrinter::drawPage(QPainter* device_painter, const QRectF& page_extent, Q
 	const bool use_buffer_for_map = rasterModeSelected() || target == imageTarget() || engineWillRasterize();
 	bool use_page_buffer = use_buffer_for_map;
 	
-	// When we don't use a buffer for the map, i.e. when we draw in vector mode,
-	// we may need to put non-opaque foreground templates to the background
-	// in order to avoid rasterization 
-	auto first_front_template = use_buffer_for_map ? map.getFirstFrontTemplate() : map.getNumTemplates();
+	auto first_front_template = map.getFirstFrontTemplate();
 	if (options.show_templates && engineMayRasterize())
 	{
-		// Choose the first front template such that no unwanted rasterization
-		// is triggered when drawing the front templates to the device (later).
-		while (first_front_template > map.getFirstFrontTemplate()
-		       && !hasAlpha(map.getTemplate(first_front_template-1)))
+		// When we don't use a buffer for the map, i.e. when we draw in vector mode,
+		// we may need to put non-opaque foreground templates to the background
+		// in order to avoid rasterization 
+		if (!use_buffer_for_map)
 		{
-			--first_front_template;
+			first_front_template = map.getNumTemplates();
+			while (first_front_template > map.getFirstFrontTemplate()
+			       && !hasAlpha(map.getTemplate(first_front_template-1)))
+			{
+				--first_front_template;
+			}
 		}
 		
 		for (int i = 0; i < first_front_template && !use_page_buffer; ++i)

--- a/src/core/map_printer.cpp
+++ b/src/core/map_printer.cpp
@@ -952,7 +952,7 @@ void MapPrinter::drawPage(QPainter* device_painter, const QRectF& page_extent, b
 	// Translate and clip for margins and print area
 	painter->translate(-page_extent.left(), -page_extent.top());
 	
-	QTransform transform = painter->transform();
+	QTransform page_extent_transform = painter->transform();
 	
 	QRectF page_region_used(page_extent.intersected(print_area));
 	painter->setClipRect(page_region_used, Qt::ReplaceClip);
@@ -980,7 +980,7 @@ void MapPrinter::drawPage(QPainter* device_painter, const QRectF& page_extent, b
 		drawBuffer(device_painter, page_buffer);
 		
 		painter = device_painter;
-		painter->setTransform(transform);
+		painter->setTransform(page_extent_transform);
 		painter->setClipRect(page_region_used, Qt::ReplaceClip);
 	}
 	
@@ -1067,7 +1067,7 @@ void MapPrinter::drawPage(QPainter* device_painter, const QRectF& page_extent, b
 				page_buffer->fill(QColor(Qt::transparent));
 				painter = new QPainter(page_buffer);
 				painter->setRenderHints(device_painter->renderHints());
-				painter->setTransform(transform);
+				painter->setTransform(page_extent_transform);
 				painter->setClipRect(page_region_used, Qt::ReplaceClip);
 			}
 			map.drawTemplates(painter, page_region_used, map.getFirstFrontTemplate(), map.getNumTemplates() - 1, view, false);

--- a/src/core/map_printer.cpp
+++ b/src/core/map_printer.cpp
@@ -1109,11 +1109,11 @@ void MapPrinter::drawPage(QPainter* device_painter, const QRectF& page_extent, Q
 			};
 			auto grid_copy = map_grid;
 			grid_copy.setColor(qRgb(opaque(qRed(rgba)), opaque(qGreen(rgba)), opaque(qBlue(rgba))));
-			grid_copy.draw(page_painter, print_area, &map, false); // Maybe replace by page_region_used?
+			grid_copy.draw(page_painter, print_area, &map, scale_adjustment); // Maybe replace by page_region_used?
 		}
 		else
 		{
-			map_grid.draw(page_painter, print_area, &map, false); // Maybe replace by page_region_used?
+			map_grid.draw(page_painter, print_area, &map, scale_adjustment); // Maybe replace by page_region_used?
 		}
 		
 		page_painter->restore();

--- a/src/core/map_printer.cpp
+++ b/src/core/map_printer.cpp
@@ -60,8 +60,12 @@
 
 // ### A namespace which collects various string constants of type QLatin1String. ###
 
-namespace literal
-{
+namespace OpenOrienteering {
+
+namespace {
+
+namespace literal {
+
 	static const QLatin1String scale("scale");
 	static const QLatin1String resolution("resolution");
 	static const QLatin1String templates_visible("templates_visible");
@@ -86,11 +90,12 @@ namespace literal
 	static const QLatin1String print_area("print_area");
 	static const QLatin1String center_area("center_area");
 	static const QLatin1String single_page("single_page");
-}
+	
+}  // namespace literal
 
 
+}  // namespace
 
-namespace OpenOrienteering {
 
 // #### MapPrinterPageFormat ###
 

--- a/src/core/map_printer.cpp
+++ b/src/core/map_printer.cpp
@@ -827,7 +827,7 @@ void drawBuffer(QPainter* device_painter, const QImage* page_buffer)
 	device_painter->restore();
 }
 
-void MapPrinter::drawPage(QPainter* device_painter, const QRectF& page_extent, bool white_background, QImage* page_buffer) const
+void MapPrinter::drawPage(QPainter* device_painter, const QRectF& page_extent, QImage* page_buffer) const
 {
 	device_painter->save();
 	
@@ -933,21 +933,10 @@ void MapPrinter::drawPage(QPainter* device_painter, const QRectF& page_extent, b
 			device_painter->end(); // Signal error
 			return;
 		}
+		scoped_buffer.fill(QColor(Qt::white));
 		
 		page_buffer = &scoped_buffer;
 		painter = new QPainter(page_buffer);
-	}
-	
-	/*
-	 * Prepare the common background
-	 */
-	if (use_page_buffer)
-	{
-		page_buffer->fill(QColor(Qt::white));
-	}
-	else if (white_background)
-	{
-		painter->fillRect(QRect(0, 0, painter->device()->width(), painter->device()->height()), Qt::white);
 	}
 	
 	painter->setRenderHints(render_hints);
@@ -1269,7 +1258,7 @@ bool MapPrinter::printMap(QPrinter* printer)
 			}
 			else
 			{
-				drawPage(&painter, page_extent, false);
+				drawPage(&painter, page_extent);
 			}
 			
 			need_new_page = true;

--- a/src/core/map_printer.cpp
+++ b/src/core/map_printer.cpp
@@ -907,7 +907,7 @@ void MapPrinter::drawPage(QPainter* device_painter, const QRectF& page_extent, Q
 	bool use_page_buffer = use_buffer_for_map ||
 	                       use_buffer_for_background ||
 	                       use_buffer_for_foreground;
-	QImage scoped_buffer;
+	QImage local_page_buffer;
 	if (use_page_buffer && !page_buffer)
 	{
 		int w = qCeil(page_format.paper_dimensions.width() * units_per_mm);
@@ -925,17 +925,17 @@ void MapPrinter::drawPage(QPainter* device_painter, const QRectF& page_extent, Q
 		}
 #endif
 		
-		scoped_buffer = QImage(w, h, QImage::Format_RGB32);
-		if (scoped_buffer.isNull())
+		local_page_buffer = QImage(w, h, QImage::Format_RGB32);
+		if (local_page_buffer.isNull())
 		{
 			// Allocation failed
 			device_painter->restore();
 			device_painter->end(); // Signal error
 			return;
 		}
-		scoped_buffer.fill(QColor(Qt::white));
+		local_page_buffer.fill(QColor(Qt::white));
 		
-		page_buffer = &scoped_buffer;
+		page_buffer = &local_page_buffer;
 		painter = new QPainter(page_buffer);
 	}
 	

--- a/src/core/map_printer.h
+++ b/src/core/map_printer.h
@@ -280,6 +280,16 @@ public:
 	bool engineMayRasterize() const;
 	
 	/**
+	 * Returns true when the Qt print engine will have to rasterize the map.
+	 * 
+	 * Drawing a map with non-opaque colors will cause rasterization with some
+	 * Qt print engines. This functions signals when this rasterization must
+	 * take place (i.e. even when we try to avoid rasterization for templates
+	 * and grid).
+	 */
+	bool engineWillRasterize() const;
+	
+	/**
 	 * Returns true when the template will be printed non-opaquely.
 	 * 
 	 * Drawing non-opaque templates might cause rasterization with some Qt

--- a/src/core/map_printer.h
+++ b/src/core/map_printer.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2016  Kai Pastor
+ *    Copyright 2012-2018  Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -292,10 +292,10 @@ public:
 	 *  Otherwise, drawPage() may allocate a buffer with this map printer's
 	 *  resolution and size. Parameter units_per_inch has no influence on this
 	 *  buffer but refers to the logical coordinates of device_painter. */
-	void drawPage(QPainter* device_painter, float units_per_inch, const QRectF& page_extent, bool white_background, QImage* page_buffer = nullptr) const;
+	void drawPage(QPainter* device_painter, const QRectF& page_extent, bool white_background, QImage* page_buffer = nullptr) const;
 	
 	/** Draws the separations as distinct pages to the printer. */
-	void drawSeparationPages(QPrinter* printer, QPainter* device_painter, float dpi, const QRectF& page_extent) const;
+	void drawSeparationPages(QPrinter* printer, QPainter* device_painter, const QRectF& page_extent) const;
 	
 	/** Returns the current configuration. */
 	const MapPrinterConfig& config() const;

--- a/src/core/map_printer.h
+++ b/src/core/map_printer.h
@@ -267,6 +267,18 @@ public:
 	/** Returns a list of vertical page positions on the map. */
 	const std::vector< qreal >& verticalPagePositions() const;
 	
+	
+	/**
+	 * Returns true when the Qt print engine may rasterize non-opaque data.
+	 * 
+	 * Drawing non-opaque data might cause rasterization with some Qt print
+	 * engines. This function is used to detect configurations where such
+	 * rasterization may happen. The result can be comined with tests for the
+	 * data actually having alpha.
+	 */
+	bool engineMayRasterize() const;
+	
+	
 	/** Creates a printer configured according to the current settings. */
 	std::unique_ptr<QPrinter> makePrinter() const;
 	

--- a/src/core/map_printer.h
+++ b/src/core/map_printer.h
@@ -292,7 +292,7 @@ public:
 	 *  Otherwise, drawPage() may allocate a buffer with this map printer's
 	 *  resolution and size. Parameter units_per_inch has no influence on this
 	 *  buffer but refers to the logical coordinates of device_painter. */
-	void drawPage(QPainter* device_painter, const QRectF& page_extent, bool white_background, QImage* page_buffer = nullptr) const;
+	void drawPage(QPainter* device_painter, const QRectF& page_extent, QImage* page_buffer = nullptr) const;
 	
 	/** Draws the separations as distinct pages to the printer. */
 	void drawSeparationPages(QPrinter* printer, QPainter* device_painter, const QRectF& page_extent) const;

--- a/src/core/map_printer.h
+++ b/src/core/map_printer.h
@@ -51,6 +51,7 @@ namespace OpenOrienteering {
 
 class Map;
 class MapView;
+class Template;
 
 
 /** The MapPrinterPageFormat is a complete description of page properties. */
@@ -277,6 +278,16 @@ public:
 	 * data actually having alpha.
 	 */
 	bool engineMayRasterize() const;
+	
+	/**
+	 * Returns true when the template will be printed non-opaquely.
+	 * 
+	 * Drawing non-opaque templates might cause rasterization with some Qt
+	 * print engines. This function is used to detect this case. It considers
+	 * the template's state and hasAlpha() property as well the view's
+	 * visibility configuration for the given template.
+	 */
+	bool hasAlpha(const Template* temp) const;
 	
 	
 	/** Creates a printer configured according to the current settings. */

--- a/src/core/map_view.cpp
+++ b/src/core/map_view.cpp
@@ -64,6 +64,16 @@ namespace literal
 
 namespace OpenOrienteering {
 
+// ### TemplateVisibility ###
+
+bool TemplateVisibility::hasAlpha() const
+{
+	return visible && opacity > 0 && opacity < 1;
+}
+
+
+// ### MapView ###
+
 const double MapView::zoom_in_limit = 512;
 const double MapView::zoom_out_limit = 1 / 16.0;
 
@@ -534,6 +544,28 @@ void MapView::setOverprintingSimulationEnabled(bool enabled)
 		overprinting_simulation_enabled = enabled;
 		emit visibilityChanged(VisibilityFeature::OverprintingEnabled, enabled);
 	}
+}
+
+
+
+bool MapView::hasAlpha() const
+{
+	auto map_visibility = effectiveMapVisibility();
+	if (map_visibility.hasAlpha() || map->hasAlpha())
+		return true;
+	
+	if (grid_visible && map->getGrid().hasAlpha())
+		return true;
+		
+	for (int i = 0; i < map->getNumTemplates(); ++i)
+	{
+		auto temp = map->getTemplate(i);
+		auto visibility = getTemplateVisibility(temp);
+		if (visibility.hasAlpha() || temp->hasAlpha())
+			return true;
+	}
+	
+	return false;
 }
 
 

--- a/src/core/map_view.h
+++ b/src/core/map_view.h
@@ -57,6 +57,9 @@ public:
 	
 	/** Visibility flag */
 	bool visible;
+	
+	/** Returns true when the template is visible but not opaque. */
+	bool hasAlpha() const;
 };
 
 bool operator==(TemplateVisibility lhs, TemplateVisibility rhs);
@@ -321,6 +324,12 @@ public:
 	
 	/** Enables or disables overprinting simulation. */
 	void setOverprintingSimulationEnabled(bool enabled);
+	
+	
+	/**
+	 * Returns true if any of the visible elements is not opaque.
+	 */
+	bool hasAlpha() const;
 	
 	
 	/** Temporarily blocks automatic template loading on visibility changes. */

--- a/src/gui/map/map_widget.cpp
+++ b/src/gui/map/map_widget.cpp
@@ -1313,7 +1313,7 @@ void MapWidget::updateMapCache(bool use_background)
 		map->draw(&painter, config);
 	
 	if (view->isGridVisible())
-		map->drawGrid(&painter, map_view_rect, true);
+		map->drawGrid(&painter, map_view_rect);
 	
 	// Finish drawing
 	painter.end();

--- a/src/gui/print_widget.cpp
+++ b/src/gui/print_widget.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2017  Kai Pastor
+ *    Copyright 2012-2018  Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -1202,7 +1202,7 @@ void PrintWidget::exportToImage()
 	
 	// Export the map
 	QPainter p(&image);
-	map_printer->drawPage(&p, map_printer->getOptions().resolution, map_printer->getPrintArea(), true, &image);
+	map_printer->drawPage(&p, map_printer->getPrintArea(), true, &image);
 	p.end();
 	if (!image.save(path))
 	{

--- a/src/gui/print_widget.cpp
+++ b/src/gui/print_widget.cpp
@@ -951,6 +951,15 @@ void PrintWidget::setOptions(const MapPrinterOptions& options)
 	auto scale = int(options.scale);
 	different_scale_edit->setValue(scale);
 	differentScaleEdited(scale);
+	
+	if (options.mode != MapPrinterOptions::Raster
+	    && map_printer->engineWillRasterize())
+	{
+		QMessageBox::warning(this, tr("Error"),
+		                     tr("The map contains transparent elements"
+		                        " which require the raster mode."));
+		map_printer->setMode(MapPrinterOptions::Raster);
+	}
 }
 
 void PrintWidget::onVisibilityChanged()

--- a/src/gui/print_widget.cpp
+++ b/src/gui/print_widget.cpp
@@ -1195,6 +1195,8 @@ void PrintWidget::exportToImage()
 	image.setDotsPerMeterX(dots_per_meter);
 	image.setDotsPerMeterY(dots_per_meter);
 	
+	image.fill(QColor(Qt::white));
+	
 #if 0  // Pointless unless drawPage drives the event loop and sends progress
 	PrintProgressDialog progress(map_printer, main_window);
 	progress.setWindowTitle(tr("Export map ..."));
@@ -1202,7 +1204,7 @@ void PrintWidget::exportToImage()
 	
 	// Export the map
 	QPainter p(&image);
-	map_printer->drawPage(&p, map_printer->getPrintArea(), true, &image);
+	map_printer->drawPage(&p, map_printer->getPrintArea(), &image);
 	p.end();
 	if (!image.save(path))
 	{

--- a/src/gui/print_widget.cpp
+++ b/src/gui/print_widget.cpp
@@ -1089,7 +1089,7 @@ void PrintWidget::showTemplatesClicked(bool checked)
 
 void PrintWidget::checkTemplateConfiguration()
 {
-	bool visibility = vector_mode_button->isChecked() && show_templates_check->isChecked();
+	bool visibility = map_printer->engineMayRasterize() && show_templates_check->isChecked();
 	templates_warning_icon->setVisible(visibility);
 	templates_warning_text->setVisible(visibility);
 }

--- a/src/gui/print_widget.cpp
+++ b/src/gui/print_widget.cpp
@@ -31,6 +31,7 @@
 #include <QAbstractButton> // IWYU pragma: keep
 #include <QButtonGroup>
 #include <QCheckBox>
+#include <QColor>
 #include <QComboBox>
 #include <QDialog>
 #include <QDialogButtonBox>

--- a/src/gui/print_widget.cpp
+++ b/src/gui/print_widget.cpp
@@ -413,11 +413,15 @@ void PrintWidget::setTask(PrintWidget::TaskFlags type)
 				
 			case EXPORT_PDF_TASK:
 				map_printer->setTarget(MapPrinter::pdfTarget());
+				if (active)
+					setOptions(map_printer->getOptions());
 				emit taskChanged(tr("PDF export"));
 				break;
 				
 			case EXPORT_IMAGE_TASK:
 				map_printer->setTarget(MapPrinter::imageTarget());
+				if (active)
+					setOptions(map_printer->getOptions());
 				policy = SinglePage;
 				if (policy_combo->itemData(policy_combo->currentIndex()) != policy)
 				{

--- a/src/templates/template.cpp
+++ b/src/templates/template.cpp
@@ -828,6 +828,15 @@ void Template::setAdjustmentDirty(bool value)
 		map->setTemplatesDirty();
 }
 
+
+
+bool Template::hasAlpha() const
+{
+	return template_state == Template::Loaded;
+}
+
+
+
 const std::vector<QByteArray>& Template::supportedExtensions()
 {
 	static std::vector<QByteArray> extensions;

--- a/src/templates/template.h
+++ b/src/templates/template.h
@@ -516,6 +516,15 @@ public:
 	inline bool isAdjustmentDirty() const {return adjustment_dirty;}
 	void setAdjustmentDirty(bool value);
 	
+	
+	/**
+	 * Returns true if the template has elements which are not opaque.
+	 * 
+	 * The default implementation returns true when the template is loaded.
+	 */
+	virtual bool hasAlpha() const;
+	
+	
 	// Static
 	/**
 	 * Returns the filename extensions supported by known subclasses.

--- a/src/templates/template_image.cpp
+++ b/src/templates/template_image.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2017 Kai Pastor
+ *    Copyright 2012-2018 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -40,6 +40,7 @@
 #include <QLineEdit>
 #include <QList>
 #include <QMessageBox>
+#include <QPaintEngine>
 #include <QPainter>
 #include <QPen>
 #include <QPoint>
@@ -61,6 +62,7 @@
 #include "gui/georeferencing_dialog.h"
 #include "gui/select_crs_dialog.h"
 #include "gui/util_gui.h"
+#include "printsupport/advanced_pdf_printer.h"
 #include "templates/world_file.h"
 #include "util/transformation.h"
 #include "util/util.h"
@@ -289,6 +291,20 @@ void TemplateImage::drawTemplate(QPainter* painter, const QRectF& clip_rect, dou
 	
 	painter->setRenderHint(QPainter::SmoothPixmapTransform);
 	painter->setOpacity(opacity);
+	// QTBUG-70752: QPdfEngine fails to properly apply constant opacity on
+	// images. This can be worked around by setting a real brush.
+	// Fixed in Qt 5.12.0.
+	/// \todo Fix image opacity in AdvancedPdfEngine
+#if QT_VERSION < 0x051200
+	if (painter->paintEngine()->type() == QPaintEngine::Pdf
+	    || painter->paintEngine()->type() == AdvancedPdfPrinter::paintEngineType())
+#else
+	if (painter->paintEngine()->type() == AdvancedPdfPrinter::paintEngineType())
+#endif
+	{
+		if (opacity < 1)
+			painter->setBrush(Qt::white);
+	}
 	painter->drawImage(QPointF(-image.width() * 0.5, -image.height() * 0.5), image);
 	painter->setRenderHint(QPainter::SmoothPixmapTransform, false);
 }

--- a/src/templates/template_map.cpp
+++ b/src/templates/template_map.cpp
@@ -163,6 +163,13 @@ Template* TemplateMap::duplicateImpl() const
 	return copy;
 }
 
+
+bool TemplateMap::hasAlpha() const
+{
+	return template_map && template_map->hasAlpha();
+}
+
+
 const Map* TemplateMap::templateMap() const
 {
 	return template_map.get();

--- a/src/templates/template_map.h
+++ b/src/templates/template_map.h
@@ -75,6 +75,9 @@ public:
 	QRectF getTemplateExtent() const override;
 	
 	
+	bool hasAlpha() const override;
+	
+	
 	const Map* templateMap() const;
 	
 protected:

--- a/src/templates/template_track.cpp
+++ b/src/templates/template_track.cpp
@@ -413,6 +413,13 @@ int TemplateTrack::getTemplateBoundingBoxPixelBorder()
 	return 10e8;
 }
 
+
+bool TemplateTrack::hasAlpha() const
+{
+	return false;
+}
+
+
 Template* TemplateTrack::duplicateImpl() const
 {
 	TemplateTrack* copy = new TemplateTrack(template_path, map);

--- a/src/templates/template_track.h
+++ b/src/templates/template_track.h
@@ -75,6 +75,7 @@ public:
     QRectF calculateTemplateBoundingBox() const override;
     int getTemplateBoundingBoxPixelBorder() override;
 	
+	bool hasAlpha() const override;
 	
 	/// Draws all tracks.
 	void drawTracks(QPainter* painter, bool on_screen) const;

--- a/test/map_t.cpp
+++ b/test/map_t.cpp
@@ -31,6 +31,7 @@
 #include "core/map_color.h"
 #include "core/map_printer.h" // IWYU pragma: keep
 #include "core/map_view.h"
+#include "core/objects/object.h"
 #include "core/objects/symbol_rule_set.h"
 #include "core/symbols/symbol.h"
 #include "core/symbols/point_symbol.h"
@@ -221,6 +222,77 @@ void MapTest::importTest()
 	auto symbol_map = map.importMap(imported_map, Map::CompleteImport, nullptr, -1, false);
 	QCOMPARE(map.getNumObjects(), original_size + imported_map.getNumObjects());
 	QCOMPARE(symbol_map.size(), imported_map.getNumSymbols());
+}
+
+
+
+void MapTest::hasAlpha()
+{
+	Map map;
+	MapView view{ &map };
+	QVERIFY(map.loadFrom(examples_dir.absoluteFilePath(QStringLiteral("complete map.omap")), nullptr, &view, false, false));
+	QVERIFY(!map.hasAlpha());
+	
+	QVERIFY(map.getNumParts() > 0);
+	QVERIFY(map.getPart(0)->getNumObjects() > 0);
+	
+	auto* symbol = [&map]() -> Symbol* {
+	               auto* symbol = map.getPart(0)->getObject(0)->getSymbol();
+	               return symbol ? map.getSymbol(map.findSymbolIndex(symbol)) : nullptr;
+	}();
+	QVERIFY(symbol);
+	
+	auto* color = [&map, symbol]() -> MapColor* {
+	              auto* color = symbol->guessDominantColor();
+	              return color ? map.getMapColor(map.findColorIndex(color)) : nullptr;
+	}();
+	QVERIFY(color);
+	
+	color->setOpacity(0.5);
+	QVERIFY(map.hasAlpha());
+	
+	color->setOpacity(0);
+	QVERIFY(!map.hasAlpha());
+	
+	color->setOpacity(0.5);
+	for (int i = 0; i < map.getNumSymbols(); ++i)
+	{
+		if (map.getSymbol(i)->containsColor(color))
+			map.getSymbol(i)->setHidden(true);
+	}
+	QVERIFY(!map.hasAlpha());
+	
+	view.setAllTemplatesHidden(false);
+	view.setGridVisible(false);
+	QVERIFY(!view.hasAlpha());
+	
+	view.setMapVisibility({1, true});
+	QVERIFY(!view.hasAlpha());
+	
+	view.setMapVisibility({1, false});
+	QVERIFY(!view.hasAlpha());
+	
+	view.setMapVisibility({0.5, false});
+	QVERIFY(!view.hasAlpha());
+	
+	view.setMapVisibility({0.5, true});
+	QVERIFY(view.hasAlpha());
+	
+	view.setAllTemplatesHidden(true);
+	QVERIFY(!view.hasAlpha());
+	
+	view.setGridVisible(true);
+	MapGrid grid;
+	
+	grid.setColor(qRgb(0, 0, 0));
+	map.setGrid(grid);
+	QVERIFY(!grid.hasAlpha());
+	QVERIFY(!view.hasAlpha());
+	
+	grid.setColor(qRgba(0, 0, 0, 128));
+	map.setGrid(grid);
+	QVERIFY(grid.hasAlpha());
+	QVERIFY(view.hasAlpha());
 }
 
 

--- a/test/map_t.h
+++ b/test/map_t.h
@@ -48,6 +48,9 @@ private slots:
 	void importTest_data();
 	void importTest();
 	
+	/** Tests hasAlpha() functions. */
+	void hasAlpha();
+	
 	/** Basic tests for symbol set replacements. */
 	void crtFileTest();
 	


### PR DESCRIPTION
This is a series of patches make the core MapPrinter::drawPage() function much easier to understand. It is a significant modification to the `master` branch, but I don't see a simpler way to eventually fix #1163.

There is still room for improvement, now more obvious than before, and more easy to add on top:
- Reduced opacity of the map "layer" will still trigger rasterization even when vector mode is selected - i.e. we must enforce 100% opacity for vector mode.
- In a similar way, rasterization might possibly be triggered from vector templates which are not 100% opaque. We might handle them like raster templates and rasterize them in the background, or we may handle them like the map "layer" and draw them 100% opaque in the foreground.
- I still need to verify if non-opaque colors in a vector drawing cause rasterization, too.
- From here, it is easy to make the code reuse the same temporary buffer allocation for drawing the map and foreground "layers".