### PR TITLE
Fix editing of Georeferencing fields

### DIFF
--- a/code-check-wrapper.sh
+++ b/code-check-wrapper.sh
@@ -49,6 +49,8 @@ PATTERN=" \
   combined_symbol.cpp \
   configure_grid_dialog.cpp \
   crs_param_widgets.cpp \
+  crs_template.cpp \
+  crs_template_implementation.cpp \
   duplicate_equals_t.cpp \
   file_dialog.cpp \
   /file_format.cpp \

--- a/code-check-wrapper.sh
+++ b/code-check-wrapper.sh
@@ -48,6 +48,7 @@ ENABLE_IWYU=true
 PATTERN=" \
   combined_symbol.cpp \
   configure_grid_dialog.cpp \
+  crs_param_widgets.cpp \
   duplicate_equals_t.cpp \
   file_dialog.cpp \
   /file_format.cpp \

--- a/src/core/crs_template_implementation.cpp
+++ b/src/core/crs_template_implementation.cpp
@@ -178,7 +178,7 @@ UTMZoneParameter::~UTMZoneParameter()
 QWidget* UTMZoneParameter::createEditor(WidgetObserver& observer) const
 {
 	auto widget = new UTMZoneEdit(observer, nullptr);
-	QObject::connect(widget, &UTMZoneEdit::textEdited, [&observer](){ observer.crsParameterEdited(); });
+	QObject::connect(widget, &UTMZoneEdit::textChanged, [&observer](){ observer.crsParameterEdited(); });
 	return widget;
 }
 

--- a/src/core/crs_template_implementation.cpp
+++ b/src/core/crs_template_implementation.cpp
@@ -128,7 +128,7 @@ QString TextParameter::value(const QWidget* edit_widget) const
 void TextParameter::setValue(QWidget* edit_widget, const QString& value)
 {
 	auto* field = qobject_cast<Editor*>(edit_widget);
-	if (field)
+	if (field && field->text() != value)
 		field->setText(value);
 }
 
@@ -198,7 +198,7 @@ void UTMZoneParameter::setValue(QWidget* edit_widget, const QString& value)
 {
 	// Don't accidentally clear this field.
 	auto* text_edit = qobject_cast<UTMZoneEdit*>(edit_widget);
-	if (text_edit && !value.isEmpty())
+	if (text_edit && !value.isEmpty() && text_edit->text() != value)
 		text_edit->setText(value);
 }
 
@@ -274,8 +274,10 @@ QString IntRangeParameter::value(const QWidget* edit_widget) const
 
 void IntRangeParameter::setValue(QWidget* edit_widget, const QString& value)
 {
-	if (auto* spin_box = qobject_cast<QSpinBox*>(edit_widget))
-		spin_box->setValue(value.toInt());
+	auto* spin_box = qobject_cast<QSpinBox*>(edit_widget);
+	auto int_value = value.toInt();
+	if (bool(spin_box) && spin_box->value() != int_value)
+		spin_box->setValue(int_value);
 }
 
 

--- a/src/core/crs_template_implementation.cpp
+++ b/src/core/crs_template_implementation.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2013, 2014 Thomas Schöps
- *    Copyright 2014-2017 Kai Pastor
+ *    Copyright 2014-2019 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -38,6 +38,7 @@
 #include "core/latlon.h"
 #include "gui/util_gui.h"
 #include "gui/widgets/crs_param_widgets.h"
