### PR TITLE
OCD: Fix string type 1039 (georeferencing) import

### DIFF
--- a/src/fileformats/ocd_file_import.cpp
+++ b/src/fileformats/ocd_file_import.cpp
@@ -363,7 +363,7 @@ namespace {
 void tryParamConvert(int& out, const QString& param_value)
 {
 	bool ok;
-	auto value = param_value.toInt(&ok);
+	auto value = qRound(param_value.toFloat(&ok));
 	if (ok)
 		out = value;
 }


### PR DESCRIPTION
Recently I received an OCAD 12 georeferenced map at scale 1:10000. After opening it in Mapper-dev I could not match the real world coordinates from Mapper to coordinates from other map services. The root cause was a failure to parse the georeferencing string. Mapper failed to parse "10000.000000" and silently filled in "15000" as map scale. This commit fixes the parsing part but not the silent breakage.