### PR TITLE
Scale tool enhancement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,7 @@ if(NOT TARGET PROJ4::proj)
 	set(PROJ4_FOUND false)
 	find_package(PROJ4 MODULE REQUIRED)
 endif()
+add_definitions(-DACCEPT_USE_OF_DEPRECATED_PROJ_API_H)
 
 if(Mapper_USE_GDAL)
 	find_package(GDAL REQUIRED)

--- a/src/gui/util_gui.cpp
+++ b/src/gui/util_gui.cpp
@@ -38,6 +38,8 @@
 #include <QLabel>
 #include <QLocale>
 #include <QMessageBox>
+#include <QPainter>
+#include <QPen>
 #include <QProcess>
 #include <QProcessEnvironment>
 #include <QSpacerItem>
@@ -230,6 +232,27 @@ namespace Util {
 	
 	
 	
+	namespace Marker
+	{
+		void drawCenterMarker(QPainter* painter, const QPointF& center)
+		{
+			const auto saved_hints = painter->renderHints();
+			painter->setRenderHint(QPainter::Antialiasing, true);
+			
+			painter->setPen(Qt::white);
+			painter->setBrush(Qt::NoBrush);
+			
+			/// \todo Use dpi-scaled dimensions
+			painter->drawEllipse(center, 3, 3);
+			painter->setPen(Qt::black);
+			painter->drawEllipse(center, 4, 4);
+			
+			painter->setRenderHints(saved_hints);
+		}
+	}  // namespace Marker
+
+
+
 	QSpacerItem* SpacerItem::create(const QWidget* widget)
 	{
 		const int spacing = widget->style()->pixelMetric(QStyle::PM_LayoutTopMargin);

--- a/src/gui/util_gui.cpp
+++ b/src/gui/util_gui.cpp
@@ -237,15 +237,19 @@ namespace Util {
 		void drawCenterMarker(QPainter* painter, const QPointF& center)
 		{
 			const auto saved_hints = painter->renderHints();
-			painter->setRenderHint(QPainter::Antialiasing, true);
+			painter->setRenderHint(QPainter::Antialiasing, Settings::getInstance().getSettingCached(Settings::MapDisplay_Antialiasing).toBool());
 			
-			painter->setPen(Qt::white);
+			const auto larger_radius = mmToPixelPhysical(1.1);
+			const auto smaller_radius = larger_radius*3/4;
+			
+			auto pen = QPen(Qt::white);
+			pen.setWidthF(larger_radius - smaller_radius);
+			painter->setPen(pen);
 			painter->setBrush(Qt::NoBrush);
-			
-			/// \todo Use dpi-scaled dimensions
-			painter->drawEllipse(center, 3, 3);
-			painter->setPen(Qt::black);
-			painter->drawEllipse(center, 4, 4);
+			painter->drawEllipse(center, smaller_radius, smaller_radius);
+			pen.setColor(Qt::black);
+			painter->setPen(pen);
+			painter->drawEllipse(center, larger_radius, larger_radius);
 			
 			painter->setRenderHints(saved_hints);
 		}

--- a/src/gui/util_gui.h
+++ b/src/gui/util_gui.h
@@ -30,6 +30,8 @@ class QCheckBox;
 class QDoubleSpinBox;
 class QLabel;
 class QObject;
+class QPainter;
+class QPointF;
 class QSpacerItem;
 class QSpinBox;
 class QWidget;
@@ -203,6 +205,13 @@ namespace Util
 	
 	
 	
+	namespace Marker
+	{
+		/** Center marker sign for rotate and scale tools. */
+		void drawCenterMarker(QPainter* painter, const QPointF& center);
+	}  // namespace Marker
+
+
 	namespace Headline
 	{
 		/**

--- a/src/tools/rotate_tool.cpp
+++ b/src/tools/rotate_tool.cpp
@@ -41,6 +41,7 @@
 #include "core/objects/object.h"
 #include "gui/modifier_key.h"
 #include "gui/map/map_widget.h"
+#include "gui/util_gui.h"
 #include "tools/tool.h"
 #include "tools/tool_helpers.h"
 #include "util/util.h"
@@ -160,18 +161,7 @@ void RotateTool::drawImpl(QPainter* painter, MapWidget* widget)
 	map()->drawSelection(painter, true, widget);
 	painter->restore();
 	
-	const auto saved_hints = painter->renderHints();
-	painter->setRenderHint(QPainter::Antialiasing, true);
-	
-	painter->setPen(Qt::white);
-	painter->setBrush(Qt::NoBrush);
-	
-	/// \todo Use dpi-scaled dimensions
-	painter->drawEllipse(center, 3, 3);
-	painter->setPen(Qt::black);
-	painter->drawEllipse(center, 4, 4);
-	
-	painter->setRenderHints(saved_hints);
+	Util::Marker::drawCenterMarker(painter, center);
 }
 
 

--- a/src/tools/scale_tool.cpp
+++ b/src/tools/scale_tool.cpp
@@ -36,6 +36,7 @@
 #include "core/map.h"
 #include "core/map_view.h"
 #include "gui/map/map_widget.h"
+#include "gui/util_gui.h"
 #include "core/objects/object.h"
 #include "gui/modifier_key.h"
 #include "gui/util_gui.h"
@@ -170,26 +171,14 @@ void ScaleTool::drawImpl(QPainter* painter, MapWidget* widget)
 {
 	drawSelectionOrPreviewObjects(painter, widget);
 	
-	// /todo - this is the same circle as in rotate tool
-	// move the function to Util and use the shared code
-	auto draw_center_sign = [&](MapCoordF circle_center){
-		painter->setPen(Qt::white);
-		painter->setBrush(Qt::NoBrush);
-
-		QPoint center = widget->mapToViewport(circle_center).toPoint();
-		painter->drawEllipse(center, 3, 3);
-		painter->setPen(Qt::black);
-		painter->drawEllipse(center, 4, 4);
-	};
-
 	if (using_scaling_center)
 	{
-		draw_center_sign(scaling_center);
+		Util::Marker::drawCenterMarker(painter, widget->mapToViewport(scaling_center));
 	}
 	else
 	{
 		for (const auto* object : map()->selectedObjects())
-			draw_center_sign(MapCoordF(object->getExtent().center()));
+			Util::Marker::drawCenterMarker(painter, widget->mapToViewport(object->getExtent().center()));
 	}
 }
 

--- a/src/tools/scale_tool.h
+++ b/src/tools/scale_tool.h
@@ -57,6 +57,9 @@ protected:
 	void dragMove() override;
 	void dragFinish() override;
 	
+	bool keyPressEvent(QKeyEvent* event) override;
+	bool keyReleaseEvent(QKeyEvent* event) override;
+
 	void drawImpl(QPainter* painter, MapWidget* widget) override;
 	
 	int updateDirtyRectImpl(QRectF& rect) override;
@@ -65,6 +68,7 @@ protected:
 	MapCoordF scaling_center;
 	double reference_length = 0;
 	double scaling_factor   = 1;
+	bool using_scaling_center = true;
 };
 
 


### PR DESCRIPTION
This is continuation of PR#1203 which got closed inadvertently.

This pull request adds a new operation mode to Scale tool. When holding `Ctrl` key, the resize operation uses object center (center of the enclosing rectangle) as the origin. Further patches in the series refine the code change in sense of code deduplication and TODO removal.

`Ctrl` + drag to resize multiple objects:
![image](https://user-images.githubusercontent.com/5584406/54029830-1be8d400-41aa-11e9-85dd-878f5052d146.png)
