### PR TITLE
Minor refactoring of Map and Symbol object interfaces

### DIFF
--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -892,7 +892,7 @@ std::size_t Map::deleteIrregularObjects()
 	{
 		for (auto part : parts)
 		{
-			if (part->deleteObject(object, false))
+			if (part->deleteObject(object))
 			{
 				++result;
 				goto next_object;
@@ -945,7 +945,7 @@ void Map::deleteSelectedObjects()
 			if (index >= 0)
 			{
 				undo_step->addObject(index, *obj);
-				part->deleteObject(index, true);
+				part->releaseObject(index);
 			}
 			else
 			{
@@ -1969,7 +1969,7 @@ void Map::removePart(std::size_t index)
 	
 	// FIXME: This loop should move to MapPart.
 	while(part->getNumObjects())
-		part->deleteObject(0, false);
+		part->deleteObject(0);
 	
 	parts.erase(parts.begin() + index);
 	if (current_part_index >= index)
@@ -2031,7 +2031,7 @@ int Map::reassignObjectsToMapPart(std::vector<int>::const_iterator first, std::v
 		if (current_part_index == source && isObjectSelected(object))
 			removeObjectFromSelection(object, false);
 		
-		source_part->deleteObject(object, true);
+		source_part->releaseObject(object);
 		target_part->addObject(object);
 	}
 	
@@ -2055,7 +2055,7 @@ int Map::mergeParts(std::size_t source, std::size_t destination)
 	for (auto i = source_part->getNumObjects(); i > 0 ; --i)
 	{
 		Object* object = source_part->getObject(0);
-		source_part->deleteObject(0, true);
+		source_part->releaseObject(0);
 		
 		int index = target_part->getNumObjects();
 		target_part->addObject(object, index);
@@ -2090,13 +2090,9 @@ int Map::addObject(Object* object, int part_index)
 	return object_index;
 }
 
-void Map::deleteObject(Object* object, bool remove_only)
+void Map::deleteObject(Object* object)
 {
-	auto object_ptr = releaseObject(object);
-	if (!remove_only)
-	{
-		delete object_ptr;
-	}
+	delete releaseObject(object);
 }
 
 Object* Map::releaseObject(Object* object)

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -2092,15 +2092,24 @@ int Map::addObject(Object* object, int part_index)
 
 void Map::deleteObject(Object* object, bool remove_only)
 {
+	auto object_ptr = releaseObject(object);
+	if (!remove_only)
+	{
+		delete object_ptr;
+	}
+}
+
+Object* Map::releaseObject(Object* object)
+{
 	for (MapPart* part : parts)
 	{
-		if (part->deleteObject(object, remove_only))
-			return;
+		if (auto object_found = part->releaseObject(object))
+			return object_found;
 	}
 	
-	qCritical().nospace() << this << "::deleteObject(" << object << "," << remove_only << "): Object not found. This is a bug.";
-	if (!remove_only)
-		delete object;
+	qCritical().nospace() << this << "::deleteObject(" << object << "): Object not found. This is a bug.";
+
+	return nullptr;
 }
 
 void Map::setObjectsDirty()

--- a/src/core/map.h
+++ b/src/core/map.h
@@ -833,6 +833,14 @@ public:
 	 * TODO: make a separate method "removeObject()", remove_only is misleading!
 	 */
 	void deleteObject(Object* object, bool remove_only);
+
+	/**
+	 * Relinquish object ownership.
+	 *
+	 * Searches map parts and returns pointer if the object was found.
+	 * Otherwise nullptr is returned.
+	 */
+	Object* releaseObject(Object* object);
 	
 	/**
 	 * Marks the objects as "dirty", i.e. as having unsaved changes.

--- a/src/core/map.h
+++ b/src/core/map.h
@@ -827,12 +827,10 @@ public:
 	
 	/**
 	 * Deletes the given object from the map.
-	 * remove_only will remove the object from the map, but not call "delete object";
-	 * be sure to call removeObjectFromSelection() if necessary.
 	 * 
-	 * TODO: make a separate method "removeObject()", remove_only is misleading!
+	 * Be sure to call removeObjectFromSelection() if necessary.
 	 */
-	void deleteObject(Object* object, bool remove_only);
+	void deleteObject(Object* object);
 
 	/**
 	 * Relinquish object ownership.

--- a/src/core/map_part.cpp
+++ b/src/core/map_part.cpp
@@ -164,18 +164,15 @@ void MapPart::addObject(Object* object, int pos)
 		map->updateAllMapWidgets();
 }
 
-void MapPart::deleteObject(int pos, bool remove_only)
+void MapPart::deleteObject(int pos)
 {
-	auto object_ptr = releaseObject(pos);
-	if (!remove_only)
-		delete object_ptr;
+	delete releaseObject(pos);
 }
 
-bool MapPart::deleteObject(Object* object, bool remove_only)
+bool MapPart::deleteObject(Object* object)
 {
 	auto object_ptr = releaseObject(object);
-	if (!remove_only && object_ptr)
-		delete object_ptr;
+	delete object_ptr;
 
 	return object_ptr;
 }

--- a/src/core/map_part.cpp
+++ b/src/core/map_part.cpp
@@ -166,29 +166,43 @@ void MapPart::addObject(Object* object, int pos)
 
 void MapPart::deleteObject(int pos, bool remove_only)
 {
+	auto object_ptr = releaseObject(pos);
+	if (!remove_only)
+		delete object_ptr;
+}
+
+bool MapPart::deleteObject(Object* object, bool remove_only)
+{
+	auto object_ptr = releaseObject(object);
+	if (!remove_only && object_ptr)
+		delete object_ptr;
+
+	return object_ptr;
+}
+
+Object* MapPart::releaseObject(int pos)
+{
 	map->removeRenderablesOfObject(objects[pos], true);
-	if (remove_only)
-		objects[pos]->setMap(nullptr);
-	else
-		delete objects[pos];
+	auto object_to_return = objects[pos];
 	objects.erase(objects.begin() + pos);
 	
 	if (objects.empty() && map->getNumObjects() == 0)
 		map->updateAllMapWidgets();
+
+	return object_to_return;
 }
 
-bool MapPart::deleteObject(Object* object, bool remove_only)
+Object* MapPart::releaseObject(Object* object)
 {
 	int size = objects.size();
 	for (int i = size - 1; i >= 0; --i)
 	{
 		if (objects[i] == object)
 		{
-			deleteObject(i, remove_only);
-			return true;
+			return releaseObject(i);
 		}
 	}
-	return false;
+	return nullptr;
 }
 
 std::unique_ptr<UndoStep> MapPart::importPart(const MapPart* other, const QHash<const Symbol*, Symbol*>& symbol_map, const QTransform& transform, bool select_new_objects)

--- a/src/core/map_part.h
+++ b/src/core/map_part.h
@@ -169,6 +169,22 @@ public:
 	 */
 	bool deleteObject(Object* object, bool remove_only);
 	
+	/**
+	  * Relinquish object ownership.
+	  *
+	  * This method removes object references from MapPart's internal
+	  * structures. Object deletion is caller's responsibility.
+	  */
+	Object* releaseObject(int pos);
+
+	/**
+	  * Relinquish object ownership.
+	  *
+	  * This method removes object references from MapPart's internal
+	  * structures. Object deletion is caller's responsibility.
+	  */
+	Object* releaseObject(Object* object);
+
 	
 	/**
 	 * Imports the contents another part into this part.

--- a/src/core/map_part.h
+++ b/src/core/map_part.h
@@ -44,7 +44,7 @@ class Map;
 class MapCoordF;
 class Object;
 class Symbol;
-using SymbolDictionary = QHash<QString, Symbol*>; // from symbol.h
+using SymbolDictionary = QHash<qint32, Symbol*>; // from symbol.h
 class UndoStep;
 
 

--- a/src/core/map_part.h
+++ b/src/core/map_part.h
@@ -144,7 +144,7 @@ public:
 	 * Adds the object as new object at the end.
 	 */
 	void addObject(Object* object);
-	
+
 	/**
 	 * Adds the object as new object at the given index.
 	 */
@@ -152,22 +152,15 @@ public:
 	
 	/**
 	 * Deleted the object from the given index.
-	 * 
-	 * If remove_only is set, does not call "delete object".
-	 * 
-	 * @todo Make a separate method "removeObject()", this is misleading!
 	 */
-	void deleteObject(int pos, bool remove_only);
+	void deleteObject(int pos);
 	
 	/**
 	 * Deleted the object from the given index.
 	 * 
-	 * If remove_only is set, does not call "delete object".
 	 * Returns if the object was found in this part.
-	 * 
-	 * @todo Make a separate method "removeObject()", this is misleading!
 	 */
-	bool deleteObject(Object* object, bool remove_only);
+	bool deleteObject(Object* object);
 	
 	/**
 	  * Relinquish object ownership.

--- a/src/core/objects/boolean_tool.cpp
+++ b/src/core/objects/boolean_tool.cpp
@@ -234,7 +234,7 @@ bool BooleanTool::executeForObjects(PathObject* subject, PathObjects& in_objects
 		if (op != Difference || object == subject)
 		{
 			map->removeObjectFromSelection(object, false);
-			map->getCurrentPart()->deleteObject(object, true);
+			map->getCurrentPart()->releaseObject(object);
 			object->setMap(map); // necessary so objects are saved correctly
 		}
 	}

--- a/src/core/objects/object.cpp
+++ b/src/core/objects/object.cpp
@@ -321,7 +321,13 @@ Object* Object::load(QXmlStreamReader& xml, Map* map, const SymbolDictionary& sy
 	else
 	{
 		QString symbol_id =  object_element.attribute<QString>(literal::symbol);
-		object->symbol = symbol_dict[symbol_id]; // FIXME: cannot work for forward references
+		bool conversion_ok;
+		const auto id_converted = symbol_id.toInt(&conversion_ok);
+		if (!symbol_id.isEmpty() && !conversion_ok)
+			throw FileFormatException(::OpenOrienteering::ImportExport::tr("Malformed symbol ID '%1' at line %2 column %3.")
+		                              .arg(symbol_id).arg(xml.lineNumber())
+		                              .arg(xml.columnNumber()));
+		object->symbol = symbol_dict[id_converted]; // FIXME: cannot work for forward references
 		// NOTE: object->symbol may be nullptr.
 	}
 	

--- a/src/core/objects/object_operations.h
+++ b/src/core/objects/object_operations.h
@@ -109,7 +109,7 @@ namespace ObjectOp
 		void operator()(Object* object, MapPart* part, int object_index) const
 		{
 			if (!object->setSymbol(new_symbol, false))
-				part->deleteObject(object_index, false);
+				part->deleteObject(object_index);
 			else
 				object->update();
 		}
@@ -120,7 +120,7 @@ namespace ObjectOp
 	{
 		void operator()(const Object*, MapPart* part, int object_index) const
 		{
-			part->deleteObject(object_index, false);
+			part->deleteObject(object_index);
 		}
 	};
 }

--- a/src/core/symbols/symbol.h
+++ b/src/core/symbols/symbol.h
@@ -59,7 +59,7 @@ class SymbolSettingDialog;
 class TextSymbol;
 class VirtualCoordVector;
 
-typedef QHash<QString, Symbol*> SymbolDictionary;
+typedef QHash<qint32, Symbol*> SymbolDictionary;
 
 
 /**

--- a/src/fileformats/file_import_export.cpp
+++ b/src/fileformats/file_import_export.cpp
@@ -163,7 +163,7 @@ void Importer::validate()
 				else
 				{
 					// There is no undefined symbol for this type of object, delete the object
-					part->deleteObject(o, false);
+					part->deleteObject(o);
 					--o;
 					continue;
 				}

--- a/src/fileformats/xml_file_format.cpp
+++ b/src/fileformats/xml_file_format.cpp
@@ -900,8 +900,8 @@ void XMLFileImporter::importSymbols()
 	auto num_symbols = symbols_element.attribute<std::size_t>(literal::count);
 	map->symbols.reserve(qMin(num_symbols, std::size_t(1000))); // 1000 is not a limit
 	
-	symbol_dict[QString::number(map->findSymbolIndex(map->getUndefinedPoint()))] = map->getUndefinedPoint();
-	symbol_dict[QString::number(map->findSymbolIndex(map->getUndefinedLine()))] = map->getUndefinedLine();
+	symbol_dict[map->findSymbolIndex(map->getUndefinedPoint())] = map->getUndefinedPoint();
+	symbol_dict[map->findSymbolIndex(map->getUndefinedLine())] = map->getUndefinedLine();
 	
 	while (xml.readNextStartElement())
 	{

--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -2767,7 +2767,7 @@ void MapEditorController::switchSymbolClicked()
 		map->clearObjectSelection(false);
 		for (auto* object : old_objects)
 		{
-			map->deleteObject(object, true);
+			map->releaseObject(object);
 		}
 		for (auto* object : new_objects)
 		{
@@ -3194,7 +3194,7 @@ void MapEditorController::connectPathsClicked()
 		for (auto* object : deleted_objects)
 		{
 			map->removeObjectFromSelection(object, false);
-			map->getCurrentPart()->deleteObject(object, false);
+			map->getCurrentPart()->deleteObject(object);
 		}
 	}
 	
@@ -3781,7 +3781,7 @@ void MapEditorController::removeMapPart()
 				--i;
 				auto* object = part->getObject(i);
 				add_step->addObject(i, object);
-				part->deleteObject(object, true);
+				part->releaseObject(object);
 			}
 			while (i > 0);
 			

--- a/src/gui/symbols/point_symbol_editor_widget.cpp
+++ b/src/gui/symbols/point_symbol_editor_widget.cpp
@@ -306,7 +306,7 @@ PointSymbolEditorWidget::~PointSymbolEditorWidget()
 	if (isVisible())
 		setEditorActive(false);
 	if (permanent_preview)
-		map->deleteObject(midpoint_object, false);
+		map->deleteObject(midpoint_object);
 }
 
 void PointSymbolEditorWidget::setEditorActive(bool active)
@@ -331,7 +331,7 @@ void PointSymbolEditorWidget::setEditorActive(bool active)
 		controller->setEditorActivity(nullptr);
 		if (!permanent_preview && midpoint_object)
 		{
-			map->deleteObject(midpoint_object, false);
+			map->deleteObject(midpoint_object);
 			midpoint_object = nullptr;
 		}
 	}

--- a/src/gui/symbols/symbol_setting_dialog.cpp
+++ b/src/gui/symbols/symbol_setting_dialog.cpp
@@ -247,7 +247,7 @@ void SymbolSettingDialog::createPreviewMap()
 	symbol_icon_label->setPixmap(QPixmap::fromImage(symbol->getIcon(source_map)));
 	
 	for (auto& object : preview_objects)
-		preview_map->deleteObject(object, false);
+		preview_map->deleteObject(object);
 	
 	preview_objects.clear();
 	

--- a/src/tools/cut_tool.cpp
+++ b/src/tools/cut_tool.cpp
@@ -742,7 +742,7 @@ void CutTool::replaceObject(Object* object, const std::vector<PathObject*>& repl
 	auto add_step = new AddObjectsUndoStep(map);
 	add_step->addObject(map_part->findObjectIndex(object), object);
 	map->removeObjectFromSelection(object, false);
-	map->deleteObject(object, true);
+	map->releaseObject(object);
 	
 	auto delete_step = new DeleteObjectsUndoStep(map);
 	for (auto new_object : replacement)

--- a/src/tools/cutout_tool.cpp
+++ b/src/tools/cutout_tool.cpp
@@ -85,7 +85,7 @@ void CutoutTool::initImpl()
 	
 	cutout_object_index = map()->getCurrentPart()->findObjectIndex(cutout_object);
 	map()->removeObjectFromSelection(cutout_object, true);
-	map()->deleteObject(cutout_object, true);
+	map()->releaseObject(cutout_object);
 }
 
 void CutoutTool::drawImpl(QPainter* painter, MapWidget* widget)

--- a/src/tools/edit_point_tool.cpp
+++ b/src/tools/edit_point_tool.cpp
@@ -251,7 +251,7 @@ void EditPointTool::clickPress()
 						int index = part->findObjectIndex(hover_object);
 						Q_ASSERT(index >= 0);
 						undo_step->addObject(index, hover_object);
-						map()->deleteObject(hover_object, true);
+						map()->releaseObject(hover_object);
 						map()->push(undo_step);
 						map()->setObjectsDirty();
 						map()->emitSelectionEdited();
@@ -682,7 +682,7 @@ void EditPointTool::finishEditing()
 			int index = part->findObjectIndex(text_object);
 			if (index >= 0)
 			{
-				part->deleteObject(index, true);
+				part->releaseObject(index);
 				
 				auto undo_step = new AddObjectsUndoStep(map);
 				undo_step->addObject(index, text_object);

--- a/src/undo/object_undo.cpp
+++ b/src/undo/object_undo.cpp
@@ -26,6 +26,8 @@
 #include "core/map.h"
 #include "core/objects/object.h"
 #include "core/symbols/symbol.h"
+#include "fileformats/file_format.h"
+#include "fileformats/file_import_export.h"
 #include "util/xml_stream_util.h"
 
 
@@ -605,8 +607,15 @@ void SwitchSymbolUndoStep::loadImpl(QXmlStreamReader& xml, SymbolDictionary& sym
 		{
 			if (xml.name() == QLatin1String("ref"))
 			{
-				QString key = xml.attributes().value(QLatin1String("symbol")).toString();
-				target_symbols.push_back(symbol_dict[key]);
+				bool conversion_ok;
+				const auto key = xml.attributes().value(QLatin1String("symbol"));
+				const auto key_converted = key.toInt(&conversion_ok);
+				if (!key.isEmpty() && conversion_ok)
+					target_symbols.push_back(symbol_dict[key_converted]);
+				else
+					throw FileFormatException(::OpenOrienteering::ImportExport::tr("Malformed symbol ID '%1' at line %2 column %3.")
+				                              .arg(key).arg(xml.lineNumber())
+				                              .arg(xml.columnNumber()));
 			}
 			
 			xml.skipCurrentElement(); // unknown

--- a/src/undo/object_undo.cpp
+++ b/src/undo/object_undo.cpp
@@ -332,7 +332,7 @@ UndoStep* DeleteObjectsUndoStep::undo()
 	for (int i = 0; i < size; ++i)
 	{
 		undo_step->addObject(modified_objects[i], part->getObject(modified_objects[i]));
-		part->deleteObject(modified_objects[i], true);
+		part->releaseObject(modified_objects[i]);
 	}
 	
 	return undo_step;
@@ -404,7 +404,7 @@ void AddObjectsUndoStep::removeContainedObjects(bool emit_selection_changed)
 			map->removeObjectFromSelection(objects[i], false);
 			object_deselected = true;
 		}
-		part->deleteObject(objects[i], true);
+		part->releaseObject(objects[i]);
 		map->setObjectsDirty();
 	}
 	if (object_deselected && emit_selection_changed)
@@ -481,7 +481,7 @@ UndoStep* SwitchPartUndoStep::undo()
 			auto object = target->getObject(i);
 			if (map->getCurrentPart() == target && map->isObjectSelected(object))
 				map->removeObjectFromSelection(object, false);
-			target->deleteObject(i, true);
+			target->releaseObject(i);
 			source->addObject(object);
 		});
 	}
@@ -494,7 +494,7 @@ UndoStep* SwitchPartUndoStep::undo()
 			auto object = source->getObject(i);
 			if (map->getCurrentPart() == source && map->isObjectSelected(object))
 				map->removeObjectFromSelection(object, false);
-			source->deleteObject(i, true);
+			source->releaseObject(i);
 			target->addObject(object, j);
 		});
 	}


### PR DESCRIPTION
This is part of code from PR#1251 which is making very slow progress. The three patches clean up minor troubles in `Map` API and `Symbol` id handling.

The remaining work for the symbol id undo is:
* Decoupling of symbol id from its position in symbol selector widget. I've hit several cul-de-sac's and I'm exploring a "sparse vector" implementation now.
* The actual symbol undo implementation, which does exist in https://github.com/lpechacek/mapper/tree/issue-1200-symbol-delete-undo and hit the roadblock of volatile symbol id assignment, needs stable symbol id for undo buffer serialization.

Please consider merging this preparatory cleanup work.