### PR TITLE
MainWindow: Start an Android foreground service

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -86,6 +86,8 @@
             <meta-data android:name="android.app.extract_android_style" android:value="default"/>
             <!-- extract android style -->
         </activity>
+        <service android:name="org.openorienteering.mapper.MapperService"
+                 android:exported="false" />
     </application>
 
     <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="28"/>
@@ -95,6 +97,7 @@
          Remove the comment if you do not require these default permissions. -->
     <!-- Not used for Mapper: %%INSERT_PERMISSIONS -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/><!-- PROTECTION_DANGEROUS -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/><!-- PROTECTION_NORMAL -->
     <uses-permission android:name="android.permission.INTERNET"/><!-- PROTECTION_NORMAL -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/><!-- PROTECTION_DANGEROUS -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/><!-- PROTECTION_DANGEROUS -->

--- a/android/src/org/openorienteering/mapper/MapperActivity.java
+++ b/android/src/org/openorienteering/mapper/MapperActivity.java
@@ -54,6 +54,7 @@ public class MapperActivity extends org.qtproject.qt5.android.bindings.QtActivit
 	
 	private static Toast toast;
 	private static CountDownTimer toast_reset;
+	private static boolean service_started = false;
 
 	@Override
 	public void onCreate(Bundle savedInstanceState)
@@ -81,7 +82,7 @@ public class MapperActivity extends org.qtproject.qt5.android.bindings.QtActivit
 			if (action == Intent.ACTION_EDIT || action == Intent.ACTION_VIEW)
 			{
 				result = intent.getDataString();
-				}
+			}
 			setIntent(null);
 		}
 		return result;
@@ -248,5 +249,30 @@ public class MapperActivity extends org.qtproject.qt5.android.bindings.QtActivit
 	public static int getDisplayRotation()
 	{
 		return instance.getWindowManager().getDefaultDisplay().getRotation();
+	}
+	
+	/** Starts a foreground service with the given notification message.
+	 */
+	public static void startService(String message)
+	{
+		if (!service_started)
+		{
+			service_started = true;
+			Intent intent = new Intent(instance, MapperService.class);
+			intent.putExtra("message", message);
+			instance.startService(intent);
+		}
+	}
+	
+	/** Stops the foreground service with the given notification message.
+	 */
+	public static void stopService()
+	{
+		if (service_started)
+		{
+			Intent intent = new Intent(instance, MapperService.class);
+			instance.stopService(intent);
+			service_started = false;
+		}
 	}
 }

