### PR TITLE
MapGrid: Fix offset direction

### DIFF
--- a/src/core/map_grid.cpp
+++ b/src/core/map_grid.cpp
@@ -136,8 +136,8 @@ void MapGrid::draw(QPainter* painter, const QRectF& bounding_box, Map* map, qrea
 	if (display == AllLines)
 		Util::gridOperation<ProcessLine>(bounding_box, final_horz_spacing, final_vert_spacing, final_horz_offset, final_vert_offset, final_rotation, process_line);
 	else if (display == HorizontalLines)
-		Util::hatchingOperation<ProcessLine>(bounding_box, final_vert_spacing, final_vert_offset, final_rotation + M_PI / 2, process_line);
-	else // if (display == VeritcalLines)
+		Util::hatchingOperation<ProcessLine>(bounding_box, final_vert_spacing, final_vert_offset, final_rotation - M_PI / 2, process_line);
+	else // if (display == VerticalLines)
 		Util::hatchingOperation<ProcessLine>(bounding_box, final_horz_spacing, final_horz_offset, final_rotation, process_line);
 }
 

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -173,9 +173,14 @@ namespace Util
 	void hatchingOperation(const QRectF& extent, double spacing, double offset, double rotation, T& processor)
 	{
 		// Make rotation unique
-		rotation = fmod(1.0 * rotation, M_PI);
+		rotation = fmod(1.0 * rotation, 2 * M_PI);
 		if (rotation < 0)
-			rotation = M_PI + rotation;
+			rotation += 2 * M_PI;
+		if (rotation >= M_PI)
+		{
+			rotation -= M_PI;
+			offset = -offset;
+		}
 		Q_ASSERT(rotation >= 0 && rotation <= M_PI);
 		
 		if (qAbs(rotation - M_PI/2) < 0.0001)
@@ -187,9 +192,11 @@ namespace Util
 				processor.processLine(QPointF(cur, extent.top()), QPointF(cur, extent.bottom()));
 			}
 		}
