### PR TITLE
Support for Gentoo Linux (licensing)

### DIFF
--- a/doc/licensing/gentoo-licensing.cmake
+++ b/doc/licensing/gentoo-licensing.cmake
@@ -1,0 +1,29 @@
+#
+#    Copyright 2019 Kai Pastor
+#    
+#    This file is part of OpenOrienteering.
+# 
+#    OpenOrienteering is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+# 
+#    OpenOrienteering is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+# 
+#    You should have received a copy of the GNU General Public License
+#    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+
+
+include("linux-distribution.cmake")
+
+set(system_copyright_dir "/usr/share")
+# Pattern to find GDAL license.
+set(copyright_pattern
+  "${system_copyright_dir}/@package@/LICENSE.TXT"
+)
+
+# Location of common license text:
+set(common_license_pattern "/usr/portage/licenses/@basename@")


### PR DESCRIPTION
Adding a gentoo-licensing.cmake to the source package would make it easier to build Mapper releases on my Gentoo-based desktop machine.

Gentoo Linux has support for all the third party dependencies except Polyclipping. I have my own "ebuild" files for Polyclipping and OpenOrienteering Mapper, which I may see about submitting for inclusion in the Gentoo distribution. These are fairly routine.

Gentoo's package database lists licenses, and for GDAL the list is  just "BSD Info-ZIP MIT". Text for each of these licenses is stored separately. It is meager in comparison to what Mapper shows for GDAL licensing on other platforms. I have set it up so that GDAL appears on Mapper's licensing page in a bare bones line just like the "easy" dependencies mentioned in `linux-distribution.cmake`.

Guidance/help/suggestions are welcome.