--- a/android/src/org/openorienteering/mapper/MapperService.java
+++ b/android/src/org/openorienteering/mapper/MapperService.java
@@ -1,0 +1,89 @@
+/*
+ *    Copyright 2019 Kai Pastor
+ *
+ *    This file is part of OpenOrienteering.
+ *
+ *    OpenOrienteering is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OpenOrienteering is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.openorienteering.mapper;
+
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.os.IBinder;
+
+
+/**
+ * A foreground service which keeps Mapper alive enough
+ * to save the modified map and to continue GPX recording.
+ */
+public class MapperService extends Service
+{
+	static private int NOTIFICATION_ID = 1;
+	static private String NOTIFICATION_CHANNEL_ID = "org.openorienteering.mapper.channel1";
+	private static NotificationChannel channel;
+	
+	private String makeNotificationChannel()
+	{
+		NotificationChannel channel = new NotificationChannel(NOTIFICATION_CHANNEL_ID,
+		                                                      "OpenOrienteering Mapper",
+		                                                      NotificationManager.IMPORTANCE_LOW);
+		((NotificationManager)this.getSystemService(Context.NOTIFICATION_SERVICE))
+			.createNotificationChannel(channel);
+		return NOTIFICATION_CHANNEL_ID;
+	}
+	
+	private Notification.Builder makeNotificationBuilder()
+	{
+		if (Build.VERSION.SDK_INT < 26)
+		{
+			return new Notification.Builder(this);
+		}
+		
+		String channel_id = makeNotificationChannel();
+		return new Notification.Builder(this, channel_id);
+	}
+	
+	@Override
+	public int onStartCommand(Intent intent, int flags, int startId)
+	{
+		String message = intent.getStringExtra("message");
+		
+		Intent notificationIntent = new Intent(this, MapperActivity.class);
+		PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, notificationIntent, 0);
+		Notification notification = makeNotificationBuilder()
+			.setSmallIcon(android.R.drawable.ic_dialog_map)
+			.setContentTitle("OpenOrienteering Mapper")
+			.setContentText(message)
+			.setContentIntent(pendingIntent)
+			.build();
+		
+		startForeground(NOTIFICATION_ID, notification);
+		
+		return START_NOT_STICKY;
+	}
+	
+	@Override
+	public IBinder onBind (Intent intent)
+	{
+		return null;
+	}
+	
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -209,6 +209,7 @@ set(Mapper_Common_SRCS
   
   util/encoding.cpp
   util/item_delegates.cpp
+  util/mapper_service_proxy.cpp
   util/matrix.cpp
   util/overriding_shortcut.cpp
   util/recording_translator.cpp

--- a/src/gui/main_window.cpp
+++ b/src/gui/main_window.cpp
@@ -63,6 +63,7 @@
 #include "undo/undo_manager.h"
 #include "util/util.h"
 #include "util/backports.h"  // IWYU pragma: keep
+#include "util/mapper_service_proxy.h"
 
 
 namespace OpenOrienteering {
@@ -498,7 +499,19 @@ void MainWindow::setHasUnsavedChanges(bool value)
 		has_unsaved_changes = value;
 		setAutosaveNeeded(has_unsaved_changes && !has_autosave_conflict);
 	}
+	else
+	{
+		Q_ASSERT(!value);
+		has_unsaved_changes = false;
+		setAutosaveNeeded(false);
+	}
 	setWindowModified(has_unsaved_changes);
+	
+#ifdef Q_OS_ANDROID
+	if (!service_proxy)
+		service_proxy = std::make_unique<MapperServiceProxy>();
+	service_proxy->setActiveWindow(has_unsaved_changes ? this : nullptr);
+#endif
 }
 
 void MainWindow::setStatusBarText(const QString& text)

--- a/src/gui/main_window.h
+++ b/src/gui/main_window.h
@@ -22,6 +22,8 @@
 #ifndef OPENORIENTEERING_MAIN_WINDOW_H
 #define OPENORIENTEERING_MAIN_WINDOW_H
 
+#include <memory>
+
 #include <Qt>
 #include <QMainWindow>
 #include <QObject>
