### PR TITLE
DrawTextTool: Use base class tool state handling

### DIFF
--- a/src/tools/draw_text_tool.cpp
+++ b/src/tools/draw_text_tool.cpp
@@ -135,7 +135,7 @@ void DrawTextTool::startEditing()
 	connect(text_editor.get(), &TextObjectEditorHelper::stateChanged, this, &DrawTextTool::updatePreviewText);
 	connect(text_editor.get(), &TextObjectEditorHelper::finished, this, &DrawTextTool::finishEditing);
 	
-	editor->setEditingInProgress(true);
+	MapEditorToolBase::startEditing();
 	
 	updatePreviewText();
 	updateStatusText();
@@ -148,7 +148,7 @@ void DrawTextTool::abortEditing()
 	renderables.removeRenderablesOfObject(preview_text.get(), false);
 	map()->clearDrawingBoundingBox();
 	
-	editor->setEditingInProgress(false);
+	MapEditorToolBase::abortEditing();
 	resetWaitingForMouseRelease();
 	
 	if (key_button_bar)
@@ -182,7 +182,7 @@ void DrawTextTool::finishEditing()
 		preview_text.reset(new TextObject(drawing_symbol));
 	}
 	
-	editor->setEditingInProgress(false);
+	MapEditorToolBase::finishEditing();
 	
 	if (QGuiApplication::mouseButtons())
 	{


### PR DESCRIPTION
For proper teardown of tools and MapEditorController, it is neccessary
to also update the tool's state itself.
Fixes GH-1418 (Crash when closing map during text editing).