### PR TITLE
TagSelectWidget: Postpone button state update

### DIFF
--- a/src/gui/widgets/tag_select_widget.cpp
+++ b/src/gui/widgets/tag_select_widget.cpp
@@ -79,7 +79,7 @@ TagSelectWidget::TagSelectWidget(QWidget* parent)
 	addRowItems(0);
 
 	connect(this, &QTableWidget::cellChanged, this, &TagSelectWidget::onCellChanged);
-	connect(this, &QTableWidget::currentCellChanged, this, &TagSelectWidget::onCurrentCellChanged);
+	connect(this, &QTableWidget::currentCellChanged, this, &TagSelectWidget::updateRowButtons, Qt::QueuedConnection);
 }
 
 
@@ -201,8 +201,9 @@ void TagSelectWidget::onCellChanged(int row, int column)
 }
 
 
-void TagSelectWidget::onCurrentCellChanged(int current_row, int /*current_column*/, int /*previous_row*/, int /*previous_column*/)
+void TagSelectWidget::updateRowButtons()
 {
+	auto current_row = currentRow();
 	move_up_button->setEnabled(current_row > 0);
 	move_down_button->setEnabled(current_row+1 < rowCount());
 }

--- a/src/gui/widgets/tag_select_widget.h
+++ b/src/gui/widgets/tag_select_widget.h
@@ -73,7 +73,7 @@ private:
 
 	void addRowItems(int row);
 	void onCellChanged(int row, int column);
-	void onCurrentCellChanged(int current_row, int current_column, int previous_row, int previous_column);
+	void updateRowButtons();
 	
 	QToolButton* delete_button;
 	QToolButton* move_down_button;


### PR DESCRIPTION
Amends bd280de: Queue the button state update request after current
cell changes, so that addition and removal of rows may have completed.
Task: GH-1451