### PR TITLE
TemplateTest: Tolerate non-UTF-8 systems

### DIFF
--- a/test/template_t.cpp
+++ b/test/template_t.cpp
@@ -188,6 +188,10 @@ private slots:
 		QCOMPARE(temp->getTemplateType(), "TemplateImage");
 		QCOMPARE(temp->getTemplateFilename(), QString::fromUtf8("\u0433\u0435\u043E.tiff"));
 #ifdef MAPPER_USE_GDAL
+#ifdef Q_OS_UNIX
+		if (QFile::encodeName(temp->getTemplateFilename()) != temp->getTemplateFilename().toUtf8())
+			QEXPECT_FAIL("", "Local 8 bit encoding is not UTF-8", Abort);
+#endif
 		QCOMPARE(temp->getTemplateState(), Template::Loaded);
 		QVERIFY(temp->isTemplateGeoreferenced());
 		auto rotation_template = 0.01 * qRound(100 * qRadiansToDegrees(temp->getTemplateRotation()));


### PR DESCRIPTION
If the system locale is not UTF-8, QFile will run into trouble
when we try to access the UTF-8-named GeoTIFF test file.