-		else if (qAbs(rotation - 0) < 0.0001)
+		else if (rotation < 0.0001 || rotation > M_PI - 0.0001)
 		{
 			// Special case: horizontal lines
+			if (rotation > M_PI/2)
+				offset = -offset;
 			double first = offset + ceil((extent.top() - offset) / (spacing)) * spacing;
 			for (double cur = first; cur < extent.bottom(); cur += spacing)
 			{
@@ -301,7 +308,7 @@ namespace Util
 	                   double horz_offset, double vert_offset, double rotation, T& processor)
 	{
 		hatchingOperation(extent, horz_spacing, horz_offset, rotation, processor);
-		hatchingOperation(extent, vert_spacing, vert_offset, rotation + M_PI / 2, processor);
+		hatchingOperation(extent, vert_spacing, vert_offset, rotation - M_PI / 2, processor);
 	}
 	
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -153,6 +153,7 @@ add_unit_test(georeferencing_t ../src/core/georeferencing
 	../src/mapper_resource
 	../src/fileformats/file_format
 )
+add_unit_test(grid_t )
 add_unit_test(locale_t ../src/util/translation_util)
 add_unit_test(map_color_t ../src/core/map_color)
 add_unit_test(ocd_t ../src/fileformats/ocd_types)

--- a/test/grid_t.cpp
+++ b/test/grid_t.cpp
@@ -1,0 +1,222 @@
+/*
+ *    Copyright 2019 Kai Pastor
+ *
+ *    This file is part of OpenOrienteering.
+ *
+ *    OpenOrienteering is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OpenOrienteering is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <utility>
+#include <vector>
+
+#include <QtMath>
+#include <QtTest>
+#include <QObject>
+#include <QPointF>
+#include <QRectF>
+#include <QVarLengthArray>
+
+#include "core/map_grid.h"
+#include "util/util.h"
+
+
+namespace OpenOrienteering
+{
+
+namespace
+{
+
+struct Recorder
+{
+	struct Record { QPointF p0, p1; };
+	QVarLengthArray<Record, 2> records;
+	void processLine(const QPointF& a, const QPointF& b)
+	{
+		records.push_back({a, b});
+	}
+};
+
+}  // namespace
+
+
+/**
+ * @test Unit test for grid operations.
+ */
+class GridTest : public QObject
+{
+Q_OBJECT
+	
+private slots:
+	void initTestCase()
+	{
+		// nothing yet
+	}
+	
+	void hatchingOperationTest()
+	{
+		QFETCH(double, rotation);
+		QFETCH(double, offset);
+		QFETCH(QPointF, p0);
+		QFETCH(QPointF, p1);
+		
+		auto bounding_box = QRectF{ -60, -60, 120, 120 };
+		auto spacing = 200.0;
+		Recorder recorder;
+		Util::hatchingOperation(bounding_box, spacing, offset, qDegreesToRadians(rotation), recorder);
+		
+		const auto num_records = int(recorder.records.size());
+		QCOMPARE(num_records, 1);
+		
+		auto& actual = recorder.records.front();
+		if (!qFuzzyCompare(actual.p0.x(), bounding_box.left()) && !qFuzzyCompare(actual.p0.y(), bounding_box.top()))
+			std::swap(actual.p0, actual.p1);  // normalize
+		QCOMPARE(actual.p0, p0);
+		QCOMPARE(actual.p1, p1);
+	}
+	
+	void hatchingOperationTest_data()
+	{
+		const auto rot37 = atan(0.75) * 180 / M_PI;
+		const auto rot53 = 90 - rot37;
+
+		QTest::addColumn<double>("rotation");
+		QTest::addColumn<double>("offset");
+		QTest::addColumn<QPointF>("p0");
+		QTest::addColumn<QPointF>("p1");
+		
+		QTest::newRow("rotation:0, offset:0")     <<    0.0 <<   0.0 << QPointF{-60,  0}  << QPointF{+60,  0};
+		QTest::newRow("rotation:0, offset:+1")    <<    0.0 <<  +1.0 << QPointF{-60, +1}  << QPointF{+60, +1};
+		QTest::newRow("rotation:0, offset:-2")    <<    0.0 <<  -2.0 << QPointF{-60, -2}  << QPointF{+60, -2};
+		QTest::newRow("rotation:+360, offset:-2") << +360.0 <<  -2.0 << QPointF{-60, -2}  << QPointF{+60, -2};
+		QTest::newRow("rotation:-360, offset:-2") << -360.0 <<  -2.0 << QPointF{-60, -2}  << QPointF{+60, -2};
+		
+		QTest::newRow("rotation:+37, offset:0")   << +rot37 <<   0.0 << QPointF{-60, +45} << QPointF{+60, -45};
+		QTest::newRow("rotation:+37, offset:12")  << +rot37 << +12.0 << QPointF{-60, +60} << QPointF{+60, -30};
+		QTest::newRow("rotation:+37, offset:-12") << +rot37 << -12.0 << QPointF{+60, -60} << QPointF{-60, +30};
+		QTest::newRow("rotation:+37, offset:24")  << +rot37 << +24.0 << QPointF{-40, +60} << QPointF{+60, -15};
+		QTest::newRow("rotation:+37, offset:-24") << +rot37 << -24.0 << QPointF{+40, -60} << QPointF{-60, +15};
+		
+		QTest::newRow("rotation:+53, offset:0")   << +rot53 <<   0.0 << QPointF{+45, -60} << QPointF{-45, +60};
+		QTest::newRow("rotation:+53, offset:12")  << +rot53 << +12.0 << QPointF{+60, -60} << QPointF{-30, +60};
+		QTest::newRow("rotation:+53, offset:-12") << +rot53 << -12.0 << QPointF{+30, -60} << QPointF{-60, +60};
+		QTest::newRow("rotation:+53, offset:24")  << +rot53 << +24.0 << QPointF{-15, +60} << QPointF{+60, -40};
+		QTest::newRow("rotation:+53, offset:-24") << +rot53 << -24.0 << QPointF{+15, -60} << QPointF{-60, +40};
+		
+		QTest::newRow("rotation:+90, offset:0")   <<  +90.0 <<   0.0 << QPointF{ 0, -60}  << QPointF{ 0, +60};
+		QTest::newRow("rotation:+90, offset:+1")  <<  +90.0 <<  +1.0 << QPointF{+1, -60}  << QPointF{+1, +60};
+		QTest::newRow("rotation:+90, offset:-2")  <<  +90.0 <<  -2.0 << QPointF{-2, -60}  << QPointF{-2, +60};
+		QTest::newRow("rotation:-270, offset:-2") << -270.0 <<  -2.0 << QPointF{-2, -60}  << QPointF{-2, +60};
+		
+		QTest::newRow("rotation:+179, offset:+1") <<+179.9999<< +1.0 << QPointF{-60, -1}  << QPointF{+60, -1};
+		QTest::newRow("rotation:+180, offset:0")  << +180.0 <<  +0.0 << QPointF{-60,  0}  << QPointF{+60,  0};
+		QTest::newRow("rotation:+180, offset:+1") << +180.0 <<  +1.0 << QPointF{-60, -1}  << QPointF{+60, -1};
+		QTest::newRow("rotation:+180, offset:-2") << +180.0 <<  -2.0 << QPointF{-60, +2}  << QPointF{+60, +2};
+		QTest::newRow("rotation:-180, offset:-2") << -180.0 <<  -2.0 << QPointF{-60, +2}  << QPointF{+60, +2};
+		
+		QTest::newRow("rotation:+270, offset:0")  << +270.0 <<   0.0 << QPointF{ 0, -60}  << QPointF{ 0, +60};
+		QTest::newRow("rotation:+270, offset:+1") << +270.0 <<  +1.0 << QPointF{-1, -60}  << QPointF{-1, +60};
+		QTest::newRow("rotation:+270, offset:-2") << +270.0 <<  -2.0 << QPointF{+2, -60}  << QPointF{+2, +60};
+		QTest::newRow("rotation:-90, offset:-2")  <<  -90.0 <<  -2.0 << QPointF{+2, -60}  << QPointF{+2, +60};
+		
+		QTest::newRow("rotation:-53, offset:0")   << -rot53 <<   0.0 << QPointF{-45, -60} << QPointF{+45, +60};
+		QTest::newRow("rotation:-53, offset:12")  << -rot53 << +12.0 << QPointF{-60, -60} << QPointF{+30, +60};
+		QTest::newRow("rotation:-53, offset:-12") << -rot53 << -12.0 << QPointF{-30, -60} << QPointF{+60, +60};
+		QTest::newRow("rotation:-53, offset:24")  << -rot53 << +24.0 << QPointF{-60, -40} << QPointF{+15, +60};
+		QTest::newRow("rotation:-53, offset:-24") << -rot53 << -24.0 << QPointF{-15, -60} << QPointF{+60, +40};
+		
+		QTest::newRow("rotation:-37, offset:0")   << -rot37 <<   0.0 << QPointF{-60, -45} << QPointF{+60, +45};
+		QTest::newRow("rotation:-37, offset:12")  << -rot37 << +12.0 << QPointF{-60, -30} << QPointF{+60, +60};
+		QTest::newRow("rotation:-37, offset:-12") << -rot37 << -12.0 << QPointF{-60, -60} << QPointF{+60, +30};
+		QTest::newRow("rotation:-37, offset:24")  << -rot37 << +24.0 << QPointF{-60, -15} << QPointF{+40, +60};
+		QTest::newRow("rotation:-37, offset:-24") << -rot37 << -24.0 << QPointF{-40, -60} << QPointF{+60, +15};
+	}
+	
+	
+	
+	void gridOperationTest()
+	{
+		QFETCH(double, rotation);
+		QFETCH(double, offset);
+		QFETCH(QPointF, p00);
+		QFETCH(QPointF, p01);
+		QFETCH(QPointF, p10);
+		QFETCH(QPointF, p11);
+		
+		auto bounding_box = QRectF{ -5, -5, 10, 10 };
+		auto spacing = 100.0;
+		Recorder recorder;
+		Util::gridOperation(bounding_box, spacing, spacing, offset, offset, qDegreesToRadians(rotation), recorder);
+		
+		const auto num_records = int(recorder.records.size());
+		QCOMPARE(num_records, 2);
+		
+		if (!qIsNull(recorder.records.front().p0.y())
+		    && qFuzzyCompare(recorder.records.front().p0.y(), -recorder.records.front().p1.y())
+		    && !qIsNull(recorder.records.back().p0.x())
+		    && qFuzzyCompare(recorder.records.back().p0.x(), -recorder.records.back().p1.x()))
+		{
+			std::swap(recorder.records.front(), recorder.records.back());  // normalize
+		}
+		
+		{
+			auto& actual = recorder.records.front();
+			if (!qFuzzyCompare(actual.p0.x(), bounding_box.left()) && !qFuzzyCompare(actual.p0.y(), bounding_box.top()))
+				std::swap(actual.p0, actual.p1);  // normalize
+			QCOMPARE(actual.p0, p00);
+			QCOMPARE(actual.p1, p01);
+		}
+		
+		{
+			auto& actual = recorder.records.back();
+			if (!qFuzzyCompare(actual.p0.x(), bounding_box.left()) && !qFuzzyCompare(actual.p0.y(), bounding_box.top()))
+				std::swap(actual.p0, actual.p1);  // normalize
+			QCOMPARE(actual.p0, p10);
+			QCOMPARE(actual.p1, p11);
+		}
+	}
+	
+	void gridOperationTest_data()
+	{
+		QTest::addColumn<double>("rotation");
+		QTest::addColumn<double>("offset");
+		QTest::addColumn<QPointF>("p00");
+		QTest::addColumn<QPointF>("p01");
+		QTest::addColumn<QPointF>("p10");
+		QTest::addColumn<QPointF>("p11");
+		
+		QTest::newRow("rotation:0, offset:0")     <<    0.0 <<  0.0 << QPointF{-5,  0} << QPointF{+5,  0} << QPointF{ 0, -5} << QPointF{ 0, +5};
+		QTest::newRow("rotation:0, offset:+1")    <<    0.0 << +1.0 << QPointF{-5, +1} << QPointF{+5, +1} << QPointF{-1, -5} << QPointF{-1, +5};
+		QTest::newRow("rotation:+360, offset:+1") << +360.0 << +1.0 << QPointF{-5, +1} << QPointF{+5, +1} << QPointF{-1, -5} << QPointF{-1, +5};
+		QTest::newRow("rotation:-360, offset:+1") << -360.0 << +1.0 << QPointF{-5, +1} << QPointF{+5, +1} << QPointF{-1, -5} << QPointF{-1, +5};
+		
+		QTest::newRow("rotation:+90, offset:+1")  <<  +90.0 << +1.0 << QPointF{-5, +1} << QPointF{+5, +1} << QPointF{+1, -5} << QPointF{+1, +5};
+		QTest::newRow("rotation:-270, offset:+1") << -270.0 << +1.0 << QPointF{-5, +1} << QPointF{+5, +1} << QPointF{+1, -5} << QPointF{+1, +5};
+		
+		QTest::newRow("rotation:+180, offset:+1") << +180.0 << +1.0 << QPointF{-5, -1} << QPointF{+5, -1} << QPointF{+1, -5} << QPointF{+1, +5};
+		QTest::newRow("rotation:-180, offset:+1") << -180.0 << +1.0 << QPointF{-5, -1} << QPointF{+5, -1} << QPointF{+1, -5} << QPointF{+1, +5};
+		
+		QTest::newRow("rotation:+270, offset:+1") << +270.0 << +1.0 << QPointF{-5, -1} << QPointF{+5, -1} << QPointF{-1, -5} << QPointF{-1, +5};
+		QTest::newRow("rotation:-90, offset:+1")  <<  -90.0 << +1.0 << QPointF{-5, -1} << QPointF{+5, -1} << QPointF{-1, -5} << QPointF{-1, +5};
+	}
+	
+};  // class GridTest
+
+
+}  // namespace OpenOrienteering
+
+
+
+QTEST_APPLESS_MAIN(OpenOrienteering::GridTest)
+
+#include "grid_t.moc"  // IWYU pragma: keep


### PR DESCRIPTION
When the Map Grid is enabled, a negative rotation leads to offsets being interpreted in the wrong direction.

To reproduce,

1. Configure the grid to be visible with an additional rotation of -20°, and a vertical offset of 30 meters.
1. The horizontal lines show up offset downwards, whereas a positive vertical offset should move the lines toward the top.
1. The snap-to-grid feature snaps to the _correct_ grid intersections, which do not match the visible horizontal lines.

Alternatively,
1. Set georeferencing such that grivation is negative, and the origin of projected coordinates is offset from the map origin.
1. Projected coordinates of the visible horizontal lines do not match multiples of the vertical spacing.
1. The snap-to-grid feature snaps to the _correct_ grid intersections, which do not match the visible horizontal lines.
***
`hatchingOperation` should recognize the full circle of possible rotation values. Also fix the direction of the quarter-turn when calling `hatchingOperation` for horizontal lines. This provides correct offset to the origin of projected coordinates.