### PR TITLE
CI: Disable the MinGW cross job

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -269,8 +269,9 @@ jobs:
 
 - job: MinGW_x64_Linux
   displayName: Windows x64 (Release, MinGW on Linux)
-  dependsOn: macOS
-  condition: succeededOrFailed()
+  #dependsOn: macOS
+  #condition: succeededOrFailed()
+  condition: False
   variables:
     IMAGE_NAME: 'ubuntu-16.04'
     SUPERBUILD_INSTALL_DIR:  /home/vsts/superbuild


### PR DESCRIPTION
This job is obsolete now, thanks to the native builds. Don't block
other queued jobs.