### PR TITLE
EditPointTool,EditLineTool: Enlarge object frame (GH-980)

### DIFF
--- a/src/tools/edit_line_tool.cpp
+++ b/src/tools/edit_line_tool.cpp
@@ -429,6 +429,11 @@ int EditLineTool::updateDirtyRectImpl(QRectF& rect)
 	
 	selection_extent = QRectF();
 	map()->includeSelectionRect(selection_extent);
+
+	const auto frame_extension = 0.001 * cur_map_widget->getMapView()
+	                             ->pixelToLength(clickTolerance()); // in mm
+	selection_extent.adjust(-frame_extension, -frame_extension,
+	                        frame_extension, frame_extension);
 	
 	rectInclude(rect, selection_extent);
 	int pixel_border = show_object_points ? pointHandles().displayRadius() : 1;
@@ -622,6 +627,13 @@ void EditLineTool::updateHoverState(const MapCoordF& cursor_pos)
 		effective_start_drag_distance = (hover_state == OverNothing) ? startDragDistance() : 0;
 		updateDirtyRect();
 	}
+}
+
+
+void EditLineTool::applyViewChanges(MapView::ChangeFlags change)
+{
+	if (change == MapView::ZoomChange)
+		updateDirtyRect(); // the bounding rectangle extent changes
 }
 
 

--- a/src/tools/edit_line_tool.h
+++ b/src/tools/edit_line_tool.h
@@ -29,6 +29,7 @@
 #include <QString>
 
 #include "core/map_coord.h"
+#include "core/map_view.h"
 #include "tools/edit_tool.h"
 
 class QAction;
@@ -68,6 +69,8 @@ public:
 	void dragMove() override;
 	void dragFinish() override;
 	void dragCanceled() override;
+	
+	void applyViewChanges(OpenOrienteering::MapView::ChangeFlags change) override;
 	
 protected:
 	bool keyPress(QKeyEvent* event) override;

--- a/src/tools/edit_point_tool.cpp
+++ b/src/tools/edit_point_tool.cpp
@@ -575,6 +575,11 @@ int EditPointTool::updateDirtyRectImpl(QRectF& rect)
 	
 	selection_extent = QRectF();
 	map()->includeSelectionRect(selection_extent);
+
+	const auto frame_extension = 0.001 * cur_map_widget->getMapView()
+	                             ->pixelToLength(clickTolerance()); // in mm
+	selection_extent.adjust(-frame_extension, -frame_extension,
+	                        frame_extension, frame_extension);
 	
 	rectInclude(rect, selection_extent);
 	int pixel_border = show_object_points ? pointHandles().displayRadius() : 1;
@@ -957,6 +962,13 @@ bool EditPointTool::moveOppositeHandle() const
 {
 	return !(active_modifiers & Qt::ShiftModifier)
 	       && hoveringOverCurveHandle();
+}
+
+
+void EditPointTool::applyViewChanges(MapView::ChangeFlags change)
+{
+	if (change == MapView::ZoomChange)
+		updateDirtyRect(); // the bounding rectangle extent changes
 }
 
 

--- a/src/tools/edit_point_tool.h
+++ b/src/tools/edit_point_tool.h
@@ -33,6 +33,7 @@
 #include <QVariant>
 
 #include "core/map_coord.h"
+#include "core/map_view.h"
 #include "tools/edit_tool.h"
 
 class QAction;
@@ -93,6 +94,8 @@ public:
 	 * Contains special treatment for text objects.
 	 */
 	void finishEditing() override;
+	
+	void applyViewChanges(OpenOrienteering::MapView::ChangeFlags change) override;
 	
 protected:
 	bool keyPress(QKeyEvent* event) override;

--- a/src/tools/edit_tool.cpp
+++ b/src/tools/edit_tool.cpp
@@ -39,6 +39,7 @@
 #include "core/virtual_path.h"
 #include "core/objects/object.h"
 #include "core/objects/text_object.h"
+#include "gui/map/map_editor.h"
 #include "gui/map/map_widget.h"
 #include "tools/object_selector.h"
 #include "tools/tool_helpers.h"
@@ -52,7 +53,9 @@ EditTool::EditTool(MapEditorController* editor, MapEditorTool::Type type, QActio
  : MapEditorToolBase { QCursor(QPixmap(QString::fromLatin1(":/images/cursor-hollow.png")), 1, 1), type, editor, tool_action }
  , object_selector { new ObjectSelector(map()) }
 {
-	; // nothing
+	connect(editor->getMainWidget()->getMapView(),
+	        SIGNAL(viewChanged(OpenOrienteering::MapView::ChangeFlags)),
+	        this, SLOT(applyViewChanges(OpenOrienteering::MapView::ChangeFlags)));
 }
 
 

--- a/src/tools/edit_tool.h
+++ b/src/tools/edit_tool.h
@@ -34,6 +34,7 @@
 #include <QString>
 
 #include "core/map_coord.h"
+#include "core/map_view.h"
 #include "tools/tool.h"
 #include "tools/tool_base.h"
 
@@ -148,6 +149,16 @@ protected:
 	 * An utility implementing object selection logic.
 	 */
 	QScopedPointer<ObjectSelector> object_selector;
+
+public slots:
+	/**
+	 * Rendering of some of the editor graphic elements may depend on
+	 * MapView settings. This method is the place where to process
+	 * the changes.
+	 *
+	 * @param change type of change as emitted by MapView
+	 */
+	virtual void applyViewChanges(OpenOrienteering::MapView::ChangeFlags change) = 0;
 };
 
 


### PR DESCRIPTION
There is a heavy code duplication between edit point and edit line tools. The work done in the `EditTool` code aims at minimizing further code duplication.