### PR TITLE
OgrTemplate: Fix map projection changes

### DIFF
--- a/src/gdal/ogr_template.cpp
+++ b/src/gdal/ogr_template.cpp
@@ -439,17 +439,25 @@ void OgrTemplate::mapTransformationChanged()
 		if (template_state != Template::Loaded)
 			return;
 		
-		if (templateMap()->getScaleDenominator() != map->getScaleDenominator())
+		auto const& templ_georef = templateMap()->getGeoreferencing();
+		auto const& map_georef = map->getGeoreferencing();
+		if (templateMap()->getScaleDenominator() == map->getScaleDenominator()
+		    && templ_georef.getProjectedCRSSpec() == map_georef.getProjectedCRSSpec())
 		{
-			// We can't know how to correctly scale symbol dimension.
-			reloadLater();
-			return;
+			auto const t = templ_georef.mapToProjected() * map_georef.projectedToMap();
+			templateMap()->applyOnAllObjects([&t](Object* o) { o->transform(t); });
+			templateMap()->setGeoreferencing(map_georef);
 		}
-		
-		QTransform t = templateMap()->getGeoreferencing().mapToProjected();
-		t *= map->getGeoreferencing().projectedToMap();
-		templateMap()->applyOnAllObjects([&t](Object* o) { o->transform(t); });
-		templateMap()->setGeoreferencing(map->getGeoreferencing());
+		else
+		{
+			// If the projected CRS changed: The necessary transformation
+			//   involves at least two CRS and might give imprecise results.
+			// If the scale changed: We can't know how to correctly scale
+			//   symbol dimensions.
+			// Reloading is a slow but safe way to get the same results as they
+			// will appear when opening the file the next time.
+			reloadLater();
+		}
 	}
 	else if (explicit_georef)
 	{
@@ -472,6 +480,7 @@ void OgrTemplate::reloadLater()
 {
 	if (reload_pending)
 		return;
+	setTemplateAreaDirty();
 	if (template_state == Loaded)
 		templateMap()->clear(); // no expensive operations before reloading
 	QTimer::singleShot(0, this, &OgrTemplate::reload);
@@ -484,6 +493,7 @@ void OgrTemplate::reload()
 		unloadTemplateFile();
 	loadTemplateFile(false);
 	reload_pending = false;
+	setTemplateAreaDirty();
 }
 
 


### PR DESCRIPTION
When the map's projected CRS changes, the transformation of the
template's data is non-trivial. We might use modern (late-binding)
PROJ for precise transformation, but for now (until modern PROJ
is available and reliable everywhere) it is easier to just reload
the template.