### PR TITLE
TemplateTransform: allow any affine transformation

### DIFF
--- a/src/fileformats/ocad8_file_format.cpp
+++ b/src/fileformats/ocad8_file_format.cpp
@@ -1227,6 +1227,7 @@ Template *OCAD8FileImport::importTemplate(OCADCString* ocad_str)
 	templ->setTemplateRotation(M_PI / 180 * background.angle);
 	templ->setTemplateScaleX(convertTemplateScale(background.sclx));
 	templ->setTemplateScaleY(convertTemplateScale(background.scly));
+	templ->setTemplateShear(0.0);
 	
 	map->templates.insert(map->templates.begin(), templ);
 	
@@ -1317,6 +1318,7 @@ Template *OCAD8FileImport::importRasterTemplate(const OCADBackground &background
         templ->setTemplateRotation(M_PI / 180 * background.angle);
         templ->setTemplateScaleX(convertTemplateScale(background.sclx));
         templ->setTemplateScaleY(convertTemplateScale(background.scly));
+        templ->setTemplateShear(0.0);
         // FIXME: import template view parameters: background.dimming and background.transparent
 		// TODO: import template visibility
         return templ;

--- a/src/gui/widgets/template_list_widget.cpp
+++ b/src/gui/widgets/template_list_widget.cpp
@@ -110,7 +110,16 @@ struct ApplyTemplateTransform
 	
 	void operator()(Object* object) const
 	{ 
-		object->scale(transform.template_scale_x, transform.template_scale_y);
+		/// \todo Move this if...else into a constructor that sets up a transform member.
+		if (qFuzzyIsNull(transform.template_shear))
+			object->scale(transform.template_scale_x, transform.template_scale_y);
+		else
+		{
+			QTransform scaling(transform.template_scale_x, transform.template_shear,
+			                   transform.template_shear, transform.template_scale_y,
+			                   0, 0);
+			object->transform(scaling);
+		}
 		object->rotate(transform.template_rotation);
 		object->move(transform.template_x, transform.template_y);
 	}

--- a/src/templates/template.h
+++ b/src/templates/template.h
@@ -51,9 +51,10 @@ class MapView;
 
 
 /**
- * Transformation parameters for non-georeferenced templates.
+ * Transformation parameters for non-georeferenced templates,
+ * transforming template coordinates to map coordinates.
  * 
- * The parameters are to applied in the order
+ * The parameters are applied to painter in the order
  * 1. translate
  * 2. rotate
  * 3. scale.
@@ -62,6 +63,9 @@ class MapView;
  * thus used in list initialization.
  * 
  * \see Template::applyTemplateTransform()
+ * 
+ * Coordinate transformations use the opposite order for the
+ * same effect.
  */
 struct TemplateTransform
 {
@@ -70,13 +74,15 @@ struct TemplateTransform
 	/// x position in 1/1000 mm
 	qint32 template_y = 0;
 	
-	/// Rotation in radians
+	/// Rotation in radians, a positive rotation is counter-clockwise.
 	double template_rotation = 0.0;
 	
-	/// Scaling in x direction (relative to 1 mm on map)
+	/// Scaling in x direction, smaller than 1 shrinks.
 	double template_scale_x = 1.0;
-	/// Scaling in y direction (relative to 1 mm on map)
+	/// Scaling in y direction, smaller than 1 shrinks.
 	double template_scale_y = 1.0;
+	/// Adjustment to scaling if anisotropy is askew.
+	double template_shear = 0.0;
 	
 	/**
 	 * Explicit implementation of aggregate initialization.
@@ -84,8 +90,8 @@ struct TemplateTransform
 	 * In C++11, there is no aggregate initialization when default initalizers are present.
 	 * \todo Remove when we can use C++14 everywhere.
 	 */
-	TemplateTransform(qint32 x, qint32 y, double rotation, double scale_x, double scale_y) noexcept
-	: template_x{x}, template_y{y}, template_rotation{rotation}, template_scale_x{scale_x}, template_scale_y{scale_y}
+	TemplateTransform(qint32 x, qint32 y, double rotation, double scale_x, double scale_y, double shear = 0.0) noexcept
+	: template_x{x}, template_y{y}, template_rotation{rotation}, template_scale_x{scale_x}, template_scale_y{scale_y}, template_shear{shear}
 	{}
 	
 	/**
@@ -521,6 +527,8 @@ public:
 	inline void setTemplateScaleX(double scale_x) {transform.template_scale_x = scale_x; updateTransformationMatrices();}
 	inline double getTemplateScaleY() const {return transform.template_scale_y;}
 	inline void setTemplateScaleY(double scale_y) {transform.template_scale_y = scale_y; updateTransformationMatrices();}
+	inline double getTemplateShear() const {return transform.template_shear;}
+	inline void setTemplateShear(double shear) {transform.template_shear = shear; updateTransformationMatrices();}
 	
 	inline double getTemplateRotation() const {return transform.template_rotation;}
 	inline void setTemplateRotation(double rotation) {transform.template_rotation = rotation; updateTransformationMatrices();}

--- a/src/templates/template_image.cpp
+++ b/src/templates/template_image.cpp
@@ -253,6 +253,7 @@ bool TemplateImage::postLoadConfiguration(QWidget* dialog_parent, bool& out_cent
 	{
 		transform.template_scale_x = open_dialog.getMpp() * 1000.0 / map->getScaleDenominator();
 		transform.template_scale_y = transform.template_scale_x;
+		transform.template_shear = 0.0;
 		
 		//transform.template_x = main_view->getPositionX();
 		//transform.template_y = main_view->getPositionY();

--- a/src/templates/template_position_dock_widget.cpp
+++ b/src/templates/template_position_dock_widget.cpp
@@ -55,6 +55,9 @@ TemplatePositionDockWidget::TemplatePositionDockWidget(Template* temp, MapEditor
 	QLabel* rotation_label = new QLabel(tr("Rotation:"));
 	rotation_edit = new QLineEdit();
 	rotation_edit->setValidator(new DoubleValidator(-999999, 999999, rotation_edit));
+	QLabel* shear_label = new QLabel(tr("Shear:"));
+	shear_edit = new QLineEdit();
+	shear_edit->setValidator(new DoubleValidator(-999999, 999999, shear_edit));
 	
 	updateValues();
 	
@@ -70,6 +73,8 @@ TemplatePositionDockWidget::TemplatePositionDockWidget(Template* temp, MapEditor
 	layout->addWidget(scale_y_edit, 3, 1);
 	layout->addWidget(rotation_label, 4, 0);
 	layout->addWidget(rotation_edit, 4, 1);
+	layout->addWidget(shear_label, 5, 0);
+	layout->addWidget(shear_edit, 5, 1);
 	child_widget->setLayout(layout);
 	setWidget(child_widget);
 	
@@ -78,6 +83,7 @@ TemplatePositionDockWidget::TemplatePositionDockWidget(Template* temp, MapEditor
 	connect(scale_x_edit, &QLineEdit::textEdited, this, &TemplatePositionDockWidget::valueChanged);
 	connect(scale_y_edit, &QLineEdit::textEdited, this, &TemplatePositionDockWidget::valueChanged);
 	connect(rotation_edit, &QLineEdit::textEdited, this, &TemplatePositionDockWidget::valueChanged);
+	connect(shear_edit, &QLineEdit::textEdited, this, &TemplatePositionDockWidget::valueChanged);
 	
 	connect(controller->getMap(), &Map::templateChanged, this, &TemplatePositionDockWidget::templateChanged);
 	connect(controller->getMap(), &Map::templateDeleted, this, &TemplatePositionDockWidget::templateDeleted);
@@ -91,6 +97,7 @@ void TemplatePositionDockWidget::updateValues()
 	scale_x_edit->setText(QString::number(temp->getTemplateScaleX()));
 	scale_y_edit->setText(QString::number(temp->getTemplateScaleY()));
 	rotation_edit->setText(QString::number(temp->getTemplateRotation() * 180 / M_PI));
+	shear_edit->setText(QString::number(temp->getTemplateShear()));
 }
 
 bool TemplatePositionDockWidget::event(QEvent* event)
@@ -157,6 +164,8 @@ void TemplatePositionDockWidget::valueChanged()
 		temp->setTemplateScaleY(scale_y_edit->text().toDouble());
 	else if (widget == rotation_edit)
 		temp->setTemplateRotation(rotation_edit->text().toDouble() * M_PI / 180.0);
+	else if (widget == shear_edit)
+		temp->setTemplateShear(shear_edit->text().toDouble());
 	
 	// Transform relevant parts of pass points back to map coords
 	for (int i = 0; i < temp->getNumPassPoints(); ++i)

--- a/src/templates/template_position_dock_widget.h
+++ b/src/templates/template_position_dock_widget.h
@@ -58,6 +58,7 @@ private:
 	QLineEdit* scale_x_edit;
 	QLineEdit* scale_y_edit;
 	QLineEdit* rotation_edit;
+	QLineEdit* shear_edit;
 	
 	bool react_to_changes;
 	Template* temp;

--- a/src/templates/template_tool_paint.cpp
+++ b/src/templates/template_tool_paint.cpp
@@ -577,6 +577,7 @@ Template* PaintOnTemplateSelectDialog::addNewTemplate() const
 	temp->setTemplatePosition(MapCoord{top_left + MapCoordF{size_mm/2, size_mm/2}});
 	temp->setTemplateScaleX(1.0/pixel_per_mm);
 	temp->setTemplateScaleY(1.0/pixel_per_mm);
+	temp->setTemplateShear(0);
 	temp->setTemplateRotation(0);
 	temp->loadTemplateFile(false);
 	

--- a/src/util/transformation.cpp
+++ b/src/util/transformation.cpp
@@ -112,11 +112,9 @@ bool PassPointList::estimateSimilarityTransformation(not_null<TemplateTransform*
 	}
 	else if (num_pass_points >= 2)
 	{
-		// Create linear equation system and solve using the pseuo inverse
+		// Create linear equation system and solve using the pseudo inverse
 		
 		// Derivation:
-		// (Attention: not by a mathematician. Please correct any errors.)
-		//
 		// Start by stating that the original coordinates (x, y) multiplied
 		// with the transformation matrix should give the desired coordinates (X, Y):
 		//
@@ -126,10 +124,10 @@ bool PassPointList::estimateSimilarityTransformation(not_null<TemplateTransform*
 		//
 		// The parametrization of the transformation matrix should be simplified because
 		// we want to have isotropic scaling.
-		// With s = scaling, r = rotation and (x, y) = offset, it looks like this:
+		// With s = scaling, r = rotation and (ox, oy) = offset, it looks like this:
 		//
-		// | s*cos(r) s*sin(r) x|    | a  b  c|
-		// |-s*sin(r) s*cos(r) y| =: |-b  a  d|
+		// | s*cos(r) s*sin(r) ox|    | a  b  c|
+		// |-s*sin(r) s*cos(r) oy| =: |-b  a  d|
 		// 
 		// With this, reordering the matrices to have the unknowns
 		// in the second matrix results in:
@@ -225,11 +223,9 @@ bool PassPointList::estimateSimilarityTransformation(not_null<QTransform*> out)
 	}
 	else if (num_pass_points >= 2)
 	{
-		// Create linear equation system and solve using the pseuo inverse
+		// Create linear equation system and solve using the pseudo inverse
 		
 		// Derivation:
-		// (Attention: not by a mathematician. Please correct any errors.)
-		//
 		// Start by stating that the original coordinates (x, y) multiplied
 		// with the transformation matrix should give the desired coordinates (X, Y):
 		//
@@ -239,10 +235,10 @@ bool PassPointList::estimateSimilarityTransformation(not_null<QTransform*> out)
 		//
 		// The parametrization of the transformation matrix should be simplified because
 		// we want to have isotropic scaling.
-		// With s = scaling, r = rotation and (x, y) = offset, it looks like this:
+		// With s = scaling, r = rotation and (ox, oy) = offset, it looks like this:
 		//
-		// | s*cos(r) s*sin(r) x|    | a  b  c|
-		// |-s*sin(r) s*cos(r) y| =: |-b  a  d|
+		// | s*cos(r) s*sin(r) ox|    | a  b  c|
+		// |-s*sin(r) s*cos(r) oy| =: |-b  a  d|
 		// 
 		// With this, reordering the matrices to have the unknowns
 		// in the second matrix results in:
@@ -317,7 +313,7 @@ bool PassPointList::estimateNonIsometricSimilarityTransform(not_null<QTransform*
 	auto num_pass_points = int(size());
 	Q_ASSERT(num_pass_points >= 3);
 	
-	// Create linear equation system and solve using the pseuo inverse
+	// Create linear equation system and solve using the pseudo inverse
 	
 	// Derivation: see comment in estimateSimilarityTransformation().
 	// Here, the resulting matrices look a bit different because the constraint


### PR DESCRIPTION
Enhances `fromQTransform` and `struct TemplateTransform` to fully reflect the
affine transformation that defines them.

This PR does not require #1277, though the need for each PR may arise in related circumstances.

In comparison to the approach taken with #1277, this PR is lighter weight. Rather than add to or replace TemplateTransform with an affine `QTransform`, a scalar `template_shear` member is added to the existing data structure.

### Example

[wintri-maps.zip](https://github.com/OpenOrienteering/mapper/files/3412647/wintri-maps.zip)
[7_tile_slope.zip](https://github.com/OpenOrienteering/mapper/files/3412645/7_tile_slope.zip)

The example maps illustrate a case in which the alignment of a template image can be improved. As with #1277 this case uses the Winkel III projection. For the current PR, it's not a matter of straightening out the map, but of aligning the template with the map that is skewed by its projection.

1. Open and view the junior.2019-05-24a.wintri.deformed.omap in Mapper.  This map is correctly georeferenced with the Winkel III projection that stretches the map along a southwest-to-northeast axis.
1. Load  7_tile_slope.gif as a template, with world file 7_tile_slope.gfw. Set the CRS to EPSG 6575. Note that the image does not align with the map.
1. Alternatively, load the map junior.2019-05-24a.original.omap as a template. Note that the template map does not align with the "deformed" map. (This map is georeferenced with EPSG 6575. The "deformed" map was created by importing this.)

This PR changes the behavior, so that the template image and template map show up aligned with the map.

Regarding #1277 (Determine grid scale automatically) @dg0yt wrote:

> What we need for all type of maps is the reasonable precise placement of geospatial data (templates or import). The junior "deformed" map example shows that Mapper seems to work okay for GPX tracks. Of course we won't achieve satisfying results with rectangular raster images when just the corners are aligned to fit.

In the "deformed" example, the current Mapper does not work okay with the template image. This PR takes care of that limitation.