### PR TITLE
Fix transform used when importing a template map

### DIFF
--- a/src/gui/widgets/template_list_widget.cpp
+++ b/src/gui/widgets/template_list_widget.cpp
@@ -110,8 +110,8 @@ struct ApplyTemplateTransform
 	
 	void operator()(Object* object) const
 	{ 
-		object->rotate(transform.template_rotation);
 		object->scale(transform.template_scale_x, transform.template_scale_y);
+		object->rotate(transform.template_rotation);
 		object->move(transform.template_x, transform.template_y);
 	}
 };


### PR DESCRIPTION
When importing a template map, objects need their coordinates transformed in the steps: scale, rotate, translate. This order needs to be the opposite of how they are applied to QPainter for drawing templates.

To experience the bug,

1. Open a map and add a template map.

1. Use the template dialog's positioning widget to set obvious rotation and non-isotropic scaling, such as rotation of 90, scale-x of 2, and scale-y of 0.5.

1. Observe that the template map is rotated counter-clockwise, and is greatly elongated vertically.

1. Use the template dialog's feature to import and remove the template map.

1. Observe that the imported map is now greatly elongated horizontally.

The imported features should not have changed their location/scaling. The rotation and scaling were applied correctly to the template map, and were applied incorrectly during import.