### PR TITLE
DrawCircleTool: Don't create empty objects

### DIFF
--- a/src/tools/draw_circle_tool.cpp
+++ b/src/tools/draw_circle_tool.cpp
@@ -31,6 +31,7 @@
 #include <QMouseEvent>
 #include <QLatin1String>
 #include <QPixmap>
+#include <QPointF>
 #include <QRectF>
 #include <QString>
 
@@ -223,7 +224,11 @@ void DrawCircleTool::finishDrawing()
 	second_point_set = false;
 	updateStatusText();
 	
-	DrawLineAndAreaTool::finishDrawing();
+	// Enforce non-zero diameter
+	if (circle_start_pos_map != opposite_pos_map)   
+		DrawLineAndAreaTool::finishDrawing();  
+	else    
+		DrawLineAndAreaTool::abortDrawing();
 	// Do not add stuff here as the tool might get deleted in DrawLineAndAreaTool::finishDrawing()!
 }
 void DrawCircleTool::abortDrawing()


### PR DESCRIPTION
For creating a circle, we need more than just the position of the
initial mouse press. That's why this tool leaves the preview object
empty after startDrawing(). However, the empty preview object must
not be added to the map on finishDrawing.
Fixes GH-1497 (crash after drawing with circle tool).