### PR TITLE
OverridingShortcut: Revise event filtering

### DIFF
--- a/src/gui/widgets/symbol_render_widget.cpp
+++ b/src/gui/widgets/symbol_render_widget.cpp
@@ -97,7 +97,7 @@ SymbolRenderWidget::SymbolRenderWidget(Map* map, bool mobile_mode, QWidget* pare
 	
 	QShortcut* description_shortcut = new OverridingShortcut(
 	  QKeySequence(tr("F1", "Shortcut for displaying the symbol's description")),
-	  window()
+	  this
 	);
 	tooltip = new SymbolToolTip(this, description_shortcut);
 	// TODO: Use a placeholder in the literal and pass the actual shortcut's string representation.

--- a/src/util/overriding_shortcut.h
+++ b/src/util/overriding_shortcut.h
@@ -75,9 +75,10 @@ public:
 	bool eventFilter(QObject* watched, QEvent* event) override;
 	
 private:
-	void updateToplevelWidget(QWidget* parent_widget);
+	void updateEventFilters();
 	
-	QPointer<QWidget> toplevel_widget = nullptr;
+	QObject* parent_or_self;
+	QPointer<QWidget> window_ = nullptr;
 };
 
 


### PR DESCRIPTION
Efficiently track parent and top-level widget changes.
Respect disabled shortcut state.