+#include "util/backports.h"  // IWYU pragma: keep (QOverload)
 
 
 namespace OpenOrienteering {
@@ -110,7 +111,7 @@ TextParameter::TextParameter(const QString& id, const QString& name)
 
 QWidget* TextParameter::createEditor(WidgetObserver& observer) const
 {
-	auto widget = new Editor();
+	auto* widget = new Editor();
 	QObject::connect(widget, &TextParameter::Editor::textChanged, [&observer](){ observer.crsParameterEdited(); });
 	return widget;
 }
@@ -126,7 +127,7 @@ QString TextParameter::value(const QWidget* edit_widget) const
 
 void TextParameter::setValue(QWidget* edit_widget, const QString& value)
 {
-	auto field = qobject_cast<Editor*>(edit_widget);
+	auto* field = qobject_cast<Editor*>(edit_widget);
 	if (field)
 		field->setText(value);
 }
@@ -143,7 +144,7 @@ FullSpecParameter::FullSpecParameter(const QString& id, const QString& name)
 
 QWidget* FullSpecParameter::createEditor(WidgetObserver& observer) const
 {
-	auto widget = qobject_cast<TextParameter::Editor*>(TextParameter::createEditor(observer));
+	auto* widget = qobject_cast<TextParameter::Editor*>(TextParameter::createEditor(observer));
 	Q_ASSERT(widget);
 	if (widget)
 	{
@@ -170,14 +171,9 @@ UTMZoneParameter::UTMZoneParameter(const QString& id, const QString& name)
 	// nothing
 }
 
-UTMZoneParameter::~UTMZoneParameter()
-{
-	// nothing
-}
-
 QWidget* UTMZoneParameter::createEditor(WidgetObserver& observer) const
 {
-	auto widget = new UTMZoneEdit(observer, nullptr);
+	auto* widget = new UTMZoneEdit(observer, nullptr);
 	QObject::connect(widget, &UTMZoneEdit::textChanged, [&observer](){ observer.crsParameterEdited(); });
 	return widget;
 }
@@ -193,7 +189,7 @@ std::vector<QString> UTMZoneParameter::specValues(const QString& edit_value) con
 QString UTMZoneParameter::value(const QWidget* edit_widget) const
 {
 	QString value;
-	if (auto text_edit = qobject_cast<const UTMZoneEdit*>(edit_widget))
+	if (auto* text_edit = qobject_cast<const UTMZoneEdit*>(edit_widget))
 		value = text_edit->text();
 	return value;
 }
@@ -201,12 +197,12 @@ QString UTMZoneParameter::value(const QWidget* edit_widget) const
 void UTMZoneParameter::setValue(QWidget* edit_widget, const QString& value)
 {
 	// Don't accidentally clear this field.
-	auto text_edit = qobject_cast<UTMZoneEdit*>(edit_widget);
+	auto* text_edit = qobject_cast<UTMZoneEdit*>(edit_widget);
 	if (text_edit && !value.isEmpty())
 		text_edit->setText(value);
 }
 
-QVariant UTMZoneParameter::calculateUTMZone(const LatLon lat_lon)
+QVariant UTMZoneParameter::calculateUTMZone(const LatLon& lat_lon)
 {
 	QVariant ret;
 	
@@ -248,16 +244,10 @@ IntRangeParameter::IntRangeParameter(const QString& id, const QString& name, int
 	// nothing
 }
 
-IntRangeParameter::~IntRangeParameter()
-{
-	// nothing
-}
-
 QWidget* IntRangeParameter::createEditor(WidgetObserver& observer) const
 {
-	using TakingIntArgument = void (QSpinBox::*)(int);
-	auto widget = Util::SpinBox::create(min_value, max_value);
-	QObject::connect(widget, (TakingIntArgument) &QSpinBox::valueChanged, [&observer](){ observer.crsParameterEdited(); });
+	auto* widget = Util::SpinBox::create(min_value, max_value);
+	QObject::connect(widget, QOverload<int>::of(&QSpinBox::valueChanged), [&observer](){ observer.crsParameterEdited(); });
 	return widget;
 }
 
@@ -277,14 +267,14 @@ std::vector<QString> IntRangeParameter::specValues(const QString& edit_value) co
 QString IntRangeParameter::value(const QWidget* edit_widget) const
 {
 	QString value;
-	if (auto spin_box = qobject_cast<const QSpinBox*>(edit_widget))
+	if (auto* spin_box = qobject_cast<const QSpinBox*>(edit_widget))
 		value = spin_box->cleanText();
 	return value;
 }
 
 void IntRangeParameter::setValue(QWidget* edit_widget, const QString& value)
 {
-	if (auto spin_box = qobject_cast<QSpinBox*>(edit_widget))
+	if (auto* spin_box = qobject_cast<QSpinBox*>(edit_widget))
 		spin_box->setValue(value.toInt());
 }
 

--- a/src/core/crs_template_implementation.h
+++ b/src/core/crs_template_implementation.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2013, 2014 Thomas Schöps
- *    Copyright 2014, 2015 Kai Pastor
+ *    Copyright 2014, 2015, 2017-2019 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -89,7 +89,6 @@ class UTMZoneParameter : public CRSTemplateParameter
 {
 public:
 	UTMZoneParameter(const QString& id, const QString& name);
-	~UTMZoneParameter() override;
 	QWidget* createEditor(WidgetObserver& observer) const override;
 	std::vector<QString> specValues(const QString& edit_value) const override;
 	QString value(const QWidget* edit_widget) const override;
@@ -100,7 +99,7 @@ public:
 	 * 
 	 * Returns a null value on error.
 	 */
-	static QVariant calculateUTMZone(const LatLon lat_lon);
+	static QVariant calculateUTMZone(const LatLon& lat_lon);
 };
 
 
@@ -115,7 +114,6 @@ public:
 	
 	IntRangeParameter(const QString& id, const QString& name, int min_value, int max_value);
 	IntRangeParameter(const QString& id, const QString& name, int min_value, int max_value, OutputList&& outputs);
-	~IntRangeParameter() override;
 	QWidget* createEditor(WidgetObserver& observer) const override;
 	std::vector<QString> specValues(const QString& edit_value) const override;
 	QString value(const QWidget* edit_widget) const override;

--- a/src/gui/georeferencing_dialog.cpp
+++ b/src/gui/georeferencing_dialog.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2017 Kai Pastor
+ *    Copyright 2012-2019 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -76,6 +76,17 @@
 
 
 namespace OpenOrienteering {
+	
+namespace  {
+
+void setValueIfChanged(QDoubleSpinBox* field, qreal value) {
+	if (!qFuzzyCompare(field->value(), value))
+		field->setValue(value);
+};
+
+}  // namespace
+
+
 
 // ### GeoreferencingDialog ###
 
@@ -300,13 +311,13 @@ void GeoreferencingDialog::transformationChanged()
 	            scale_factor_edit
 	);
 	
-	map_x_edit->setValue(georef->getMapRefPoint().x());
-	map_y_edit->setValue(-1 * georef->getMapRefPoint().y());
+	setValueIfChanged(map_x_edit, georef->getMapRefPoint().x());
+	setValueIfChanged(map_y_edit, -georef->getMapRefPoint().y());
 	
-	easting_edit->setValue(georef->getProjectedRefPoint().x());
-	northing_edit->setValue(georef->getProjectedRefPoint().y());
+	setValueIfChanged(easting_edit, georef->getProjectedRefPoint().x());
+	setValueIfChanged(northing_edit, georef->getProjectedRefPoint().y());
 	
-	scale_factor_edit->setValue(georef->getGridScaleFactor());
+	setValueIfChanged(scale_factor_edit, georef->getGridScaleFactor());
 	
 	updateGrivation();
 }
@@ -338,8 +349,8 @@ void GeoreferencingDialog::projectionChanged()
 	LatLon latlon = georef->getGeographicRefPoint();
 	double latitude  = latlon.latitude();
 	double longitude = latlon.longitude();
-	lat_edit->setValue(latitude);
-	lon_edit->setValue(longitude);
+	setValueIfChanged(lat_edit, latitude);
+	setValueIfChanged(lon_edit, longitude);
 	QString osm_link =
 	  QString::fromLatin1("http://www.openstreetmap.org/?lat=%1&lon=%2&zoom=18&layers=M").
 	  arg(latitude).arg(longitude);
@@ -362,7 +373,7 @@ void GeoreferencingDialog::projectionChanged()
 void GeoreferencingDialog::declinationChanged()
 {
 	const QSignalBlocker block(declination_edit);
-	declination_edit->setValue(georef->getDeclination());
+	setValueIfChanged(declination_edit, georef->getDeclination());
 }
 
 void GeoreferencingDialog::requestDeclination(bool no_confirm)
@@ -656,7 +667,7 @@ void GeoreferencingDialog::declinationReplyFinished(QNetworkReply* reply)
 								double declination = text.toDouble(&ok);
 								if (ok)
 								{
-									declination_edit->setValue(Georeferencing::roundDeclination(declination));
+									setValueIfChanged(declination_edit, Georeferencing::roundDeclination(declination));
 									return;
 								}
 								else 

--- a/src/gui/widgets/crs_param_widgets.h
+++ b/src/gui/widgets/crs_param_widgets.h
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2015 Kai Pastor
+ *    Copyright 2015, 2017-2019 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -21,6 +21,7 @@
 #ifndef OPENORIENTEERING_CRS_PARAM_WIDGETS_H
 #define OPENORIENTEERING_CRS_PARAM_WIDGETS_H
 
+#include <QtGlobal>
 #include <QObject>
 #include <QString>
 #include <QWidget>
@@ -35,6 +36,7 @@ class CRSParameterWidgetObserver;
 class UTMZoneEdit : public QWidget
 {
 	Q_OBJECT
+	Q_DISABLE_COPY(UTMZoneEdit)
 public:
 	UTMZoneEdit(CRSParameterWidgetObserver& observer, QWidget* parent = nullptr);
 	~UTMZoneEdit() override;
@@ -44,7 +46,7 @@ public:
 	bool calculateValue();
 	
 signals:
-	void textEdited(const QString& text); // TODO: rename to textChanged, see QLineEdit
+	void textChanged(const QString& text);
 	
 private:
 	CRSParameterWidgetObserver& observer;


### PR DESCRIPTION
Most fields in the Georeferencing dialog were hard to edit because the cursor jumped to the end of the text after each key press. This is fixed by not touching the field if we don't have a new value.