### PR TITLE
TemplateMap: Fix RenderConfig::scaling

### DIFF
--- a/src/core/renderables/renderable.h
+++ b/src/core/renderables/renderable.h
@@ -90,7 +90,7 @@ public:
 	QRectF  bounding_box; ///< The bounding box of the area to be drawn.
 	                      ///  Given in map coordinates.
 	
-	qreal   scaling;      ///< The scaling.
+	qreal   scaling;      ///< The scaling expressed as pixels per mm.
 	                      ///  Used to calculate the final object sizes when
                           ///  ForceMinSize is set.
     

--- a/src/templates/template_map.cpp
+++ b/src/templates/template_map.cpp
@@ -25,6 +25,7 @@
 
 #include <QtGlobal>
 #include <QByteArray>
+#include <QPaintEngine>
 #include <QPainter>
 #include <QRectF>
 #include <QStringList>
@@ -36,6 +37,7 @@
 #include "core/map.h"
 #include "core/map_coord.h"
 #include "core/renderables/renderable.h"
+#include "gui/util_gui.h"
 #include "util/transformation.h"
 #include "util/util.h"
 
@@ -139,9 +141,22 @@ void TemplateMap::drawTemplate(QPainter* painter, const QRectF& clip_rect, doubl
 	}
 	
 	RenderConfig::Options options;
+	auto scaling = scale;
 	if (on_screen)
+	{
 		options |= RenderConfig::Screen;
-	RenderConfig config = { *(template_map.get()), transformed_clip_rect, scale, options, qreal(opacity) };
+		/// \todo Get the actual screen's resolution.
+		scaling = Util::mmToPixelPhysical(scale);
+	}
+	else
+	{
+		auto dpi = painter->device()->physicalDpiX();
+		if (!dpi)
+			dpi = painter->device()->logicalDpiX();
+		if (dpi > 0)
+			scaling *= dpi / 25.4;
+	}
+	RenderConfig config = { *template_map, transformed_clip_rect, scaling, options, qreal(opacity) };
 	// TODO: introduce template-specific options, adjustable by the user, to allow changing some of these parameters
 	template_map->draw(painter, config);
 }


### PR DESCRIPTION
When drawing the map, RenderConfig::scaling must be set to the number
of pixels per mm. Fixes #1186.