### PR TITLE
Changing a template's georeferenced state may trigger lossy rewriting of the template file

### DIFF
--- a/src/templates/template_image.cpp
+++ b/src/templates/template_image.cpp
@@ -391,7 +391,7 @@ bool TemplateImage::trySetTemplateGeoreferenced(bool value, QWidget* dialog_pare
 		{
 			is_georeferenced = false;
 		}
-		setHasUnsavedChanges(true);
+		map->setTemplatesDirty();
 	}
 	return is_georeferenced;
 }


### PR DESCRIPTION
Changing whether a template is used georeferenced or not does not mean
that the template file itself should be rewritten. In fact, the old
behaviour is dangerous: Rewriting may cause loss of quality (JPEG) or
loss of georeferencing information (GeoTIFF -> TIFF).