### PR TITLE
SymbolRenderWidget: Fix crash when deleting multiple symbols

### DIFF
--- a/src/gui/widgets/symbol_render_widget.cpp
+++ b/src/gui/widgets/symbol_render_widget.cpp
@@ -841,8 +841,12 @@ void SymbolRenderWidget::deleteSymbols()
 		map->deleteSymbol(map->findSymbolIndex(symbol));
 	}
 	
-	if (selected_symbols.empty() && map->getFirstSelectedObject())
-		selectSingleSymbol(map->getFirstSelectedObject()->getSymbol());
+	if (selected_symbols.empty()) {
+		if (map->getFirstSelectedObject())
+			selectSingleSymbol(map->getFirstSelectedObject()->getSymbol());
+		else
+			selectSingleSymbol(-1);
+	}
 }
 
 void SymbolRenderWidget::duplicateSymbol()


### PR DESCRIPTION
When deleting more than half of the symbols at one go (and the second one that is clicked on is after the first one), and then creating a new symbol; Mapper crashes.

This crash is due to the fact that current_symbol_index is still at the index of the last symbol clicked on and is now out of bounds so AddSymbol crashes when trying to add a new symbol there.

Solve it by explicitly setting the selected symbol (and therefore current_symbol_index) to the invalid -1