### PR TITLE
GdalTemplate: Don't lose GDAL error string

### DIFF
--- a/src/gdal/gdal_template.cpp
+++ b/src/gdal/gdal_template.cpp
@@ -21,6 +21,7 @@
 
 #include <QtGlobal>
 #include <QByteArray>
+#include <QChar>
 #include <QImageReader>
 #include <QString>
 
@@ -75,7 +76,7 @@ bool GdalTemplate::loadTemplateFileImpl(bool configuring)
 			qDebug("GdalTemplate: Falling back to QImageReader, reason: %s", qPrintable(errorString()));
 			if (!image_reader.read(&image))
 			{
-				setErrorString(image_reader.errorString());
+				setErrorString(errorString() + QChar::LineFeed + image_reader.errorString());
 				return false;
 			}
 		}


### PR DESCRIPTION
When QImageReader is used as a fallback after GdalImageReader failed,
and QImageReader fails, too, we shall combine the error strings:
The error message from GdalImageReader can be more specific.
Resolves GH-1550.