### PR TITLE
OcdFileExport: Update per-symbol color list

### DIFF
--- a/src/fileformats/ocd_file_export.h
+++ b/src/fileformats/ocd_file_export.h
@@ -170,6 +170,12 @@ protected:
 	void setupBaseSymbol(const Symbol* symbol, quint32 symbol_number, OcdBaseSymbol& ocd_base_symbol);
 	
 	template< class OcdBaseSymbol >
+	void setupSymbolColors(const Symbol* symbol, OcdBaseSymbol& ocd_base_symbol);
+	
+	template< typename Counter, typename Iterator >
+	void setupSymbolColors(const Symbol* symbol, Counter& num_colors, Iterator first, Iterator last);
+	
+	template< class OcdBaseSymbol >
 	void setupIcon(const Symbol* symbol, OcdBaseSymbol& ocd_base_symbol);
 	
 	template< class OcdPointSymbol >

--- a/src/fileformats/ocd_types_v11.h
+++ b/src/fileformats/ocd_types_v11.h
@@ -46,7 +46,7 @@ namespace Ocd
 		qint32  extent;
 		quint32 file_pos;
 		quint8  RESERVED_MEMBER[2];
-		quint16 num_colors;
+		qint16  num_colors;
 		quint16 colors[14];
 		Utf16PascalString<64> description;
 		IconV9  icon;

--- a/src/fileformats/ocd_types_v9.h
+++ b/src/fileformats/ocd_types_v9.h
@@ -205,7 +205,7 @@ namespace Ocd
 		qint32  extent;
 		qint32  file_pos;
 		quint16 group;
-		quint16 num_colors;
+		qint16  num_colors;
 		quint16 colors[14];
 		PascalString<31> description;
 		IconV9  icon;


### PR DESCRIPTION
Per-symbol color information was implemented for the color bitmask
in OCD version 8, but not for the color counter and index list in
newer versions of the format.
Assumed to resolve GH-1452 (map not displayed in CONDES).