### PR TITLE
GdalManagerPrivate: Fix extensions removal

### DIFF
--- a/src/gdal/gdal_manager.cpp
+++ b/src/gdal/gdal_manager.cpp
@@ -236,7 +236,7 @@ private:
 	
 	static void removeExtension(ExtensionList& list, const char* extension)
 	{
-		list.erase(std::find(begin(list), end(list), extension), end(list));
+		list.erase(std::remove(begin(list), end(list), extension), end(list));
 	}
 	
 	void updateExtensions(QSettings& settings)


### PR DESCRIPTION
Closes GH-1476 (broken OSM support).