### PR TITLE
README: Add Repology and Weblate badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # OpenOrienteering Mapper
+[![Packaging status](https://repology.org/badge/tiny-repos/openorienteering-mapper.svg)](https://repology.org/metapackage/openorienteering-mapper/versions)
+[![Translation status](https://hosted.weblate.org/widgets/openorienteering/-/svg-badge.svg)](https://hosted.weblate.org/engage/openorienteering/?utm_source=widget)
 
 ![Mapper Screenshot](https://www.openorienteering.org/mapper-manual/pages/images/main_window.png)
 


### PR DESCRIPTION
* Repology badge shows the openorienteering package available in downstream repositories.
* Weblate badge shows the percentage of the openorienteering project that has been translated.

Preview commit at https://github.com/luzpaz/mapper/blob/README-badges/README.md