### PR TITLE
cove: Warn when vectorizing thick lines

### DIFF
--- a/3rd-party/cove/app/mainform.cpp
+++ b/3rd-party/cove/app/mainform.cpp
@@ -167,8 +167,10 @@ mainForm::mainForm(QWidget* parent, OpenOrienteering::Map* map,
 	setTabEnabled(ui.colorsTab, false);
 
 	ui.howManyColorsSpinBox->setValue(settings.getInt("nColors"));
-	rollbackHistory = false;
-	bwBitmapHistoryIterator = bwBitmapHistory.begin();
+
+	bwBitmapUndo = new QUndoStack(this);
+	connect(bwBitmapUndo, SIGNAL(canUndoChanged(bool)), ui.bwImageHistoryBack, SLOT(setEnabled(bool)));
+	connect(bwBitmapUndo, SIGNAL(canRedoChanged(bool)), ui.bwImageHistoryForward, SLOT(setEnabled(bool)));
 
 	loadImage(templ->getImage(), templ->getTemplateFilename());
 
@@ -184,7 +186,7 @@ mainForm::~mainForm()
 //! Clears the Thinning tab, i.e. removes displayed image and polygons
 void mainForm::clearBWImageTab()
 {
-	bwImageClearHistory();
+	bwBitmapUndo->clear();
 	ui.bwImageView->setPolygons(PolygonList());
 	ui.saveVectorsButton->setEnabled(false);
 	ui.bwImageView->setImage(nullptr);
@@ -499,8 +501,10 @@ void mainForm::on_mainTabWidget_currentChanged(int tabindex)
 		return;
 	}
 	
-	if (bwBitmapHistory.empty()
-	    || bwBitmapHistory.back().constBits() != newBWBitmap.constBits())
+	const auto* undoCommand = static_cast<const BwBitmapUndoStep*>
+	                      (bwBitmapUndo->command(0));
+	if (!undoCommand
+	    || undoCommand->image.constBits() != newBWBitmap.constBits())
 	{
 		// new BW image
 		clearBWImageTab();
@@ -538,122 +542,53 @@ bool mainForm::performMorphologicalOperation(
 	if (transBitmap.isNull())
 		return false;
 
+	// store the current image onto undo stack
+	auto* command = new BwBitmapUndoStep(*this, bwBitmap);
+	bwBitmapUndo->push(command);
+
 	bwBitmap = transBitmap;
 	ui.bwImageView->setImage(&bwBitmap);
 	return true;
 }
 
-//! Inserts the current displayed image into the history queue.  Pops the last
-// image from the history queue in case \a rollbackHistory is set, what means
-// the last image was not committed into the queue.
-void mainForm::prepareBWImageHistory()
-{
-	if (rollbackHistory)
-	{
-		if (!bwBitmapHistory.empty()) bwBitmapHistory.pop_front();
-	}
-	else if (bwBitmapHistoryIterator != bwBitmapHistory.begin())
-	{
-		bwBitmapHistory.erase(bwBitmapHistory.begin(), bwBitmapHistoryIterator);
-		bwBitmapHistory.pop_front();
-	}
-	bwBitmapHistory.push_front(bwBitmap);
-	bwBitmapHistoryIterator = bwBitmapHistory.begin();
-	ui.bwImageView->setImage(&bwBitmap);
-	rollbackHistory = true;
-}
-
-//! Completely clears the history.
-void mainForm::bwImageClearHistory()
-{
-	ui.bwImageHistoryBack->setEnabled(false);
-	ui.bwImageHistoryForward->setEnabled(false);
-	bwBitmapHistory.clear();
-	bwBitmapHistoryIterator = bwBitmapHistory.begin();
-	rollbackHistory = false;
-}
-
-//! Commits the image into the history queue.
-void mainForm::bwImageCommitHistory()
-{
-	ui.bwImageHistoryBack->setEnabled(true);
-	ui.bwImageHistoryForward->setEnabled(false);
-	rollbackHistory = false;
-}
-
 //! Returns one image back in the history.
 void mainForm::on_bwImageHistoryBack_clicked()
 {
-	// safety check
-	if (bwBitmapHistoryIterator == bwBitmapHistory.end()) return;
-	if (bwBitmapHistoryIterator == bwBitmapHistory.begin())
-	{
-		bwBitmapHistory.push_front(bwBitmap);
-		bwBitmapHistoryIterator = bwBitmapHistory.begin();
-	}
-	if (++bwBitmapHistoryIterator != bwBitmapHistory.end())
-	{
-		bwBitmap = *bwBitmapHistoryIterator;
-		ui.bwImageView->setImage(&bwBitmap);
-		if (bwBitmapHistoryIterator + 1 == bwBitmapHistory.end())
-		{
-			ui.bwImageHistoryBack->setEnabled(false);
-		}
-		ui.bwImageHistoryForward->setEnabled(true);
-	}
+	bwBitmapUndo->undo();
 }
 
 //! Advances one image forward in the history.
 void mainForm::on_bwImageHistoryForward_clicked()
 {
-	if (bwBitmapHistoryIterator != bwBitmapHistory.begin())
-	{
-		bwBitmap = *(--bwBitmapHistoryIterator);
-		ui.bwImageView->setImage(&bwBitmap);
-		ui.bwImageHistoryBack->setEnabled(true);
-		if (bwBitmapHistoryIterator == bwBitmapHistory.begin())
-		{
-			ui.bwImageHistoryForward->setEnabled(false);
-			bwBitmapHistory.pop_front();
-			bwBitmapHistoryIterator = bwBitmapHistory.begin();
-		}
-	}
+	bwBitmapUndo->redo();
 }
 
 /*! Runs the thinning.
   \sa performMorphologicalOperation */
 void mainForm::on_runThinningButton_clicked()
 {
-	prepareBWImageHistory();
-	if (performMorphologicalOperation(Vectorizer::THINNING_ROSENFELD))
-		bwImageCommitHistory();
+	performMorphologicalOperation(Vectorizer::THINNING_ROSENFELD);
 }
 
 /*! Runs the pruning.
   \sa performMorphologicalOperation */
 void mainForm::on_runPruningButton_clicked()
 {
-	prepareBWImageHistory();
-	if (performMorphologicalOperation(Vectorizer::PRUNING))
-		bwImageCommitHistory();
+	performMorphologicalOperation(Vectorizer::PRUNING);
 }
 
 /*! Erodes the image.
   \sa performMorphologicalOperation */
 void mainForm::on_runErosionButton_clicked()
 {
-	prepareBWImageHistory();
-	if (performMorphologicalOperation(Vectorizer::EROSION))
-		bwImageCommitHistory();
+	performMorphologicalOperation(Vectorizer::EROSION);
 }
 
 /*! Dilates the image.
   \sa performMorphologicalOperation */
 void mainForm::on_runDilationButton_clicked()
 {
-	prepareBWImageHistory();
-	if (performMorphologicalOperation(Vectorizer::DILATION))
-		bwImageCommitHistory();
+	performMorphologicalOperation(Vectorizer::DILATION);
 }
 
 /*! Spawns dialog on classification config options.
@@ -891,6 +826,29 @@ void mainForm::on_applyFIRFilterPushButton_clicked()
 	QImage newImageBitmap = Concurrency::process<QImage>(&progressDialog, functor, imageBitmap);
 	if (!newImageBitmap.isNull()) imageBitmap = newImageBitmap;
 	ui.imageView->setImage(&imageBitmap);
+}
+
+/* \class mainForm::BwBitmapUndoStep
+ * \brief Embedded struct holding undo data.
+ */
+
+mainForm::BwBitmapUndoStep::BwBitmapUndoStep(mainForm& form, QImage image)
+    : form { form }
+    , image { image }
+{
+	// nothing
+}
+
+void mainForm::BwBitmapUndoStep::redo()
+{
+	undo(); // the same data swap
+}
+
+void mainForm::BwBitmapUndoStep::undo()
+{
+	using std::swap;
+	swap(form.bwBitmap, image);
+	form.ui.bwImageView->setImage(&form.bwBitmap);
 }
 } // cove
 

--- a/3rd-party/cove/app/mainform.h
+++ b/3rd-party/cove/app/mainform.h
@@ -55,12 +55,13 @@ class mainForm : public QDialog
 
 	struct BwBitmapUndoStep : public QUndoCommand
 	{
-		BwBitmapUndoStep(mainForm& form, QImage image);
+		BwBitmapUndoStep(mainForm& form, QImage image, bool vectorizable);
 		void redo() override;
 		void undo() override;
 
 		mainForm& form;
 		QImage image;
+		bool suitableForVectorization;
 	};
 
 public:
@@ -74,6 +75,7 @@ protected:
 	QImage imageBitmap;
 	QImage classifiedBitmap;
 	QImage bwBitmap;
+	bool bwBitmapVectorizable {};
 	QUndoStack* bwBitmapUndo {};
 	std::vector<QPushButton*> colorButtons;
 	Settings settings;

--- a/3rd-party/cove/app/mainform.h
+++ b/3rd-party/cove/app/mainform.h
@@ -30,6 +30,7 @@
 #include <QRgb>
 #include <QString>
 #include <Qt>
+#include <QUndoCommand>
 
 #include "libvectorizer/Vectorizer.h"
 
@@ -38,6 +39,7 @@
 
 class QPushButton;
 class QWidget;
+class QUndoStack;
 
 namespace OpenOrienteering {
 class Map;
@@ -51,6 +53,16 @@ class mainForm : public QDialog
 {
 	Q_OBJECT
 
+	struct BwBitmapUndoStep : public QUndoCommand
+	{
+		BwBitmapUndoStep(mainForm& form, QImage image);
+		void redo() override;
+		void undo() override;
+
+		mainForm& form;
+		QImage image;
+	};
+
 public:
 	Ui::mainForm ui;
 
@@ -62,17 +74,12 @@ protected:
 	QImage imageBitmap;
 	QImage classifiedBitmap;
 	QImage bwBitmap;
-	bool rollbackHistory;
-	QList<QImage> bwBitmapHistory;
-	QList<QImage>::iterator bwBitmapHistoryIterator;
+	QUndoStack* bwBitmapUndo {};
 	std::vector<QPushButton*> colorButtons;
 	Settings settings;
 	static const int MESSAGESHOWDELAY;
 
 	bool performMorphologicalOperation(Vectorizer::MorphologicalOperation mo);
-	void prepareBWImageHistory();
-	void bwImageCommitHistory();
-	void bwImageClearHistory();
 	void clearColorsTab();
 	void clearBWImageTab();
 	void setTabEnabled(QWidget* tab, bool state);

--- a/3rd-party/cove/app/mainform.ui
+++ b/3rd-party/cove/app/mainform.ui
@@ -401,6 +401,9 @@
          </item>
          <item>
           <widget class="QPushButton" name="bwImageHistoryBack">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
            <property name="toolTip">
             <string>Undo last operation.</string>
            </property>
@@ -411,6 +414,9 @@
          </item>
          <item>
           <widget class="QPushButton" name="bwImageHistoryForward">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
            <property name="toolTip">
             <string>Redo last operation.</string>
            </property>


### PR DESCRIPTION
It is very easy for a user to omit the thinning operation in line vectorization. The function then gives unsatisfactory results. This patchset makes CoVe emit a warning in case the user runs vectorization on B/W image which didn't see thinning. Attempt for proper integration with the undo/redo functionality resulted in the removal of the legacy code and adoption of `QUndoStack`. Although the rewrite is fairly straightforward, I'd appreciate a review. Thanks!