### PR TITLE
Allow tool switch when selecting symbol in scribble mode

### DIFF
--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -2270,7 +2270,7 @@ void MapEditorController::selectedSymbolsChanged()
 		if (symbol && !symbol->isHidden() && !symbol->isProtected() && current_tool)
 		{
 			// Auto-switch to a draw tool when selecting a symbol under certain conditions
-			if (current_tool->toolType() == MapEditorTool::Pan
+			if (current_tool->toolType() == MapEditorTool::Pan || current_tool->toolType() == MapEditorTool::Scribble
 			    || ((current_tool->toolType() == MapEditorTool::EditLine || current_tool->toolType() == MapEditorTool::EditPoint) && map->getNumSelectedObjects() == 0))
 			{
 				current_tool->switchToDefaultDrawTool(active_symbol);

--- a/src/templates/template_tool_paint.cpp
+++ b/src/templates/template_tool_paint.cpp
@@ -140,7 +140,7 @@ int PaintOnTemplateTool::erase_width = 4;
 
 
 PaintOnTemplateTool::PaintOnTemplateTool(MapEditorController* editor, QAction* tool_action)
-: MapEditorTool(editor, Other, tool_action)
+: MapEditorTool(editor, Scribble, tool_action)
 {
 	connect(map(), &Map::templateDeleted, this, &PaintOnTemplateTool::templateDeleted);
 }

--- a/src/tools/tool.h
+++ b/src/tools/tool.h
@@ -89,6 +89,7 @@ public:
 		DrawText      = 7,
 		DrawFreehand  = 8,
 		Pan           = 9,
+		Scribble      = 10,
 		Other         = 0
 	};
 	


### PR DESCRIPTION
Usability defect pointed out by mlerjen in issue #1143. I chose `Scribble` name as it's an established name for the tool among its users and `PaintOnTemplate` feels clumsy.