### PR TITLE
print area consistency

### DIFF
--- a/src/core/map_printer.cpp
+++ b/src/core/map_printer.cpp
@@ -653,15 +653,14 @@ void MapPrinter::updatePaperDimensions()
 		printer->setOrientation((page_format.orientation == MapPrinterPageFormat::Portrait) ? QPrinter::Portrait : QPrinter::Landscape);
 	}
 	
+	printer->setFullPage(true);
 	page_format.page_rect = printer->paperRect(QPrinter::Millimeter);
 	page_format.paper_dimensions = page_format.page_rect.size();
 	
 	if ( target != imageTarget() && target != pdfTarget() &&
 		 page_format.page_size != QPageSize::Custom )
 	{
-		qreal left, top, right, bottom;
-		printer->getPageMargins(&left, &top, &right, &bottom, QPrinter::Millimeter);
-		page_format.page_rect.adjust(left, top, -right, -bottom);
+		page_format.page_rect = printer->pageRect(QPrinter::Millimeter);
 	}
 	page_format.h_overlap = qMax(qreal(0), qMin(page_format.h_overlap, page_format.page_rect.width()));
 	page_format.v_overlap = qMax(qreal(0), qMin(page_format.v_overlap, page_format.page_rect.height()));

--- a/src/gui/print_widget.cpp
+++ b/src/gui/print_widget.cpp
@@ -761,9 +761,12 @@ void PrintWidget::applyPrintAreaPolicy() const
 	{
 		setOverlapEditEnabled(false);
 		auto print_area = map_printer->getPrintArea();
+		const auto center = print_area.center();
 		print_area.setSize(map_printer->getPageRectPrintAreaSize());
 		if (center_check->isChecked())
 			centerOnMap(print_area);
+		else
+			print_area.moveCenter(center);
 		map_printer->setPrintArea(print_area);
 	}
 	else


### PR DESCRIPTION
This PR has two commits. The first fixes #1209 "print area alignment error" by setting the QPrinter into full page mode in updatePaperDimensions. It also changes from using the obsolete QPrinter::getPageMargins to QPrinter::pageRect.

The second commit presents a suggestion, which arose while I was investigating #1209. Why was it biased toward retaining the top-left of the print area, while moving the bottom-right away from what the user selected earlier? This behavior is determined by PrintWidget::applyPrintAreaPolicy. I suggest preserving the center of the print area rather than the top left.