### PR TITLE
[WIP] SymbolRenderWidget: Add Yes To All action for symbol delete #1201

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,7 @@ if(NOT TARGET PROJ4::proj)
 	set(PROJ4_FOUND false)
 	find_package(PROJ4 MODULE REQUIRED)
 endif()
+add_definitions(-DACCEPT_USE_OF_DEPRECATED_PROJ_API_H)
 
 if(Mapper_USE_GDAL)
 	find_package(GDAL REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -203,6 +203,7 @@ set(Mapper_Common_SRCS
   
   undo/map_part_undo.cpp
   undo/object_undo.cpp
+  undo/symbol_undo.cpp
   undo/undo.cpp
   undo/undo_manager.cpp
   

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -2081,15 +2081,24 @@ int Map::addObject(Object* object, int part_index)
 
 void Map::deleteObject(Object* object, bool remove_only)
 {
+	auto object_ptr = releaseObject(object);
+	if (!remove_only)
+	{
+		delete object_ptr;
+	}
+}
+
+Object* Map::releaseObject(Object* object)
+{
 	for (MapPart* part : parts)
 	{
-		if (part->deleteObject(object, remove_only))
-			return;
+		if (auto object_found = part->releaseObject(object))
+			return object_found;
 	}
 	
-	qCritical().nospace() << this << "::deleteObject(" << object << "," << remove_only << "): Object not found. This is a bug.";
-	if (!remove_only)
-		delete object;
+	qCritical().nospace() << this << "::deleteObject(" << object << "): Object not found. This is a bug.";
+
+	return nullptr;
 }
 
 void Map::setObjectsDirty()

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -1600,6 +1600,11 @@ void Map::setSymbol(Symbol* symbol, int pos)
 
 void Map::deleteSymbol(int pos)
 {
+	delete releaseSymbol(pos);
+}
+
+Symbol* Map::releaseSymbol(int pos)
+{
 	if (deleteAllObjectsWithSymbol(symbols[pos]))
 		undo_manager->clear();
 	
@@ -1613,9 +1618,7 @@ void Map::deleteSymbol(int pos)
 			updateAllObjectsWithSymbol(symbols[i]);
 	}
 	
-	// Delete the symbol
-	Symbol* temp = symbols[pos];
-	delete symbols[pos];
+	auto symbol_ptr = symbols[pos];
 	symbols.erase(symbols.begin() + pos);
 	
 	if (symbols.empty())
@@ -1624,8 +1627,9 @@ void Map::deleteSymbol(int pos)
 		updateAllMapWidgets();
 	}
 	
-	emit symbolDeleted(pos, temp);
+	emit symbolDeleted(pos, symbol_ptr);
 	setSymbolsDirty();
+	return symbol_ptr;
 }
 
 int Map::findSymbolIndex(const Symbol* symbol) const

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -887,7 +887,7 @@ std::size_t Map::deleteIrregularObjects()
 	{
 		for (auto part : parts)
 		{
-			if (part->deleteObject(object, false))
+			if (part->deleteObject(object))
 			{
 				++result;
 				goto next_object;
@@ -940,7 +940,7 @@ void Map::deleteSelectedObjects()
 			if (index >= 0)
 			{
 				undo_step->addObject(index, *obj);
-				part->deleteObject(index, true);
+				part->releaseObject(index);
 			}
 			else
 			{
@@ -1958,7 +1958,7 @@ void Map::removePart(std::size_t index)
 	
 	// FIXME: This loop should move to MapPart.
 	while(part->getNumObjects())
-		part->deleteObject(0, false);
+		part->deleteObject(0);
 	
 	parts.erase(parts.begin() + index);
 	if (current_part_index >= index)
@@ -2020,7 +2020,7 @@ int Map::reassignObjectsToMapPart(std::vector<int>::const_iterator first, std::v
 		if (current_part_index == source && isObjectSelected(object))
 			removeObjectFromSelection(object, false);
 		
-		source_part->deleteObject(object, true);
+		source_part->releaseObject(object);
 		target_part->addObject(object);
 	}
 	
@@ -2044,7 +2044,7 @@ int Map::mergeParts(std::size_t source, std::size_t destination)
 	for (auto i = source_part->getNumObjects(); i > 0 ; --i)
 	{
 		Object* object = source_part->getObject(0);
-		source_part->deleteObject(0, true);
+		source_part->releaseObject(0);
 		
 		int index = target_part->getNumObjects();
 		target_part->addObject(object, index);
@@ -2079,13 +2079,9 @@ int Map::addObject(Object* object, int part_index)
 	return object_index;
 }
 
-void Map::deleteObject(Object* object, bool remove_only)
+void Map::deleteObject(Object* object)
 {
-	auto object_ptr = releaseObject(object);
-	if (!remove_only)
-	{
-		delete object_ptr;
-	}
+	delete releaseObject(object);
 }
 
 Object* Map::releaseObject(Object* object)

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -62,6 +62,7 @@
 #include "templates/template.h"
 #include "undo/map_part_undo.h"
 #include "undo/object_undo.h"
+#include "undo/symbol_undo.h"
 #include "undo/undo.h"
 #include "undo/undo_manager.h"
 #include "util/util.h"
@@ -708,10 +709,11 @@ QHash<const Symbol*, Symbol*> Map::importMap(
 	QHash<const Symbol*, Symbol*> symbol_map;
 	if ((mode & 0x0f) != ColorImport)
 	{
+		auto* undo_step = new CombinedUndoStep(this);
 		if (imported_map.getNumSymbols() > 0)
 		{
 			// Import symbols
-			symbol_map = importSymbols(imported_map, color_map, symbol_insert_pos, merge_duplicate_symbols, symbol_filter);
+			symbol_map = importSymbols(imported_map, color_map, symbol_insert_pos, merge_duplicate_symbols, symbol_filter, undo_step);
 		}
 		
 		if ((mode & 0x0f) != SymbolImport
@@ -720,7 +722,6 @@ QHash<const Symbol*, Symbol*> Map::importMap(
 			// Import parts like this:
 			//  - if the other map has only one part, import it into the current part
 			//  - else check if there is already a part with an equal name for every part to import and import into this part if found, else create a new part
-			auto* undo_step = new CombinedUndoStep(this);
 			for (const auto* part_to_import : imported_map.parts)
 			{
 				MapPart* dest_part = nullptr;
@@ -761,6 +762,10 @@ QHash<const Symbol*, Symbol*> Map::importMap(
 				
 				current_part_index = std::size_t(findPartIndex(temp_current_part));
 			}
+		}
+
+		if (undo_step->getNumSubSteps())
+		{
 			push(undo_step);
 		}
 	}
@@ -1409,7 +1414,8 @@ QHash<const Symbol*, Symbol*> Map::importSymbols(
         const MapColorMap& color_map,
         int insert_pos,
         bool merge_duplicates,
-        const std::vector<bool>& filter )
+        const std::vector<bool>& filter,
+        CombinedUndoStep* undo_step)
 {
 	QHash<const Symbol*, Symbol*> out_pointermap;
 	
@@ -1448,6 +1454,10 @@ QHash<const Symbol*, Symbol*> Map::importSymbols(
 	for (auto* symbol : created_symbols)
 	{
 		addSymbol(symbol, insert_pos);
+		if (undo_step)
+		{
+			undo_step->push(new SymbolUndoStep(this, SymbolUndoStep::RemoveSymbol, symbol, insert_pos));
+		}
 		++insert_pos;
 	}
 	
@@ -1561,7 +1571,7 @@ Symbol* Map::getSymbol(int i)
 	return const_cast<Symbol*>(static_cast<const Map*>(this)->getSymbol(i));
 }
 
-void Map::setSymbol(Symbol* symbol, int pos)
+std::unique_ptr<Symbol> Map::setSymbol(Symbol* symbol, int pos)
 {
 	Symbol* old_symbol = symbols[pos];
 	
@@ -1592,10 +1602,11 @@ void Map::setSymbol(Symbol* symbol, int pos)
 	symbols[pos] = symbol;
 	emit symbolChanged(pos, symbol, old_symbol);
 	setSymbolsDirty();
-	delete old_symbol;
 	
 	if (object_with_symbol_selected)
 		emit selectedObjectEdited();
+
+	return std::unique_ptr<Symbol>(old_symbol);
 }
 
 void Map::deleteSymbol(int pos)
@@ -1605,8 +1616,7 @@ void Map::deleteSymbol(int pos)
 
 Symbol* Map::releaseSymbol(int pos)
 {
-	if (deleteAllObjectsWithSymbol(symbols[pos]))
-		undo_manager->clear();
+	deleteAllObjectsWithSymbol(symbols[pos]);
 	
 	int size = (int)symbols.size();
 	for (int i = 0; i < size; ++i)

--- a/src/core/map.h
+++ b/src/core/map.h
@@ -833,6 +833,14 @@ public:
 	 * TODO: make a separate method "removeObject()", remove_only is misleading!
 	 */
 	void deleteObject(Object* object, bool remove_only);
+
+	/**
+	 * Relinquish object ownership.
+	 *
+	 * Searches map parts and returns pointer if the object was found.
+	 * Otherwise nullptr is returned.
+	 */
+	Object* releaseObject(Object* object);
 	
 	/**
 	 * Marks the objects as "dirty", i.e. as having unsaved changes.

--- a/src/core/map.h
+++ b/src/core/map.h
@@ -827,12 +827,10 @@ public:
 	
 	/**
 	 * Deletes the given object from the map.
-	 * remove_only will remove the object from the map, but not call "delete object";
-	 * be sure to call removeObjectFromSelection() if necessary.
 	 * 
-	 * TODO: make a separate method "removeObject()", remove_only is misleading!
+	 * Be sure to call removeObjectFromSelection() if necessary.
 	 */
-	void deleteObject(Object* object, bool remove_only);
+	void deleteObject(Object* object);
 
 	/**
 	 * Relinquish object ownership.

--- a/src/core/map.h
+++ b/src/core/map.h
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <functional>
+#include <memory>
 #include <set>
 #include <vector>
 
@@ -54,6 +55,7 @@ class QWidget;
 namespace OpenOrienteering {
 
 class CombinedSymbol;
+class CombinedUndoStep;
 class Georeferencing;
 class LineSymbol;
 class MapColor;
@@ -511,7 +513,7 @@ public:
 	 * Replaces the symbol at the given index with another symbol.
 	 * Emits symbolChanged() and possibly selectedObjectEdited().
 	 */
-	void setSymbol(Symbol* symbol, int pos);
+	std::unique_ptr<Symbol> setSymbol(Symbol* symbol, int pos);
 	
 	/**
 	 * Adds the given symbol at the specified index.
@@ -1489,6 +1491,9 @@ private:
 	 * 
 	 * If a filter is given, imports only the symbols for which filter[color_index] == true.
 	 * Imported symbols are placed at insert_pos (if positive), or after the existing symbols.
+	 *
+	 * @param undo_step Optional pointer to CombinedUndoStep where importSymbols() will store symbol removal operations.
+	 *
 	 * Returns a mapping from original symbols (in other) to imported symbols.
 	 */
 	QHash<const Symbol*, Symbol*> importSymbols(
@@ -1496,7 +1501,8 @@ private:
 	        const MapColorMap& color_map,
 	        int insert_pos = -1,
 	        bool merge_duplicates = true,
-	        const std::vector<bool>& filter = {}
+	        const std::vector<bool>& filter = {},
+	        CombinedUndoStep* undo_step = nullptr
 	);
 	
 	

--- a/src/core/map.h
+++ b/src/core/map.h
@@ -534,6 +534,10 @@ public:
 	 * Emits symbolDeleted().
 	 */
 	void deleteSymbol(int pos);
+
+	/** Remove symbol from internal structures
+	 */
+	Symbol* releaseSymbol(int pos);
 	
 	/**
 	 * Loops over all symbols, looking for the given symbol pointer.

--- a/src/core/map_part.cpp
+++ b/src/core/map_part.cpp
@@ -164,18 +164,15 @@ void MapPart::addObject(Object* object, int pos)
 		map->updateAllMapWidgets();
 }
 
-void MapPart::deleteObject(int pos, bool remove_only)
+void MapPart::deleteObject(int pos)
 {
-	auto object_ptr = releaseObject(pos);
-	if (!remove_only)
-		delete object_ptr;
+	delete releaseObject(pos);
 }
 
-bool MapPart::deleteObject(Object* object, bool remove_only)
+bool MapPart::deleteObject(Object* object)
 {
 	auto object_ptr = releaseObject(object);
-	if (!remove_only && object_ptr)
-		delete object_ptr;
+	delete object_ptr;
 
 	return object_ptr;
 }

--- a/src/core/map_part.cpp
+++ b/src/core/map_part.cpp
@@ -166,29 +166,43 @@ void MapPart::addObject(Object* object, int pos)
 
 void MapPart::deleteObject(int pos, bool remove_only)
 {
+	auto object_ptr = releaseObject(pos);
+	if (!remove_only)
+		delete object_ptr;
+}
+
+bool MapPart::deleteObject(Object* object, bool remove_only)
+{
+	auto object_ptr = releaseObject(object);
+	if (!remove_only && object_ptr)
+		delete object_ptr;
+
+	return object_ptr;
+}
+
+Object* MapPart::releaseObject(int pos)
+{
 	map->removeRenderablesOfObject(objects[pos], true);
-	if (remove_only)
-		objects[pos]->setMap(nullptr);
-	else
-		delete objects[pos];
+	auto object_to_return = objects[pos];
 	objects.erase(objects.begin() + pos);
 	
 	if (objects.empty() && map->getNumObjects() == 0)
 		map->updateAllMapWidgets();
+
+	return object_to_return;
 }
 
-bool MapPart::deleteObject(Object* object, bool remove_only)
+Object* MapPart::releaseObject(Object* object)
 {
 	int size = objects.size();
 	for (int i = size - 1; i >= 0; --i)
 	{
 		if (objects[i] == object)
 		{
-			deleteObject(i, remove_only);
-			return true;
+			return releaseObject(i);
 		}
 	}
-	return false;
+	return nullptr;
 }
 
 std::unique_ptr<UndoStep> MapPart::importPart(const MapPart* other, const QHash<const Symbol*, Symbol*>& symbol_map, const QTransform& transform, bool select_new_objects)

--- a/src/core/map_part.h
+++ b/src/core/map_part.h
@@ -169,6 +169,22 @@ public:
 	 */
 	bool deleteObject(Object* object, bool remove_only);
 	
+	/**
+	  * Relinquish object ownership.
+	  *
+	  * This method removes object references from MapPart's internal
+	  * structures. Object deletion is caller's responsibility.
+	  */
+	Object* releaseObject(int pos);
+
+	/**
+	  * Relinquish object ownership.
+	  *
+	  * This method removes object references from MapPart's internal
+	  * structures. Object deletion is caller's responsibility.
+	  */
+	Object* releaseObject(Object* object);
+
 	
 	/**
 	 * Imports the contents another part into this part.

--- a/src/core/map_part.h
+++ b/src/core/map_part.h
@@ -144,7 +144,7 @@ public:
 	 * Adds the object as new object at the end.
 	 */
 	void addObject(Object* object);
-	
+
 	/**
 	 * Adds the object as new object at the given index.
 	 */
@@ -152,22 +152,15 @@ public:
 	
 	/**
 	 * Deleted the object from the given index.
-	 * 
-	 * If remove_only is set, does not call "delete object".
-	 * 
-	 * @todo Make a separate method "removeObject()", this is misleading!
 	 */
-	void deleteObject(int pos, bool remove_only);
+	void deleteObject(int pos);
 	
 	/**
 	 * Deleted the object from the given index.
 	 * 
-	 * If remove_only is set, does not call "delete object".
 	 * Returns if the object was found in this part.
-	 * 
-	 * @todo Make a separate method "removeObject()", this is misleading!
 	 */
-	bool deleteObject(Object* object, bool remove_only);
+	bool deleteObject(Object* object);
 	
 	/**
 	  * Relinquish object ownership.

--- a/src/core/objects/boolean_tool.cpp
+++ b/src/core/objects/boolean_tool.cpp
@@ -234,7 +234,7 @@ bool BooleanTool::executeForObjects(PathObject* subject, PathObjects& in_objects
 		if (op != Difference || object == subject)
 		{
 			map->removeObjectFromSelection(object, false);
-			map->getCurrentPart()->deleteObject(object, true);
+			map->getCurrentPart()->releaseObject(object);
 			object->setMap(map); // necessary so objects are saved correctly
 		}
 	}

--- a/src/core/objects/object_operations.h
+++ b/src/core/objects/object_operations.h
@@ -109,7 +109,7 @@ namespace ObjectOp
 		void operator()(Object* object, MapPart* part, int object_index) const
 		{
 			if (!object->setSymbol(new_symbol, false))
-				part->deleteObject(object_index, false);
+				part->deleteObject(object_index);
 			else
 				object->update();
 		}
@@ -120,7 +120,7 @@ namespace ObjectOp
 	{
 		void operator()(const Object*, MapPart* part, int object_index) const
 		{
-			part->deleteObject(object_index, false);
+			part->deleteObject(object_index);
 		}
 	};
 }

--- a/src/fileformats/file_import_export.cpp
+++ b/src/fileformats/file_import_export.cpp
@@ -164,7 +164,7 @@ void Importer::validate()
 				else
 				{
 					// There is no undefined symbol for this type of object, delete the object
-					part->deleteObject(o, false);
+					part->deleteObject(o);
 					--o;
 					continue;
 				}

--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -2716,7 +2716,7 @@ void MapEditorController::switchSymbolClicked()
 		map->clearObjectSelection(false);
 		for (auto object : old_objects)
 		{
-			map->deleteObject(object, true);
+			map->releaseObject(object);
 		}
 		for (auto object : new_objects)
 		{
@@ -3140,7 +3140,7 @@ void MapEditorController::connectPathsClicked()
 		for (auto object : deleted_objects)
 		{
 			map->removeObjectFromSelection(object, false);
-			map->getCurrentPart()->deleteObject(object, false);
+			map->getCurrentPart()->deleteObject(object);
 		}
 	}
 	
@@ -3727,7 +3727,7 @@ void MapEditorController::removeMapPart()
 				--i;
 				auto object = part->getObject(i);
 				add_step->addObject(i, object);
-				part->deleteObject(object, true);
+				part->releaseObject(object);
 			}
 			while (i > 0);
 			

--- a/src/gui/symbols/point_symbol_editor_widget.cpp
+++ b/src/gui/symbols/point_symbol_editor_widget.cpp
@@ -306,7 +306,7 @@ PointSymbolEditorWidget::~PointSymbolEditorWidget()
 	if (isVisible())
 		setEditorActive(false);
 	if (permanent_preview)
-		map->deleteObject(midpoint_object, false);
+		map->deleteObject(midpoint_object);
 }
 
 void PointSymbolEditorWidget::setEditorActive(bool active)
@@ -331,7 +331,7 @@ void PointSymbolEditorWidget::setEditorActive(bool active)
 		controller->setEditorActivity(nullptr);
 		if (!permanent_preview && midpoint_object)
 		{
-			map->deleteObject(midpoint_object, false);
+			map->deleteObject(midpoint_object);
 			midpoint_object = nullptr;
 		}
 	}

--- a/src/gui/symbols/symbol_setting_dialog.cpp
+++ b/src/gui/symbols/symbol_setting_dialog.cpp
@@ -247,7 +247,7 @@ void SymbolSettingDialog::createPreviewMap()
 	symbol_icon_label->setPixmap(QPixmap::fromImage(symbol->getIcon(source_map)));
 	
 	for (auto& object : preview_objects)
-		preview_map->deleteObject(object, false);
+		preview_map->deleteObject(object);
 	
 	preview_objects.clear();
 	

--- a/src/gui/widgets/symbol_render_widget.cpp
+++ b/src/gui/widgets/symbol_render_widget.cpp
@@ -834,12 +834,26 @@ void SymbolRenderWidget::deleteSymbols()
 	}
 	
 	// delete symbols in order
+	bool yes_to_all = false;
 	for (auto* symbol : saved_selection)
 	{
-		if (map->existsObjectWithSymbol(symbol))
+		if (!yes_to_all && map->existsObjectWithSymbol(symbol))
 		{
-			if (QMessageBox::warning(this, tr("Confirmation"), tr("The map contains objects with the symbol \"%1\". Deleting it will delete those objects and clear the undo history! Do you really want to do that?").arg(symbol->getName()), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
+			auto response = QMessageBox::warning(this, tr("Confirmation"),
+			                                     tr("The map contains objects with the symbol \"%1\"."
+			                                        " Deleting it will delete those objects and clear the undo history!"
+			                                        " Do you really want to do that?").arg(symbol->getName()),
+			                                     QMessageBox::Yes | QMessageBox::No | QMessageBox::YesToAll);
+			switch (response)
+			{
+			case QMessageBox::No:
 				continue;
+			case QMessageBox::YesToAll:
+				yes_to_all = true;
+				break;
+			default:
+				;
+			}
 		}
 		map->deleteSymbol(map->findSymbolIndex(symbol));
 	}

--- a/src/gui/widgets/symbol_render_widget.cpp
+++ b/src/gui/widgets/symbol_render_widget.cpp
@@ -46,6 +46,10 @@
 #include "core/symbols/text_symbol.h"
 #include "gui/symbols/symbol_setting_dialog.h"
 #include "gui/widgets/symbol_tooltip.h"
+#include "core/objects/object_operations.h"
+#include "undo/object_undo.h"
+#include "undo/symbol_undo.h"
+#include "undo/undo.h"
 #include "util/backports.h"
 #include "util/overriding_shortcut.h"
 
@@ -799,7 +803,10 @@ void SymbolRenderWidget::editSymbol()
 	dialog.setWindowModality(Qt::WindowModal);
 	if (dialog.exec() == QDialog::Accepted)
 	{
-		map->setSymbol(dialog.getNewSymbol().release(), current_symbol_index);
+		auto old_symbol_ptr = map->setSymbol(dialog.getNewSymbol().release(), current_symbol_index);
+		map->push(new SymbolUndoStep(map, SymbolUndoStep::ChangeSymbol,
+		                             map->getSymbol(current_symbol_index),
+		                             old_symbol_ptr.release()));
 	}
 }
 
@@ -835,13 +842,14 @@ void SymbolRenderWidget::deleteSymbols()
 	
 	// delete symbols in order
 	bool yes_to_all = false;
+	auto undo_step = new CombinedUndoStep(map);
 	for (auto* symbol : saved_selection)
 	{
 		if (!yes_to_all && map->existsObjectWithSymbol(symbol))
 		{
 			auto response = QMessageBox::warning(this, tr("Confirmation"),
 			                                     tr("The map contains objects with the symbol \"%1\"."
-			                                        " Deleting it will delete those objects and clear the undo history!"
+			                                        " Deleting it will delete those objects!"
 			                                        " Do you really want to do that?").arg(symbol->getName()),
 			                                     QMessageBox::Yes | QMessageBox::No | QMessageBox::YesToAll);
 			switch (response)
@@ -855,8 +863,24 @@ void SymbolRenderWidget::deleteSymbols()
 				;
 			}
 		}
-		map->deleteSymbol(map->findSymbolIndex(symbol));
+		const auto symbol_pos = map->findSymbolIndex(symbol);
+		auto undo_objects_step = new AddObjectsUndoStep(map);
+		auto move_object_to_undo = [this, undo_objects_step](Object* object_ptr, MapPart* part, int object_index) {
+			Q_UNUSED(part); // FIXME - part information is lost
+			map->releaseObject(object_ptr);
+			if (map->isObjectSelected(object_ptr))
+			{
+				map->removeObjectFromSelection(object_ptr, false);
+			}
+			undo_objects_step->addObject(object_index, object_ptr);
+		};
+		map->applyOnMatchingObjects(move_object_to_undo, ObjectOp::HasSymbol{symbol});
+		undo_step->push(undo_objects_step);
+
+		undo_step->push(new SymbolUndoStep(map, SymbolUndoStep::AddSymbol, const_cast<Symbol*>(symbol), symbol_pos));
+		map->releaseSymbol(symbol_pos);
 	}
+	map->push(undo_step);
 	
 	if (selected_symbols.empty() && map->getFirstSelectedObject())
 		selectSingleSymbol(map->getFirstSelectedObject()->getSymbol());
@@ -866,7 +890,9 @@ void SymbolRenderWidget::duplicateSymbol()
 {
 	Q_ASSERT(current_symbol_index >= 0);
 	
-	map->addSymbol(duplicate(*map->getSymbol(current_symbol_index)).release(), current_symbol_index + 1);
+	const auto symbol_ptr = duplicate(*map->getSymbol(current_symbol_index)).release();
+	map->addSymbol(symbol_ptr, current_symbol_index + 1);
+	map->push(new SymbolUndoStep(map, SymbolUndoStep::RemoveSymbol, symbol_ptr, current_symbol_index + 1));
 	selectSingleSymbol(current_symbol_index + 1);
 }
 
@@ -1130,7 +1156,9 @@ bool SymbolRenderWidget::newSymbol(Symbol* prototype)
 		return false;
 	
 	int pos = (current_symbol_index >= 0) ? current_symbol_index : map->getNumSymbols();
-	map->addSymbol(dialog.getNewSymbol().release(), pos);
+	const auto symbol_ptr = dialog.getNewSymbol().release();
+	map->addSymbol(symbol_ptr, pos);
+	map->push(new SymbolUndoStep(map, SymbolUndoStep::RemoveSymbol, symbol_ptr, pos));
 	// Ensure that a change in selection is detected
 	selectSingleSymbol(-1);
 	selectSingleSymbol(pos);

--- a/src/tools/cut_tool.cpp
+++ b/src/tools/cut_tool.cpp
@@ -736,7 +736,7 @@ void CutTool::replaceObject(Object* object, const std::vector<PathObject*>& repl
 	auto add_step = new AddObjectsUndoStep(map);
 	add_step->addObject(map_part->findObjectIndex(object), object);
 	map->removeObjectFromSelection(object, false);
-	map->deleteObject(object, true);
+	map->releaseObject(object);
 	
 	auto delete_step = new DeleteObjectsUndoStep(map);
 	for (auto new_object : replacement)

--- a/src/tools/cutout_tool.cpp
+++ b/src/tools/cutout_tool.cpp
@@ -85,7 +85,7 @@ void CutoutTool::initImpl()
 	
 	cutout_object_index = map()->getCurrentPart()->findObjectIndex(cutout_object);
 	map()->removeObjectFromSelection(cutout_object, true);
-	map()->deleteObject(cutout_object, true);
+	map()->releaseObject(cutout_object);
 }
 
 void CutoutTool::drawImpl(QPainter* painter, MapWidget* widget)

--- a/src/tools/edit_point_tool.cpp
+++ b/src/tools/edit_point_tool.cpp
@@ -251,7 +251,7 @@ void EditPointTool::clickPress()
 						int index = part->findObjectIndex(hover_object);
 						Q_ASSERT(index >= 0);
 						undo_step->addObject(index, hover_object);
-						map()->deleteObject(hover_object, true);
+						map()->releaseObject(hover_object);
 						map()->push(undo_step);
 						map()->setObjectsDirty();
 						map()->emitSelectionEdited();
@@ -681,7 +681,7 @@ void EditPointTool::finishEditing()
 			int index = part->findObjectIndex(text_object);
 			if (index >= 0)
 			{
-				part->deleteObject(index, true);
+				part->releaseObject(index);
 				
 				auto undo_step = new AddObjectsUndoStep(map);
 				undo_step->addObject(index, text_object);

--- a/src/undo/object_undo.cpp
+++ b/src/undo/object_undo.cpp
@@ -318,7 +318,7 @@ UndoStep* DeleteObjectsUndoStep::undo()
 	for (int i = 0; i < size; ++i)
 	{
 		undo_step->addObject(modified_objects[i], part->getObject(modified_objects[i]));
-		part->deleteObject(modified_objects[i], true);
+		part->releaseObject(modified_objects[i]);
 	}
 	
 	return undo_step;
@@ -390,7 +390,7 @@ void AddObjectsUndoStep::removeContainedObjects(bool emit_selection_changed)
 			map->removeObjectFromSelection(objects[i], false);
 			object_deselected = true;
 		}
-		part->deleteObject(objects[i], true);
+		part->releaseObject(objects[i]);
 		map->setObjectsDirty();
 	}
 	if (object_deselected && emit_selection_changed)
@@ -467,7 +467,7 @@ UndoStep* SwitchPartUndoStep::undo()
 			auto object = target->getObject(i);
 			if (map->getCurrentPart() == target && map->isObjectSelected(object))
 				map->removeObjectFromSelection(object, false);
-			target->deleteObject(i, true);
+			target->releaseObject(i);
 			source->addObject(object);
 		});
 	}
@@ -480,7 +480,7 @@ UndoStep* SwitchPartUndoStep::undo()
 			auto object = source->getObject(i);
 			if (map->getCurrentPart() == source && map->isObjectSelected(object))
 				map->removeObjectFromSelection(object, false);
-			source->deleteObject(i, true);
+			source->releaseObject(i);
 			target->addObject(object, j);
 		});
 	}

--- a/src/undo/object_undo.cpp
+++ b/src/undo/object_undo.cpp
@@ -151,8 +151,7 @@ ObjectCreatingUndoStep::ObjectCreatingUndoStep(Type type, Map* map)
 : ObjectModifyingUndoStep(type, map)
 , valid(true)
 {
-	connect(map, &Map::symbolChanged, this, &ObjectCreatingUndoStep::symbolChanged);
-	connect(map, &Map::symbolDeleted, this, &ObjectCreatingUndoStep::symbolDeleted);
+	// nothing
 }
 
 ObjectCreatingUndoStep::~ObjectCreatingUndoStep()
@@ -224,31 +223,6 @@ void ObjectCreatingUndoStep::loadImpl(QXmlStreamReader& xml, SymbolDictionary& s
 	}
 	else
 		ObjectModifyingUndoStep::loadImpl(xml, symbol_dict);
-}
-
-void ObjectCreatingUndoStep::symbolChanged(int pos, const Symbol* new_symbol, const Symbol* old_symbol)
-{
-	Q_UNUSED(pos);
-	int size = (int)objects.size();
-	for (int i = 0; i < size; ++i)
-	{
-		if (objects[i]->getSymbol() == old_symbol)
-			objects[i]->setSymbol(new_symbol, true);
-	}
-}
-
-void ObjectCreatingUndoStep::symbolDeleted(int pos,  const Symbol* old_symbol)
-{
-	Q_UNUSED(pos);
-	int size = (int)objects.size();
-	for (int i = 0; i < size; ++i)
-	{
-		if (objects[i]->getSymbol() == old_symbol)
-		{
-			valid = false;
-			return;
-		}
-	}
 }
 
 
@@ -522,8 +496,7 @@ SwitchSymbolUndoStep::SwitchSymbolUndoStep(Map* map)
 : ObjectModifyingUndoStep(SwitchSymbolUndoStepType, map)
 , valid(true)
 {
-	connect(map, &Map::symbolChanged, this, &SwitchSymbolUndoStep::symbolChanged);
-	connect(map, &Map::symbolDeleted, this, &SwitchSymbolUndoStep::symbolDeleted);
+	// nothing
 }
 
 SwitchSymbolUndoStep::~SwitchSymbolUndoStep()
@@ -601,31 +574,6 @@ void SwitchSymbolUndoStep::loadImpl(QXmlStreamReader& xml, SymbolDictionary& sym
 	else
 		ObjectModifyingUndoStep::loadImpl(xml, symbol_dict);
 }
-
-void SwitchSymbolUndoStep::symbolChanged(int pos, const Symbol* new_symbol, const Symbol* old_symbol)
-{
-	Q_UNUSED(pos);
-	int size = (int)target_symbols.size();
-	for (int i = 0; i < size; ++i)
-	{
-		if (target_symbols[i] == old_symbol)
-			target_symbols[i] = new_symbol;
-	}
-}
-void SwitchSymbolUndoStep::symbolDeleted(int pos, const Symbol* old_symbol)
-{
-	Q_UNUSED(pos);
-	int size = (int)target_symbols.size();
-	for (int i = 0; i < size; ++i)
-	{
-		if (target_symbols[i] == old_symbol)
-		{
-			valid = false;
-			return;
-		}
-	}
-}
-
 
 
 // ### SwitchDashesUndoStep ###

--- a/src/undo/object_undo.h
+++ b/src/undo/object_undo.h
@@ -198,17 +198,6 @@ public:
 	void getModifiedObjects(int, ObjectSet&) const override;
 	
 	
-public slots:
-	/**
-	 * Adapts the symbol pointers of objects referencing the changed symbol.
-	 */
-	virtual void symbolChanged(int pos, const Symbol* new_symbol, const Symbol* old_symbol);
-	
-	/**
-	 * Invalidates the undo step if a contained object references the deleted symbol.
-	 */
-	virtual void symbolDeleted(int pos, const Symbol* old_symbol);
-	
 protected:
 	/**
 	 * @copybrief UndoStep::saveImpl()
@@ -353,11 +342,6 @@ public:
 	
 	UndoStep* undo() override;
 	
-	
-public slots:
-	virtual void symbolChanged(int pos, const Symbol* new_symbol, const Symbol* old_symbol);
-	
-	virtual void symbolDeleted(int pos, const Symbol* old_symbol);
 	
 protected:
 	void saveImpl(QXmlStreamWriter& xml) const override;

--- a/src/undo/symbol_undo.cpp
+++ b/src/undo/symbol_undo.cpp
@@ -1,0 +1,173 @@
+/*
+ *    Copyright 2019 Libor Pecháček
+ *
+ *    This file is part of OpenOrienteering.
+ *
+ *    OpenOrienteering is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OpenOrienteering is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <QDebug>
+#include <QLatin1String>
+#include <QXmlStreamReader>
+#include <QXmlStreamWriter>
+
+#include "core/map.h"
+#include "core/symbols/symbol.h"
+#include "core/symbols/symbol.h"
+#include "symbol_undo.h"
+#include "util/xml_stream_util.h"
+
+
+namespace literal
+{
+	const QLatin1String name("name");
+	const QLatin1String pos("pos");
+	const QLatin1String type("type");
+	const QLatin1String add("add");
+	const QLatin1String change("change");
+	const QLatin1String remove("remove");
+}  // namespace literal
+
+
+namespace OpenOrienteering {
+
+SymbolUndoStep::SymbolUndoStep(Map* map, SymbolUndoStep::SymbolChange change_type, Symbol* symbol, Symbol* new_symbol)
+    : UndoStep(UndoStep::SymbolUndoStepType, map)
+    , change_type(change_type)
+    , symbol_ptr(symbol)
+    , new_symbol_ptr(new_symbol)
+    , symbol_pos(0)
+{
+	// nothing
+}
+
+
+SymbolUndoStep::SymbolUndoStep(Map* map, SymbolUndoStep::SymbolChange change_type, Symbol* symbol, int pos)
+    : SymbolUndoStep(map, change_type, symbol, nullptr)
+{
+	symbol_pos = pos;
+}
+
+
+SymbolUndoStep::SymbolUndoStep(Map* map)
+    : SymbolUndoStep(map, UndefinedChange, nullptr, nullptr)
+{
+	// nothing
+}
+
+
+UndoStep* SymbolUndoStep::undo()
+{
+	UndoStep* redo_step = nullptr;
+	switch (change_type)
+	{
+	case AddSymbol:
+		map->addSymbol(symbol_ptr, symbol_pos);
+		redo_step = new SymbolUndoStep(map, RemoveSymbol, symbol_ptr, symbol_pos);
+		break;
+	case RemoveSymbol:
+		{
+			const auto current_symbol_pos = map->findSymbolIndex(symbol_ptr);
+			Q_ASSERT(current_symbol_pos >= 0);
+			redo_step = new SymbolUndoStep(map, AddSymbol, map->releaseSymbol(current_symbol_pos), current_symbol_pos);
+		}
+		break;
+	case ChangeSymbol:
+		{
+			const auto current_symbol_pos = map->findSymbolIndex(symbol_ptr);
+			Q_ASSERT(current_symbol_pos >= 0);
+			auto old_symbol_ptr = map->setSymbol(new_symbol_ptr, current_symbol_pos);
+			redo_step = new SymbolUndoStep(map, SymbolUndoStep::ChangeSymbol,
+			                               map->getSymbol(current_symbol_pos),
+			                               old_symbol_ptr.release());
+		}
+		break;
+	case UndefinedChange:
+		Q_ASSERT(false);
+		redo_step = new NoOpUndoStep(map, true);
+		break;
+	}
+
+	Q_ASSERT(redo_step);
+	return redo_step;
+}
+
+bool SymbolUndoStep::isValid() const
+{
+	return change_type != UndefinedChange;
+}
+
+void SymbolUndoStep::saveImpl(QXmlStreamWriter &xml) const
+{
+	UndoStep::saveImpl(xml);
+	XmlElementWriter change_element(xml, literal::change);
+
+	switch (change_type)
+	{
+	case AddSymbol:
+		change_element.writeAttribute(literal::type, literal::add);
+		change_element.writeAttribute(literal::pos, symbol_pos);
+		symbol_ptr->save(xml, *map);
+		break;
+	case RemoveSymbol:
+		{
+			change_element.writeAttribute(literal::type, literal::remove);
+			change_element.writeAttribute(literal::pos, symbol_pos);
+		}
+		break;
+	case ChangeSymbol:
+		{
+			change_element.writeAttribute(literal::type, literal::change);
+			change_element.writeAttribute(literal::pos, current_symbol_pos);
+			new_symbol_ptr->save(xml, *map);
+		}
+	case UndefinedChange:
+		qWarning() << this << " Attempt to save invalid undo change";
+		break;
+	}
+}
+
+void SymbolUndoStep::loadImpl(QXmlStreamReader &xml, SymbolDictionary &)
+{
+	if (xml.name() == literal::change)
+	{
+		XmlElementReader change_element(xml);
+		QString type = change_element.attribute(literal::type);
+		if (type == literal::add)
+		{
+			change_type = AddSymbol;
+			symbol_pos = change_element.attribute<int>(literal::pos);
+			SymbolDictionary fake_symbol_dict;
+			symbol_ptr = Symbol::load(xml, map, fake_symbol_dict);
+		}
+		else if (type == literal::remove)
+		{
+			change_type = RemoveSymbol;
+			symbol_pos = change_element.attribute<int>(literal::pos);
+		}
+		else if (type == literal::change)
+		{
+			change_type = ChangeSymbol;
+			symbol_pos = change_element.attribute<int>(literal::pos);
+			SymbolDictionary fake_symbol_dict;
+			symbol_ptr = Symbol::load(xml, map, fake_symbol_dict);
+		}
+		else
+		{
+			qWarning() << "Unknown symbol change type \"" << type << "\"";
+		}
+	}
+}
+
+}  // namespace OpenOrienteering

--- a/src/undo/symbol_undo.h
+++ b/src/undo/symbol_undo.h
@@ -1,0 +1,38 @@
+#ifndef OPENORIENTEERING_SYMBOL_UNDO_H
+#define OPENORIENTEERING_SYMBOL_UNDO_H
+
+#include <undo/undo.h>
+
+namespace OpenOrienteering {
+
+class Map;
+class Symbol;
+
+class SymbolUndoStep : public UndoStep
+{
+public:
+    enum SymbolChange {	UndefinedChange, AddSymbol,	RemoveSymbol, ChangeSymbol };
+
+	SymbolUndoStep(Map* map, SymbolChange change_type, Symbol* symbol, Symbol* new_symbol);
+	SymbolUndoStep(Map* map, SymbolChange change_type, Symbol* symbol, int pos);
+	SymbolUndoStep(Map* map);
+	SymbolUndoStep() = delete;
+
+	~SymbolUndoStep() override = default;
+
+	UndoStep* undo() override;
+	bool isValid() const override;
+
+protected:
+	void saveImpl(QXmlStreamWriter& xml) const;
+	void loadImpl(QXmlStreamReader& xml, SymbolDictionary&symbol_dict);
+
+	SymbolChange change_type;
+	Symbol* symbol_ptr;
+	Symbol* new_symbol_ptr;
+	int symbol_pos;
+};
+
+}  // namespace OpenOrienteering
+
+#endif // OPENORIENTEERING_SYMBOL_UNDO_H

--- a/src/undo/undo.cpp
+++ b/src/undo/undo.cpp
@@ -27,6 +27,7 @@
 
 #include "object_undo.h"
 #include "map_part_undo.h"
+#include "symbol_undo.h"
 #include "util/xml_stream_util.h"
 
 
@@ -76,6 +77,9 @@ UndoStep* UndoStep::getUndoStepForType(Type type, Map* map)
 		
 	case MapPartUndoStepType:
 		return new MapPartUndoStep(map);
+		
+	case SymbolUndoStepType:
+		return new SymbolUndoStep(map);
 		
 	default:
 		qWarning("Undefined undo step type");

--- a/src/undo/undo.h
+++ b/src/undo/undo.h
@@ -67,6 +67,7 @@ public:
 		MapPartUndoStepType        =   8,
 		SwitchPartUndoStepTypeV0   =   9,
 		SwitchPartUndoStepType     =  10,
+		SymbolUndoStepType         =  11,
 		InvalidUndoStepType        = 999
 	};
 	


### PR DESCRIPTION
Continuation of #1201. The cherry-pick of "Accept use of deprecated PROJ API" is there solely for the purpose of compiling Mapper on my system. Will be left out from the final patch set.

Currently there is open question about symbol code uniqueness. Without unique symbol id the undo operations cannot be serialized. The solution is to either assign symbols another id, make symbol codes unique again, or some other clever idea which has not yet occurred to me.