### PR TITLE
OcdFileExport: Remove WIP warning

### DIFF
--- a/src/fileformats/ocd_file_export.cpp
+++ b/src/fileformats/ocd_file_export.cpp
@@ -612,8 +612,6 @@ void setupFileHeaderGeneric(quint16 actual_version, Ocd::FileHeaderGeneric& head
 template<class Format>
 bool OcdFileExport::exportImplementation()
 {
-	addWarning(QLatin1String("OcdFileExport: WORK IN PROGRESS, FILE INCOMPLETE"));
-	
 	OcdFile<Format> file;
 	
 	custom_8bit_encoding = determineEncoding<typename Format::Encoding>();


### PR DESCRIPTION
The work is complete with regard to what was achieved for OCD 8 in
the legacy implementation. OCD export is still declared as lossy.