### PR TITLE
MapEditorController: Defer template position dock deletion

### DIFF
--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -514,7 +514,8 @@ void MapEditorController::removeTemplatePositionDockWidget(Template* temp)
 {
 	emit templatePositionDockWidgetClosed(temp);
 	
-	delete getTemplatePositionDockWidget(temp);
+	if (auto* w = getTemplatePositionDockWidget(temp))
+		w->deleteLater();
 	int num_deleted = template_position_widgets.remove(temp);
 	Q_ASSERT(num_deleted == 1);
 	Q_UNUSED(num_deleted);


### PR DESCRIPTION
We must not immediately delete a TemplatePositionDockWidget when we
remove it from the list: When the removal is triggered from a close
event, there might be accesses following our event handling.
Fixes GH-1494 (crash on closing dock widget).