### PR TITLE
Rewrite object tags undo save/load

### DIFF
--- a/src/undo/object_undo.cpp
+++ b/src/undo/object_undo.cpp
@@ -104,14 +104,14 @@ void ObjectModifyingUndoStep::saveImpl(QXmlStreamWriter& xml) const
 	
 	XmlElementWriter element(xml, QLatin1String("affected_objects"));
 	element.writeAttribute(QLatin1String("part"), part_index);
-	int size = modified_objects.size();
+	auto size = modified_objects.size();
 	if (size > 8)
 		element.writeAttribute(QLatin1String("count"), size);
 	
-	for (int i = 0; i < size; ++i)
+	for (auto object_index : modified_objects)
 	{
 		XmlElementWriter ref(xml, QLatin1String("ref"));
-		ref.writeAttribute(QLatin1String("object"), modified_objects[i]);
+		ref.writeAttribute(QLatin1String("object"), object_index);
 	}
 }
 
@@ -121,9 +121,10 @@ void ObjectModifyingUndoStep::loadImpl(QXmlStreamReader& xml, SymbolDictionary& 
 	{
 		XmlElementReader element(xml);
 		part_index = element.attribute<int>(QLatin1String("part"));
-		int size = element.attribute<int>(QLatin1String("count"));
+		auto size = element.attribute<std::size_t>(QLatin1String("count"));
 		if (size)
 			modified_objects.reserve(size);
+		
 		while (xml.readNextStartElement())
 		{
 			if (xml.name() == QLatin1String("ref"))

--- a/src/undo/object_undo.h
+++ b/src/undo/object_undo.h
@@ -39,6 +39,8 @@ class QXmlStreamWriter;
 namespace OpenOrienteering {
 
 class Map;
+class XmlElementReader;
+class XmlElementWriter;
 
 
 /** 
@@ -114,6 +116,13 @@ protected:
 	void saveImpl(QXmlStreamWriter& xml) const override;
 	
 	/**
+	 * Saves object details to the the xml stream.
+	 * 
+	 * The default implemenentation does nothing.
+	 */
+	virtual void saveObject(XmlElementWriter& xml, int index) const;
+	
+	/**
 	 * Loads undo properties from the the xml stream.
 	 * 
 	 * Implementations in derived classes shall first check the element's name
@@ -121,6 +130,13 @@ protected:
 	 * implementation.
 	 */
 	void loadImpl(QXmlStreamReader& xml, SymbolDictionary& symbol_dict) override;
+	
+	/**
+	 * Loads object details from the the xml stream.
+	 * 
+	 * The default implemenentation does nothing.
+	 */
+	virtual void loadObject(XmlElementReader& xml, int index);
 	
 	
 private:
@@ -390,9 +406,6 @@ public:
 
 /**
  * Undo step which modifies object tags.
- * 
- * Note: For reduced file size, this implementation copies, not calls,
- * ObjectModifyingUndoStep::saveImpl()/ObjectModifyingUndoStep::loadImpl().
  */
 class ObjectTagsUndoStep : public ObjectModifyingUndoStep
 {
@@ -406,9 +419,9 @@ public:
 	UndoStep* undo() override;
 	
 protected:
-	void saveImpl(QXmlStreamWriter& xml) const override;
+	void saveObject(XmlElementWriter& xml, int index) const override;
 	
-	void loadImpl(QXmlStreamReader& xml, SymbolDictionary& symbol_dict) override;
+	void loadObject(XmlElementReader& xml, int index) override;
 	
 	typedef std::map<int, Object::Tags> ObjectTagsMap;
 	


### PR DESCRIPTION
The first commit is just a modernization. The second one fixes a clazy warning which pointed to a DRY violation. This should result in one compiler warning disappearing in the new CI, so that's why I'm inviting more reviewers than usual.