### PR TITLE
Add Sensor settings

### DIFF
--- a/code-check-wrapper.sh
+++ b/code-check-wrapper.sh
@@ -61,7 +61,6 @@ PATTERN=" \
   georeferencing_t.cpp \
   gdal_manager.cpp \
   gdal_template.cpp \
-  gps_display.cpp \
   key_button_bar.cpp \
   line_symbol.cpp \
   /map.cpp \
@@ -101,6 +100,7 @@ PATTERN=" \
   xml_stream_util.cpp \
   \
   ocd \
+  src/sensors/ \
   src/tools/ \
   settings \
   \

--- a/src/gui/settings_dialog.cpp
+++ b/src/gui/settings_dialog.cpp
@@ -60,6 +60,10 @@
 #  include "gdal/gdal_settings_page.h"
 #endif
 
+#ifdef MAPPER_USE_SENSORS
+#  include "sensors/sensors_settings_page.h"
+#endif
+
 
 namespace OpenOrienteering {
 
@@ -211,6 +215,9 @@ void SettingsDialog::addPages()
 	addPage(new EditorSettingsPage(this));
 #ifdef MAPPER_USE_GDAL
 	addPage(new GdalSettingsPage(this));
+#endif
+#ifdef MAPPER_USE_SENSORS
+	addPage(new SensorsSettingsPage(this));
 #endif
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,6 +24,7 @@
 
 #include <Qt>
 #include <QtGlobal>
+#include <QtPlugin>
 #include <QApplication>
 #include <QLatin1String>
 #include <QLocale>
@@ -57,6 +58,11 @@
 // IWYU pragma: no_forward_declare QTranslator
 
 using namespace OpenOrienteering;
+
+
+#if defined(Q_OS_WIN32) && defined(MAPPER_USE_POWERSHELL_POSITION_PLUGIN)
+Q_IMPORT_PLUGIN(PowershellPositionPlugin)
+#endif
 
 
 // From map.h

--- a/src/sensors/CMakeLists.txt
+++ b/src/sensors/CMakeLists.txt
@@ -70,6 +70,7 @@ set(MAPPER_SENSORS_SOURCES
   gps_display.cpp
   gps_temporary_markers.cpp
   gps_track_recorder.cpp
+  sensors_settings_page.cpp
 )
 
 set(MAPPER_SENSORS_DEFINITIONS

--- a/src/sensors/CMakeLists.txt
+++ b/src/sensors/CMakeLists.txt
@@ -27,6 +27,42 @@ endif()
 set(CMAKE_AUTOMOC ON)
 
 
+# PowershellPositionPlugin
+#
+# For testing purposes, we build this plugin on all platforms,
+# but we register it in main.cpp on WIN32 only.
+
+set(POWERSHELL_POSITION_DEFINITIONS
+  PRIVATE
+    QT_NO_CAST_FROM_ASCII
+    QT_NO_CAST_TO_ASCII
+    QT_USE_QSTRINGBUILDER
+    QT_STATICPLUGIN
+)
+set(POWERSHELL_POSITION_SOURCES )
+set(POWERSHELL_POSITION_LINK_LIBRARIES )
+if(TARGET Qt5::Positioning)
+	list(APPEND POWERSHELL_POSITION_DEFINITIONS
+	  PUBLIC MAPPER_USE_POWERSHELL_POSITION_PLUGIN
+	)
+	list(APPEND POWERSHELL_POSITION_SOURCES
+	  powershell_position_plugin.cpp
+	  powershell_position_plugin.json
+	  powershell_position_source.cpp
+	)
+	qt5_add_resources(POWERSHELL_POSITION_SOURCES
+	  "${CMAKE_CURRENT_SOURCE_DIR}/powershell_position_source.qrc"
+	)
+	list(APPEND POWERSHELL_POSITION_LINK_LIBRARIES
+	  PRIVATE Qt5::Positioning
+	)
+endif()
+
+add_library(powershell_position_source STATIC  ${POWERSHELL_POSITION_SOURCES})
+target_compile_definitions(powershell_position_source  ${POWERSHELL_POSITION_DEFINITIONS})
+target_link_libraries(powershell_position_source  ${POWERSHELL_POSITION_LINK_LIBRARIES})
+
+
 # Mapper sensors
 
 set(MAPPER_SENSORS_SOURCES
@@ -47,20 +83,12 @@ if(TARGET Qt5::Positioning OR TARGET Qt5::Sensors)
 	list(APPEND MAPPER_SENSORS_DEFINITIONS  PUBLIC MAPPER_USE_SENSORS)
 endif()
 
-if(TARGET Qt5::Positioning)
-	list(APPEND MAPPER_SENSORS_SOURCES
-	  powershell_position_source.cpp
-	)
-	qt5_add_resources(MAPPER_SENSORS_SOURCES
-	  "${CMAKE_CURRENT_SOURCE_DIR}/powershell_position_source.qrc"
-	)
-endif()
-
 add_library(mapper-sensors STATIC  ${MAPPER_SENSORS_SOURCES})
 target_compile_definitions(mapper-sensors  ${MAPPER_SENSORS_DEFINITIONS})
 target_include_directories(mapper-sensors  PRIVATE "${PROJECT_SOURCE_DIR}/src")
 target_link_libraries(mapper-sensors
   PUBLIC
+    powershell_position_source
     Qt5::Core
     Qt5::Gui
     Qt5::Widgets
@@ -76,4 +104,5 @@ endforeach()
 
 mapper_translations_sources(
   ${MAPPER_SENSORS_SOURCES}
+  ${POWERSHELL_POSITION_SOURCES}
 )

--- a/src/sensors/CMakeLists.txt
+++ b/src/sensors/CMakeLists.txt
@@ -26,12 +26,8 @@ endif()
 
 set(CMAKE_AUTOMOC ON)
 
-set(MAPPER_SENSORS_RESOURCES )
 
-# Extra header to be shown in the IDE (e.g. private) or to be translated
-set(MAPPER_SENSORS_HEADERS
-  # not needed ATM
-)
+# Mapper sensors
 
 set(MAPPER_SENSORS_SOURCES
   compass.cpp
@@ -40,40 +36,29 @@ set(MAPPER_SENSORS_SOURCES
   gps_track_recorder.cpp
 )
 
-if(TARGET Qt5::Positioning)
-	list(APPEND MAPPER_SENSORS_SOURCES
-	  powershell_position_source.cpp
-	)
-	qt5_add_resources(MAPPER_SENSORS_RESOURCES
-	  "${CMAKE_CURRENT_SOURCE_DIR}/powershell_position_source.qrc"
-	)
-endif()
-
-mapper_translations_sources(
-  ${MAPPER_SENSORS_HEADERS}
-  ${MAPPER_SENSORS_SOURCES}
-)
-
-add_library(mapper-sensors STATIC
-  ${MAPPER_SENSORS_HEADERS}
-  ${MAPPER_SENSORS_SOURCES}
-  ${MAPPER_SENSORS_RESOURCES}
-)
-
-target_compile_definitions(mapper-sensors
-  PUBLIC
-    MAPPER_USE_SENSORS
+set(MAPPER_SENSORS_DEFINITIONS
   PRIVATE
     QT_NO_CAST_FROM_ASCII
     QT_NO_CAST_TO_ASCII
     QT_USE_QSTRINGBUILDER
 )
 
-target_include_directories(mapper-sensors
-  PRIVATE
-    "${PROJECT_SOURCE_DIR}/src"
-)
+if(TARGET Qt5::Positioning OR TARGET Qt5::Sensors)
+	list(APPEND MAPPER_SENSORS_DEFINITIONS  PUBLIC MAPPER_USE_SENSORS)
+endif()
 
+if(TARGET Qt5::Positioning)
+	list(APPEND MAPPER_SENSORS_SOURCES
+	  powershell_position_source.cpp
+	)
+	qt5_add_resources(MAPPER_SENSORS_SOURCES
+	  "${CMAKE_CURRENT_SOURCE_DIR}/powershell_position_source.qrc"
+	)
+endif()
+
+add_library(mapper-sensors STATIC  ${MAPPER_SENSORS_SOURCES})
+target_compile_definitions(mapper-sensors  ${MAPPER_SENSORS_DEFINITIONS})
+target_include_directories(mapper-sensors  PRIVATE "${PROJECT_SOURCE_DIR}/src")
 target_link_libraries(mapper-sensors
   PUBLIC
     Qt5::Core
@@ -82,6 +67,13 @@ target_link_libraries(mapper-sensors
 )
 foreach(lib Qt5::Positioning Qt5::Sensors Qt5::AndroidExtras)
 	if(TARGET ${lib})
-		target_link_libraries(mapper-sensors PRIVATE ${lib})
+		target_link_libraries(mapper-sensors  PRIVATE ${lib})
 	endif()
 endforeach()
+
+
+# Translations
+
+mapper_translations_sources(
+  ${MAPPER_SENSORS_SOURCES}
+)

--- a/src/sensors/CMakeLists.txt
+++ b/src/sensors/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(Qt5Core 5.3 REQUIRED)
 find_package(Qt5Widgets REQUIRED)
 find_package(Qt5Sensors)
 find_package(Qt5Positioning)
+find_package(Qt5SerialPort)
 if(ANDROID)
 	find_package(Qt5AndroidExtras REQUIRED)
 endif()
@@ -94,7 +95,7 @@ target_link_libraries(mapper-sensors
     Qt5::Gui
     Qt5::Widgets
 )
-foreach(lib Qt5::Positioning Qt5::Sensors Qt5::AndroidExtras)
+foreach(lib Qt5::Positioning Qt5::Sensors Qt5::SerialPort Qt5::AndroidExtras)
 	if(TARGET ${lib})
 		target_link_libraries(mapper-sensors  PRIVATE ${lib})
 	endif()

--- a/src/sensors/compass.cpp
+++ b/src/sensors/compass.cpp
@@ -20,30 +20,39 @@
 
 #include "compass.h"
 
-#include <cmath>
-
-#include <QtMath>  // IWYU pragma: keep
 #include <QtGlobal>  // IWYU pragma: keep
 #include <QMetaMethod>
 #include <QMetaObject>
-#include <QMutex>  // IWYU pragma: keep
-#include <QTime>
 
 #ifdef QT_SENSORS_LIB
 
+#include <cmath>
+#include <cstring>
+
+#include <Qt>
+#include <QtMath>
+#include <QAccelerometer>
+#include <QAccelerometerReading>
+#include <QGyroscope>
+#include <QGyroscopeFilter>
+#include <QGyroscopeReading>
+#include <QList>
+#include <QMagnetometer>
+#include <QMagnetometerReading>
+#include <QMutex>
+#include <QSensor>
 #include <QThread>
-#include <QDebug>
 #include <QWaitCondition>
-#include <QtSensors/QAccelerometer>
-#include <QtSensors/QGyroscope>
-#include <QtSensors/QMagnetometer>
-#include <QtSensors/QSensor>
 
 #ifdef Q_OS_ANDROID
 #include <QtAndroidExtras/QAndroidJniObject>
 #endif
 
-#endif  // # QT_SENSORS_LIB
+#else  // no Qt Sensors lib
+
+#include <QTime>
+
+#endif  // QT_SENSORS_LIB
 
 
 // clazy:excludeall=missing-qobject-macro

--- a/src/sensors/compass.h
+++ b/src/sensors/compass.h
@@ -25,6 +25,7 @@
 #include <memory>
 
 #include <QObject>
+#include <QString>
 
 class QMetaMethod;
 

--- a/src/sensors/gps_display.cpp
+++ b/src/sensors/gps_display.cpp
@@ -54,9 +54,6 @@
 #include "gui/util_gui.h"
 #include "gui/map/map_widget.h"
 #include "sensors/compass.h"
-#ifdef WIN32
-#  include "sensors/powershell_position_source.h"
-#endif
 #include "util/backports.h"  // IWYU pragma: keep
 
 
@@ -111,14 +108,6 @@ GPSDisplay::GPSDisplay(MapWidget* widget, const Georeferencing& georeferencing, 
 {
 #if defined(QT_POSITIONING_LIB)
 	source = QGeoPositionInfoSource::createDefaultSource(this);
-#if defined(Q_OS_WIN)
-	if (!source)
-	{
-		auto powershell_source = std::make_unique<PowershellPositionSource>(this);
-		if (powershell_source->error() == QGeoPositionInfoSource::NoError)
-			source = powershell_source.release();
-	}
-#endif
 	if (!source)
 	{
 		qDebug("Cannot create QGeoPositionInfoSource!");

--- a/src/sensors/gps_display.cpp
+++ b/src/sensors/gps_display.cpp
@@ -38,6 +38,7 @@
 #include <QtMath>
 #include <QColor>
 #include <QFlags>
+#include <QLatin1String>
 #include <QPainter>
 #include <QPen>
 #include <QPoint>
@@ -48,6 +49,7 @@
 #include <QTimer>  // IWYU pragma: keep
 #include <QTimerEvent>
 
+#include "settings.h"
 #include "core/georeferencing.h"
 #include "core/latlon.h"
 #include "core/map_view.h"
@@ -107,10 +109,21 @@ GPSDisplay::GPSDisplay(MapWidget* widget, const Georeferencing& georeferencing, 
  , georeferencing(georeferencing)
 {
 #if defined(QT_POSITIONING_LIB)
-	source = QGeoPositionInfoSource::createDefaultSource(this);
+	auto const & settings = Settings::getInstance();
+	auto source_name = settings.positionSource();
+	if (source_name.isEmpty())
+	{
+		source_name = QLatin1String("default");
+		source = QGeoPositionInfoSource::createDefaultSource(this);
+	}
+	else
+	{
+		source = QGeoPositionInfoSource::createSource(source_name, this);	
+	}
+	
 	if (!source)
 	{
-		qDebug("Cannot create QGeoPositionInfoSource!");
+		qDebug("Cannot create QGeoPositionInfoSource '%s'!", qPrintable(source_name));
 		return;
 	}
 	

--- a/src/sensors/gps_display.cpp
+++ b/src/sensors/gps_display.cpp
@@ -118,6 +118,12 @@ GPSDisplay::GPSDisplay(MapWidget* widget, const Georeferencing& georeferencing, 
 	}
 	else
 	{
+		auto const nmea_serialport = settings.nmeaSerialPort();
+		if (source_name == QLatin1String("serialnmea") && !nmea_serialport.isEmpty())
+		{
+			qputenv("QT_NMEA_SERIAL_PORT", nmea_serialport.toUtf8());
+			source_name += QLatin1String(" from ") + nmea_serialport;
+		}
 		source = QGeoPositionInfoSource::createSource(source_name, this);	
 	}
 	

--- a/src/sensors/gps_temporary_markers.cpp
+++ b/src/sensors/gps_temporary_markers.cpp
@@ -21,11 +21,20 @@
 
 #include "gps_temporary_markers.h"
 
+#include <Qt>
+#include <QtGlobal>
+#include <QBrush>
 #include <QPainter>
+#include <QPen>
+#include <QRgb>
 
+#include "core/map_coord.h"
+#include "core/map_view.h"
 #include "gui/map/map_widget.h"
-#include "gps_display.h"
+#include "sensors/gps_display.h"
 #include "tools/tool.h"
+
+class QPointF;
 
 
 namespace OpenOrienteering {

--- a/src/sensors/gps_temporary_markers.h
+++ b/src/sensors/gps_temporary_markers.h
@@ -25,6 +25,7 @@
 
 #include <QObject>
 #include <QPointF>
+#include <QString>
 
 class QPainter;
 // IWYU pragma: no_forward_declare QPointF

--- a/src/sensors/gps_track_recorder.cpp
+++ b/src/sensors/gps_track_recorder.cpp
@@ -20,7 +20,13 @@
 
 #include "gps_track_recorder.h"
 
+#include <QDateTime>
+#include <QtGlobal>
+
+#include "core/latlon.h"
 #include "core/map.h"
+#include "core/map_view.h"
+#include "core/track.h"
 #include "gui/map/map_widget.h"
 #include "sensors/gps_display.h"
 #include "templates/template_track.h"

--- a/src/sensors/gps_track_recorder.h
+++ b/src/sensors/gps_track_recorder.h
@@ -22,6 +22,7 @@
 #define OPENORIENTEERING_GPS_TRACK_RECORDER_H
 
 #include <QObject>
+#include <QString>
 #include <QTimer>
 
 namespace OpenOrienteering {

--- a/src/sensors/powershell_position_plugin.cpp
+++ b/src/sensors/powershell_position_plugin.cpp
@@ -1,0 +1,51 @@
+/*
+ *    Copyright 2019 Kai Pastor
+ *
+ *    This file is part of OpenOrienteering.
+ *
+ *    OpenOrienteering is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OpenOrienteering is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "powershell_position_plugin.h"
+
+#include "powershell_position_source.h"
+
+
+namespace OpenOrienteering
+{
+
+PowershellPositionPlugin::PowershellPositionPlugin(QObject* parent)
+: QObject(parent)
+{}
+
+PowershellPositionPlugin::~PowershellPositionPlugin() = default;
+
+
+QGeoAreaMonitorSource* PowershellPositionPlugin::areaMonitor(QObject* /* parent */)
+{
+	return nullptr;
+}
+
+QGeoPositionInfoSource* PowershellPositionPlugin::positionInfoSource(QObject* parent)
+{
+	return new PowershellPositionSource(parent);
+}
+
+QGeoSatelliteInfoSource* PowershellPositionPlugin::satelliteInfoSource(QObject* /* parent */)
+{
+	return nullptr;
+}
+
+
+}  // namespace OpenOrienteering

--- a/src/sensors/powershell_position_plugin.h
+++ b/src/sensors/powershell_position_plugin.h
@@ -1,0 +1,58 @@
+/*
+ *    Copyright 2019 Kai Pastor
+ *
+ *    This file is part of OpenOrienteering.
+ *
+ *    OpenOrienteering is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OpenOrienteering is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPENORIENTEERING_POWERSHELL_POSITION_PLUGIN_H
+#define OPENORIENTEERING_POWERSHELL_POSITION_PLUGIN_H
+
+#include <QGeoPositionInfoSourceFactory>
+#include <QObject>
+#include <QString>
+
+class QGeoAreaMonitorSource;
+class QGeoPositionInfoSource;
+class QGeoSatelliteInfoSource;
+
+namespace OpenOrienteering
+{
+
+/**
+ * A plugin for properly registering PowershellPositionSource.
+ */
+class PowershellPositionPlugin : public QObject, public QGeoPositionInfoSourceFactory 
+{
+	Q_OBJECT
+	Q_PLUGIN_METADATA(IID "org.qt-project.qt.position.sourcefactory/5.0"
+	                  FILE "powershell_position_plugin.json")
+	Q_INTERFACES(QGeoPositionInfoSourceFactory)
+public:
+	PowershellPositionPlugin(QObject* parent = nullptr);
+	PowershellPositionPlugin(const PowershellPositionPlugin&) = delete;
+	PowershellPositionPlugin(PowershellPositionPlugin&&) = delete;
+	PowershellPositionPlugin& operator=(const PowershellPositionPlugin&) = delete;
+	PowershellPositionPlugin&& operator=(PowershellPositionPlugin&&) = delete;
+	~PowershellPositionPlugin() override;
+	QGeoAreaMonitorSource* areaMonitor(QObject* parent) override;
+	QGeoPositionInfoSource* positionInfoSource(QObject* parent) override;
+	QGeoSatelliteInfoSource* satelliteInfoSource(QObject* parent) override;
+};
+
+
+}  // namespace OpenOrienteering
+
+#endif  // OPENORIENTEERING_POWERSHELL_POSITION_PLUGIN_H

--- a/src/sensors/powershell_position_plugin.json
+++ b/src/sensors/powershell_position_plugin.json
@@ -1,0 +1,9 @@
+{
+    "Keys":      ["powershell"],
+    "Provider":  "Windows",
+    "Position":  true,
+    "Satellite": false,
+    "Monitor":   false,
+    "Priority":  1000,
+    "Testable":  false
+}

--- a/src/sensors/powershell_position_source.cpp
+++ b/src/sensors/powershell_position_source.cpp
@@ -19,9 +19,21 @@
 
 #include "powershell_position_source.h"
 
+#include <algorithm>
+#include <iterator>
+
+#include <Qt>
+#include <QtGlobal>
+#include <QtNumeric>
+#include <QDateTime>
 #include <QFile>
 #include <QFileDevice>
+#include <QGeoCoordinate>
+#include <QIODevice>
+#include <QLatin1Char>
+#include <QLatin1String>
 #include <QStandardPaths>
+#include <QStringList>
 
 
 inline void initPowershellPositionResources()

--- a/src/sensors/powershell_position_source.h
+++ b/src/sensors/powershell_position_source.h
@@ -20,8 +20,6 @@
 #ifndef OPENORIENTEERING_POWERSHELL_POSITION_SOURCE_H
 #define OPENORIENTEERING_POWERSHELL_POSITION_SOURCE_H
 
-#ifdef QT_POSITIONING_LIB
-
 #include <QByteArray>
 #include <QGeoPositionInfo>
 #include <QGeoPositionInfoSource>
@@ -131,7 +129,5 @@ private:
 
 
 }  // namespace OpenOrienteering
-
-#endif  // QT_POSITIONING_LIB
 
 #endif  // OPENORIENTEERING_POWERSHELL_POSITION_SOURCE_H

--- a/src/sensors/powershell_position_source.h
+++ b/src/sensors/powershell_position_source.h
@@ -25,7 +25,9 @@
 #include <QByteArray>
 #include <QGeoPositionInfo>
 #include <QGeoPositionInfoSource>
+#include <QObject>
 #include <QProcess>
+#include <QString>
 #include <QTimer>
 
 namespace OpenOrienteering

--- a/src/sensors/sensors_settings_page.cpp
+++ b/src/sensors/sensors_settings_page.cpp
@@ -1,0 +1,67 @@
+/*
+ *    Copyright 2019 Kai Pastor
+ *
+ *    This file is part of OpenOrienteering.
+ *
+ *    OpenOrienteering is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OpenOrienteering is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "sensors_settings_page.h"
+
+#include <QFormLayout>
+
+#include "settings.h"
+
+
+namespace OpenOrienteering {
+
+SensorsSettingsPage::SensorsSettingsPage(QWidget* parent)
+: SettingsPage(parent)
+{
+	auto* form_layout = new QFormLayout(this);
+	
+	Q_UNUSED(form_layout)  // TODO
+	
+	updateWidgets();
+}
+
+SensorsSettingsPage::~SensorsSettingsPage() = default;
+
+
+QString SensorsSettingsPage::title() const
+{
+	return tr("Sensors");
+}
+
+
+void SensorsSettingsPage::apply()
+{
+	Settings::getInstance().applySettings();
+}
+
+
+void SensorsSettingsPage::reset()
+{
+	updateWidgets();
+}
+
+
+void SensorsSettingsPage::updateWidgets()
+{
+	// todo
+}
+
+
+}  // namespace OpenOrienteering

--- a/src/sensors/sensors_settings_page.cpp
+++ b/src/sensors/sensors_settings_page.cpp
@@ -20,9 +20,19 @@
 
 #include "sensors_settings_page.h"
 
+#include <QComboBox>
 #include <QFormLayout>
+#include <QLabel>
+#include <QLatin1String>
+#include <QSpacerItem>
+#include <QVariant>
+
+#ifdef QT_POSITIONING_LIB
+#  include <QGeoPositionInfoSource>
+#endif
 
 #include "settings.h"
+#include "gui/util_gui.h"
 
 
 namespace OpenOrienteering {
@@ -32,7 +42,14 @@ SensorsSettingsPage::SensorsSettingsPage(QWidget* parent)
 {
 	auto* form_layout = new QFormLayout(this);
 	
-	Q_UNUSED(form_layout)  // TODO
+#ifdef QT_POSITIONING_LIB
+	form_layout->addRow(Util::Headline::create(tr("Location:")));
+	
+	position_source_box = new QComboBox();
+	form_layout->addRow(tr("Source:"), position_source_box);
+	
+	form_layout->addItem(Util::SpacerItem::create(this));
+#endif
 	
 	updateWidgets();
 }
@@ -48,6 +65,10 @@ QString SensorsSettingsPage::title() const
 
 void SensorsSettingsPage::apply()
 {
+	auto& settings = Settings::getInstance();
+	
+	settings.setPositionSource(position_source_box->currentData().toString());
+	
 	Settings::getInstance().applySettings();
 }
 
@@ -60,7 +81,39 @@ void SensorsSettingsPage::reset()
 
 void SensorsSettingsPage::updateWidgets()
 {
-	// todo
+#ifdef QT_POSITIONING_LIB
+	position_source_box->clear();
+	
+	auto const current_source_name = Settings::getInstance().positionSource();
+	auto add_position_source = [this, &current_source_name](const QString& id) {
+		auto display_name = id;
+		if (display_name.isEmpty())
+			//: Position source
+			display_name = tr("Default");
+		else if (display_name == QLatin1String("serialnmea"))
+			//: Position source
+			display_name = tr("Serial port (NMEA)");
+		else if (display_name == QLatin1String("Windows"))
+			//: Position source; product name, do not translate literally.
+			display_name = tr("Windows");
+		else if (display_name == QLatin1String("geoclue"))
+			//: Position source; product name, do not translate literally.
+			display_name = tr("GeoClue");
+		else if (display_name == QLatin1String("corelocation"))
+			//: Position source; product name, do not translate literally.
+			display_name = tr("Core Location");
+		position_source_box->addItem(display_name, id);
+		if (id == current_source_name)
+			position_source_box->setCurrentIndex(position_source_box->count()-1);
+	};
+	
+	add_position_source(QString{});
+	auto const position_sources = QGeoPositionInfoSource::availableSources();
+	for (const auto& source : position_sources)
+	{
+		add_position_source(source);
+	}
+#endif  // QT_POSITIONING_LIB
 }
 
 

--- a/src/sensors/sensors_settings_page.h
+++ b/src/sensors/sensors_settings_page.h
@@ -25,6 +25,7 @@
 
 #include "gui/widgets/settings_page.h"
 
+class QComboBox;
 class QWidget;
 
 namespace OpenOrienteering {
@@ -48,7 +49,7 @@ protected:
 	void updateWidgets();
 	
 private:
-	// Widgets ...
+	QComboBox* position_source_box = nullptr;
 };
 
 

--- a/src/sensors/sensors_settings_page.h
+++ b/src/sensors/sensors_settings_page.h
@@ -50,6 +50,8 @@ protected:
 	
 private:
 	QComboBox* position_source_box = nullptr;
+	QComboBox* nmea_serialport_box = nullptr;
+	
 };
 
 

--- a/src/sensors/sensors_settings_page.h
+++ b/src/sensors/sensors_settings_page.h
@@ -1,0 +1,57 @@
+/*
+ *    Copyright 2019 Kai Pastor
+ *
+ *    This file is part of OpenOrienteering.
+ *
+ *    OpenOrienteering is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OpenOrienteering is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPENORIENTEERING_SENSORS_SETTINGS_PAGE_H
+#define OPENORIENTEERING_SENSORS_SETTINGS_PAGE_H
+
+#include <QObject>
+#include <QString>
+
+#include "gui/widgets/settings_page.h"
+
+class QWidget;
+
+namespace OpenOrienteering {
+
+
+class SensorsSettingsPage : public SettingsPage
+{
+Q_OBJECT
+public:
+	explicit SensorsSettingsPage(QWidget* parent = nullptr);
+	
+	~SensorsSettingsPage() override;
+	
+	QString title() const override;
+
+	void apply() override;
+	
+	void reset() override;
+	
+protected:
+	void updateWidgets();
+	
+private:
+	// Widgets ...
+};
+
+
+}  // namespace OpenOrienteering
+
+#endif  // OPENORIENTEERING_SENSORS_SETTINGS_PAGE_H

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -166,6 +166,7 @@ Settings::Settings()
 #endif
 	
 	sensors.position_source = settings.value(QLatin1String("Sensors/position_source"), sensors.position_source).toString();
+	sensors.nmea_serialport = settings.value(QLatin1String("Sensors/nmea_serialport"), sensors.nmea_serialport).toString();
 	
 	// Migrate old settings
 	static bool migration_checked = false;
@@ -375,6 +376,16 @@ void Settings::setPositionSource(const QString& name)
 	{
 		sensors.position_source = name;
 		QSettings().setValue(QLatin1String("Sensors/position_source"), name);
+		emit settingsChanged();
+	}
+}
+
+void Settings::setNmeaSerialPort(const QString& name)
+{
+	if (name != sensors.nmea_serialport)
+	{
+		sensors.nmea_serialport = name;
+		QSettings().setValue(QLatin1String("Sensors/nmea_serialport"), name);
 		emit settingsChanged();
 	}
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -165,6 +165,8 @@ Settings::Settings()
 	touch_mode_enabled = mobileModeEnforced() || settings.value(QLatin1String("General/touch_mode_enabled"), touch_mode_enabled).toBool();
 #endif
 	
+	sensors.position_source = settings.value(QLatin1String("Sensors/position_source"), sensors.position_source).toString();
+	
 	// Migrate old settings
 	static bool migration_checked = false;
 	if (!migration_checked)
@@ -365,6 +367,17 @@ bool Settings::mobileModeEnforced() noexcept
 }
 
 #endif
+
+
+void Settings::setPositionSource(const QString& name)
+{
+	if (name != sensors.position_source)
+	{
+		sensors.position_source = name;
+		QSettings().setValue(QLatin1String("Sensors/position_source"), name);
+		emit settingsChanged();
+	}
+}
 
 
 }  // namespace OpenOrienteering

--- a/src/settings.h
+++ b/src/settings.h
@@ -168,6 +168,25 @@ public:
 	static bool mobileModeEnforced() noexcept;
 #endif
 	
+	
+	/**
+	 * Returns the name of the position source to be used.
+	 * 
+	 * If this is empty, the system's default source shall be used.
+	 * 
+	 * \see QGeoPositionInfoSource::createSource
+	 * \see QGeoPositionInfoSource::createDefaultSource
+	 */
+	QString positionSource() const { return sensors.position_source; }
+	
+	/**
+	 * Changes the name of the position source.
+	 * 
+	 * Setting this to an empty string selects the system's default source.
+	 */
+	void setPositionSource(const QString& name);
+	
+	
 signals:
 	void settingsChanged();
 	
@@ -185,6 +204,10 @@ private:
 	QHash<SettingsEnum, QVariant> settings_cache;
 	QHash<SettingsEnum, QString> setting_paths;
 	QHash<SettingsEnum, QVariant> setting_defaults;
+	
+	struct {
+		QString position_source = {};
+	} sensors;
 	
 #ifndef Q_OS_ANDROID
 	bool touch_mode_enabled = false;

--- a/src/settings.h
+++ b/src/settings.h
@@ -187,6 +187,26 @@ public:
 	void setPositionSource(const QString& name);
 	
 	
+	/**
+	 * Returns the name of the serial port for reading NMEA data.
+	 * 
+	 * If this is empty, port selection is left to Qt which either reads the
+	 * port name from the environment variable QT_NMEA_SERIAL_PORT, or
+	 * recognizes a few GPS chipsets by serial port vendor IDs.
+	 * 
+	 * \see qtlocation/src/plugins/position/serialnmea/qgeopositioninfosourcefactory_serialnmea.cpp
+	 */
+	QString nmeaSerialPort() const { return sensors.nmea_serialport; }
+	
+	/**
+	 * Changes the name of the serial port for reading NMEA data.
+	 * 
+	 * Setting this to an empty string activates Qt's default port selection
+	 * behaviour.
+	 */
+	void setNmeaSerialPort(const QString& name);
+	
+	
 signals:
 	void settingsChanged();
 	
@@ -207,6 +227,7 @@ private:
 	
 	struct {
 		QString position_source = {};
+		QString nmea_serialport = {};
 	} sensors;
 	
 #ifndef Q_OS_ANDROID


### PR DESCRIPTION
For now, the new settings page allows:
- selecting the location source, and
- selecting the serial port for the NMEA source.

This PR also wraps the PowershellPositionSource into a proper plugin, so that it does not need any special treatment, apart from registering the (static) plugin.