### PR TITLE
MapEditorController: Basic fix for map parts UI

### DIFF
--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -318,6 +318,8 @@ MapEditorController::~MapEditorController()
 	delete mappart_merge_act;
 	delete mappart_merge_menu;
 	delete mappart_move_menu;
+	if (mappart_selector_box)
+		delete mappart_selector_box;
 	for (TemplatePositionDockWidget* widget : qAsConst(template_position_widgets))
 		delete widget;
 	delete gps_display;
@@ -3915,11 +3917,11 @@ void MapEditorController::setMapAndView(Map* map, MapView* map_view)
 		{
 			this->map->disconnect(symbol_widget);
 		}
-		updateMapPartsUI();
 	}
 	
 	this->map = map;
 	this->main_view = map_view;
+	updateMapPartsUI();
 	
 	connect(&map->undoManager(), &UndoManager::canRedoChanged, this, &MapEditorController::undoStepAvailabilityChanged);
 	connect(&map->undoManager(), &UndoManager::canUndoChanged, this, &MapEditorController::undoStepAvailabilityChanged);

--- a/src/gui/map/map_editor.h
+++ b/src/gui/map/map_editor.h
@@ -793,7 +793,7 @@ private:
 	QToolBar* toolbar_drawing;
 	QToolBar* toolbar_editing;
 	QToolBar* toolbar_advanced_editing;
-	QToolBar* toolbar_mapparts;
+	QToolBar* toolbar_mapparts = nullptr;
 	
 	// For mobile UI
 	ActionGridBar* bottom_action_bar;
@@ -802,7 +802,7 @@ private:
 	QAction* mobile_symbol_selector_action;
 	QMenu* mobile_symbol_button_menu;
 	
-	QComboBox* mappart_selector_box;
+	QPointer<QComboBox> mappart_selector_box;
 	
 	QScopedPointer<GeoreferencingDialog> georeferencing_dialog;
 	QScopedPointer<ReopenTemplateDialog> reopen_template_dialog;


### PR DESCRIPTION
When creating a new map with touch mode enabled, Mapper crashed due to uninitialized map part UI components. This is just a minimal fix for now, to minimize risk of side effects. In the end, the controller state and UI setup will need much more work.