### PR TITLE
GeoreferencingTest: Check PROJ's pj_set_finder()

### DIFF
--- a/test/georeferencing_t.cpp
+++ b/test/georeferencing_t.cpp
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2012-2015 Kai Pastor
+ *    Copyright 2012-2015, 2019 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -218,6 +218,33 @@ void GeoreferencingTest::testProjection()
 		QCOMPARE(QString::number(lat_lon.latitude(), 'f'), QString::number(latitude, 'f'));
 	if (fabs(lat_lon.longitude() - longitude) > (max_angl_error / cos(latitude)))
 		QCOMPARE(QString::number(lat_lon.longitude(), 'f'), QString::number(longitude, 'f'));
+}
+
+
+
+namespace {
+	static bool finder_called;
+
+	const char* projFinderTestFakeCRS(const char* name)
+	{
+		finder_called = true;
+		[name]() {
+			QCOMPARE(name, "fake_crs");
+		}();
+		return nullptr;
+	}
+}
+
+void GeoreferencingTest::testPjSetFinder()
+{
+	finder_called = false;
+	
+	pj_set_finder(&projFinderTestFakeCRS);
+	QVERIFY(!finder_called);
+	
+	Georeferencing fake_georef;
+	fake_georef.setProjectedCRS(QStringLiteral("Fake CRS"), QString::fromLatin1("+init=fake_crs:123"));
+	QVERIFY(finder_called);
 }
 
 

--- a/test/georeferencing_t.h
+++ b/test/georeferencing_t.h
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2012-2015 Kai Pastor
+ *    Copyright 2012-2015, 2019 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -69,6 +69,14 @@ private slots:
 	void testProjection();
 	
 	void testProjection_data();
+	
+	/**
+	 * Tests whether the `pj_set_finder()` function is working.
+	 * The `pj_set_finder()` function is deprecated API in PROJ 6.0.0, but a 
+	 * substitute is not available. Mapper relies on this function to extract
+	 * data files on Android. This test covers this function in native builds.
+	 */
+	void testPjSetFinder();
 	
 private:
 	Georeferencing georef;


### PR DESCRIPTION
pj_set_finder() is deprecated API since PROJ 6.0.0. Cf. GH-1214.