### PR TITLE
Drawing tool: Prevent data loss on tool change

### DIFF
--- a/src/tools/draw_line_and_area_tool.cpp
+++ b/src/tools/draw_line_and_area_tool.cpp
@@ -81,6 +81,12 @@ void DrawLineAndAreaTool::leaveEvent(QEvent* event)
 		map()->clearDrawingBoundingBox();
 }
 
+void DrawLineAndAreaTool::finishEditing()
+{
+	finishDrawing();
+	MapEditorTool::finishEditing();
+}
+
 void DrawLineAndAreaTool::setDrawingSymbol(const Symbol* symbol)
 {
 	// Avoid using deleted symbol

--- a/src/tools/draw_line_and_area_tool.h
+++ b/src/tools/draw_line_and_area_tool.h
@@ -63,6 +63,7 @@ public:
 	~DrawLineAndAreaTool() override;
 	
 	void leaveEvent(QEvent* event) override;
+	void finishEditing() override;
 	
 signals:
 	void dirtyRectChanged(const QRectF& rect);


### PR DESCRIPTION
This is a minimalistic fix for the most annoying part of issue #1175 ("Selecting Edit or Pan tool aborts path drawing"). I'll look into the interaction with Pan tool in issue #988 ("Fluent drawing enhancement").

Please consider the fix for v0.8.4.