### PR TITLE
Georeferencing: Pass t=HUGE_VAL to proj_trans

### DIFF
--- a/src/core/georeferencing.cpp
+++ b/src/core/georeferencing.cpp
@@ -21,6 +21,7 @@
 #include "georeferencing.h"
 
 #include <algorithm>
+#include <cmath> // IWYU pragma: keep
 #include <iterator>
 
 #include <QtGlobal>
@@ -321,7 +322,7 @@ bool ProjTransform::isGeographic() const
 QPointF ProjTransform::forward(const LatLon& lat_lon, bool* ok) const
 {
 	proj_errno_reset(pj);
-	auto pj_coord = proj_trans(pj, PJ_FWD, proj_coord(lat_lon.longitude(), lat_lon.latitude(), 0, 0));
+	auto pj_coord = proj_trans(pj, PJ_FWD, proj_coord(lat_lon.longitude(), lat_lon.latitude(), 0, HUGE_VAL));
 	if (ok)
 		*ok = proj_errno(pj) == 0;
 	return {pj_coord.xy.x, pj_coord.xy.y};
@@ -330,7 +331,7 @@ QPointF ProjTransform::forward(const LatLon& lat_lon, bool* ok) const
 LatLon ProjTransform::inverse(const QPointF& projected_coords, bool* ok) const
 {
 	proj_errno_reset(pj);
-	auto pj_coord = proj_trans(pj, PJ_INV, proj_coord(projected_coords.x(), projected_coords.y(), 0, 0));
+	auto pj_coord = proj_trans(pj, PJ_INV, proj_coord(projected_coords.x(), projected_coords.y(), 0, HUGE_VAL));
 	if (ok)
 		*ok = proj_errno(pj) == 0;
 	return {pj_coord.lp.phi, pj_coord.lp.lam};


### PR DESCRIPTION
This change is a result of properly reporting the first sub-issue of GH-1325 and contribution documentation updates to the PROJ project:

For reliable conversions, t shall be initialized to HUGE_VAL to allow for proper selection of time-dependent operations if one of the CRS is dynamic.
Cf. https://github.com/OSGeo/PROJ/pull/1603#discussion_r323656045