@@ -44,6 +46,7 @@ class QWidget;
 namespace OpenOrienteering {
 
 class MainWindowController;
+class MapperServiceProxy;
 
 
 /**
@@ -509,6 +512,8 @@ private:
 	QAction* settings_act;
 	QAction* close_act;
 	QLabel* status_label;
+	
+	std::unique_ptr<MapperServiceProxy> service_proxy;
 	
 	/// Canonical path to the currently open file or an empty string if the file was not saved yet ("untitled")
 	QString current_path;

--- a/src/util/mapper_service_proxy.cpp
+++ b/src/util/mapper_service_proxy.cpp
@@ -1,0 +1,130 @@
+/*
+ *    Copyright 2019 Kai Pastor
+ *
+ *    This file is part of OpenOrienteering.
+ *
+ *    OpenOrienteering is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OpenOrienteering is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "mapper_service_proxy.h"
+
+#include <QWidget>
+
+#ifdef Q_OS_ANDROID
+#include <QtAndroid>
+#include <QtAndroidExtras/QAndroidJniObject>
+#endif
+
+#include "gui/main_window.h"
+
+
+namespace OpenOrienteering {
+
+#ifdef Q_OS_ANDROID
+
+namespace {
+
+auto const foreground_service = QStringLiteral("android.permission.FOREGROUND_SERVICE");
+
+/**
+ * A callback which handles Android permission request results.
+ * 
+ * In addition to the MapperServiceProxy and it is member function, this unit
+ * takes a QPointer to the target window which also serves as an indicator that
+ * the proxy object still exists at the time the functor is called.
+ */
+struct MapperServiceProxyCallback
+{
+	MapperServiceProxy* proxy;
+	void (MapperServiceProxy::*start_service)();
+	QPointer<QWidget> window;
+	
+	void operator()(const QtAndroid::PermissionResultMap &results)
+	{
+		if (!window || window != proxy->activeWindow())
+			return;
+		if (results[foreground_service] == QtAndroid::PermissionResult::Granted)
+			(proxy->*start_service)();
+	}
+};
+
+}
+
+#endif
+
+
+MapperServiceProxy::~MapperServiceProxy()
+{
+	setActiveWindow(nullptr);
+}
+
+
+void MapperServiceProxy::setActiveWindow(QWidget* window)
+{
+	if (active_window == window)
+		return;
+	
+	if (active_window != nullptr)
+		stopService();
+		
+	active_window = window;
+		
+	if (active_window == nullptr)
+		return;
+	
+#ifdef Q_OS_ANDROID
+	if (QtAndroid::androidSdkVersion() >= 28)
+	{
+		if (QtAndroid::checkPermission(foreground_service) != QtAndroid::PermissionResult::Granted)
+		{
+			auto callback = MapperServiceProxyCallback{this, &MapperServiceProxy::startService, window};
+			QtAndroid::requestPermissions({foreground_service}, callback);
+			return;
+		}
+	}
+#endif
+	
+	startService();
+}
+
+
+void MapperServiceProxy::startService()
+{
+	Q_ASSERT(active_window);
+	
+#ifdef Q_OS_ANDROID
+	auto const file_path = active_window->windowFilePath();
+	auto const prefix_length = file_path.lastIndexOf(QLatin1Char('/')) + 1;
+	QAndroidJniObject java_string = QAndroidJniObject::fromString(file_path.mid(prefix_length));
+	QAndroidJniObject::callStaticMethod<void>("org/openorienteering/mapper/MapperActivity",
+	                                          "startService",
+	                                          "(Ljava/lang/String;)V",
+	                                          java_string.object<jstring>());
+#endif
+}
+
+
+void MapperServiceProxy::stopService()
+{
+	Q_ASSERT(active_window);
+	
+#ifdef Q_OS_ANDROID
+	QAndroidJniObject::callStaticMethod<void>("org/openorienteering/mapper/MapperActivity",
+	                                          "stopService",
+	                                          "()V");
+#endif
+}
+
+}  // namespace OpenOrienteering

--- a/src/util/mapper_service_proxy.h
+++ b/src/util/mapper_service_proxy.h
@@ -1,0 +1,64 @@
+/*
+ *    Copyright 2019 Kai Pastor
+ *
+ *    This file is part of OpenOrienteering.
+ *
+ *    OpenOrienteering is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OpenOrienteering is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#ifndef OPENORIENTEERING_MAPPER_SERVICE_PROXY_H
+#define OPENORIENTEERING_MAPPER_SERVICE_PROXY_H
+
+#include <QPointer>
+
+class QWidget;
+
+namespace OpenOrienteering {
+
+/**
+ * A class which helps to run a service alongside the application.
+ * 
+ * The service is started by setting a non-null active window, and stopped
+ * by setting the active window to null.
+ * 
+ * On Android, this utility runs a foregound service with a notification
+ * showing the app name and the file name. Running a foreground service
+ * increases the app's importance with regard to power management and
+ * continuous location access, and it makes the user aware of the app
+ * when it is in the background.
+ * 
+ * On other platforms, this class does nothing at the moment.
+ */
+class MapperServiceProxy
+{
+public:
+	MapperServiceProxy() = default;
+	~MapperServiceProxy();
+	
+	QWidget* activeWindow() { return active_window.data(); }
+	void setActiveWindow(QWidget* widget);
+	
+private:
+	void startService();
+	void stopService();
+	
+	QPointer<QWidget> active_window;
+	
+	Q_DISABLE_COPY(MapperServiceProxy)
+};
+
+}  // namespace OpenOrienteering
+
+#endif


### PR DESCRIPTION
To protect unsaved map changes and to keep continuity of track
recording when the screen is off or the app is in the background,
let MainWindow start an Android foreground service when the it
is told that the map is modified.
This is expected to resolve #576. However this needs to be verified
in the field, across build and device configurations.