### PR TITLE
main: Globally set QT_QPA_NO_TEXT_HANDLES

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -124,6 +124,9 @@ int main(int argc, char** argv)
 	
 #ifdef Q_OS_ANDROID
 	qputenv("QT_USE_ANDROID_NATIVE_STYLE", "1");
+	// Workaround for Mapper issue GH-1373, QTBUG-72408
+	/// \todo Remove QTBUG-72408 workaround once solved in Qt.
+	qputenv("QT_QPA_NO_TEXT_HANDLES", "1");
 #endif
 	
 	// Load resources


### PR DESCRIPTION
Qt 5.12 introduced a special left button handling for Android
which breaks our edit tools. This change disables the new Qt
feature for now. Resolves GH-1373 (self-snapping behaviour).