### PR TITLE
Case of convergence change affecting declination

### DIFF
--- a/src/gui/georeferencing_dialog.cpp
+++ b/src/gui/georeferencing_dialog.cpp
@@ -456,27 +456,33 @@ void GeoreferencingDialog::reset()
 
 void GeoreferencingDialog::accept()
 {
-	float declination_change_degrees = georef->getDeclination() - initial_georef->getDeclination();
-	if ( !grivation_locked &&
-	     declination_change_degrees != 0 &&
-	     (map->getNumObjects() > 0 || map->getNumTemplates() > 0) )
+	if (grivation_locked)
 	{
-		int result = QMessageBox::question(this, tr("Declination change"), tr("The declination has been changed. Do you want to rotate the map content accordingly, too?"), QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
-		if (result == QMessageBox::Cancel)
+		georef->updateGrivation();
+	}
+	else
+	{
+		float declination_change_degrees = georef->getDeclination() - initial_georef->getDeclination();
+		if ( declination_change_degrees != 0 &&
+		     (map->getNumObjects() > 0 || map->getNumTemplates() > 0) )
 		{
-			return;
-		}
-		else if (result == QMessageBox::Yes)
-		{
-			RotateMapDialog dialog(this, map);
-			dialog.setWindowModality(Qt::WindowModal);
-			dialog.setRotationDegrees(declination_change_degrees);
-			dialog.setRotateAroundGeorefRefPoint();
-			dialog.setAdjustDeclination(false);
-			dialog.showAdjustDeclination(false);
-			int result = dialog.exec();
-			if (result == QDialog::Rejected)
+			int result = QMessageBox::question(this, tr("Declination change"), tr("The declination has been changed. Do you want to rotate the map content accordingly, too?"), QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
+			if (result == QMessageBox::Cancel)
+			{
 				return;
+			}
+			else if (result == QMessageBox::Yes)
+			{
+				RotateMapDialog dialog(this, map);
+				dialog.setWindowModality(Qt::WindowModal);
+				dialog.setRotationDegrees(declination_change_degrees);
+				dialog.setRotateAroundGeorefRefPoint();
+				dialog.setAdjustDeclination(false);
+				dialog.showAdjustDeclination(false);
+				int result = dialog.exec();
+				if (result == QDialog::Rejected)
+					return;
+			}
 		}
 	}
 	
@@ -613,6 +619,7 @@ void GeoreferencingDialog::keepCoordsChanged()
 		grivation_locked = false;
 		original_declination = georef->getDeclination();
 		updateGrivation();
+		georef->updateGrivation();
 	}
 	reset_button->setEnabled(true);
 }


### PR DESCRIPTION
I had a case in which a template became misaligned with the map, and tracked it down to the relationship between declination and grivation getting messed up by a georeferencing dialog.
To reproduce with my data in Tennessee, USA
  1.  Create map, open the georeferencing dialog, and set EPSG6575 into the georeferencing.
  2.  Set the reference point with EPSG coordinates
      922801  222772
  3.  DO NOT touch the declination, and click OK on the georeferencing dialog.
  4.  Import Willow_Springs_Park_contours.dxf to the map.
      Observe contour tile is drawn with EPSG6575 grid aligned to screen, i.e. grivation is 0.
  5.  Open Template control and add Willow_Springs_Park_slope.gif (with .gfw)
      with same georef as map.
  6.  Open georeferencing dialog. Shows both declination and grivation = 0.
  7.  Change declination to -6.87, choose option to "rotate map".
  8.  Observe template no longer aligned to map.
The above mentioned files can be downloaded from https://pkturner.org/1206.zip.

This PR has a suggested fix. In the existing code, when a CRS is added to Georeferencing, the declination and grivation are set if grivation is not locked. These are set via a call to setGeographicReferencePoint or setProjectedReferencePoint. I believe that any time either of these functions is called for a valid CRS, the convergence should be calculated and the declination and grivation should end up differing from one another accordingly. When one of these functions does not update grivation, it should update declination.