### PR TITLE
[RFC] Resize multiple objects at once

### DIFF
--- a/src/tools/scale_tool.h
+++ b/src/tools/scale_tool.h
@@ -57,14 +57,20 @@ protected:
 	void dragMove() override;
 	void dragFinish() override;
 	
+	bool keyPressEvent(QKeyEvent* event) override;
+	bool keyReleaseEvent(QKeyEvent* event) override;
+	bool mouseDoubleClickEvent(QMouseEvent *event, const MapCoordF &map_coord, MapWidget *widget) override;
+
 	void drawImpl(QPainter* painter, MapWidget* widget) override;
 	
 	int updateDirtyRectImpl(QRectF& rect) override;
 	void objectSelectionChangedImpl() override;
 	
 	MapCoordF scaling_center;
+	MapCoordF prev_scaling_center;
 	double reference_length = 0;
 	double scaling_factor   = 1;
+	bool group_scaling = true;
 };
 
 


### PR DESCRIPTION
While making a 1:15 000 map, I noticed that most of the buildings imported from OSM are below minimum dimensions in my country. That led to necessity to enlarge objects en-mass to 160 % of their original size. First iteration was done by hand, then I thought how to automate that.

This morning I gave a shot to implementation and this is where it led. I added a new mode of operation to _Scale tool_. When holding `Ctrl` key, the resize operation uses object center (center of the enclosing rectangle) as the origin. As a bonus, double click bring in a dialog allowing to enter the scaling value in numeric format.

`Ctrl` + drag to resize multiple objects:
![image](https://user-images.githubusercontent.com/5584406/52121281-62816680-261f-11e9-924a-06a4a9eff119.png)

Double click to enter numeric value:
![image](https://user-images.githubusercontent.com/5584406/52121440-eb000700-261f-11e9-8945-1367ccde033e.png)

Known patch deficiencies:
- it does combine two changes in one (new mode of operation and numeric input)
- status line text is not updated
- double click for numeric input is not aligned with [a seemingly reasonable UI design rule](https://stackoverflow.com/a/4628577): double click function should be extension of function triggered by single click
- when holding `Ctrl` during double click, `Ctrl` key release is consumed by the modal dialog

How do you like the idea? Any opinions about the user interface?