### PR TITLE
Georeferencing: Fix state switching

### DIFF
--- a/src/core/georeferencing.cpp
+++ b/src/core/georeferencing.cpp
@@ -891,13 +891,8 @@ void Georeferencing::updateGridCompensation()
 	if (determinant < 0.00000000001)
 		return;
 
-	// This is the angle between true azimuth and grid azimuth.
-	// In case of deformation, the convergence varies with direction and this is an average.
 	convergence = qRadiansToDegrees(atan2(d_northing_dx - d_easting_dy,
 	                                      d_easting_dx + d_northing_dy));
-
-	// This is the scale factor from true distance to grid distance.
-	// In case of deformation, the scale factor varies with direction and this is an average.
 	grid_scale_factor = sqrt(determinant);
 }
 

--- a/src/core/georeferencing.h
+++ b/src/core/georeferencing.h
@@ -637,12 +637,29 @@ private:
 	unsigned int scale_denominator;
 	double combined_scale_factor;
 	double auxiliary_scale_factor;
+	
+	/**
+	 * This is the scale factor from true distance to grid distance.
+	 * 
+	 * In case of deformation, the scale factor varies with direction and this is an average.
+	 * 
+	 * \see updateGridCompensation()
+	 */
 	double grid_scale_factor;
 
 	double declination;
 	double grivation;
 	double grivation_error;
+	
+	/**
+	 * This is the angle between true azimuth and grid azimuth.
+	 * 
+	 * In case of deformation, the convergence varies with direction and this is an average.
+	 * 
+	 * \see updateGridCompensation()
+	 */
 	double convergence;
+	
 	MapCoord map_ref_point;
 	
 	QPointF projected_ref_point;

--- a/test/georeferencing_t.cpp
+++ b/test/georeferencing_t.cpp
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2012-2015, 2019 Kai Pastor
+ *    Copyright 2012-2020 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -228,9 +228,8 @@ void GeoreferencingTest::testGridScaleFactor()
 	{
 		QCOMPARE(geod_distance, elevation_scale_factor * ground_distance);
 	}
-
-	// Finally, see that the auxiliary scale factor is preserved when
-	// the CRS changes.
+	
+	// See that the auxiliary scale factor is preserved when the CRS changes.
 	georef.setProjectedCRS(QString::fromLatin1(QTest::currentDataTag()), utm32_spec);
 	QVERIFY2(georef.isValid(), georef.getErrorText().toLatin1());
 	QCOMPARE(georef.getAuxiliaryScaleFactor(), elevation_scale_factor);
@@ -240,6 +239,35 @@ void GeoreferencingTest::testGridScaleFactor()
 	{
 		QCOMPARE(geod_distance, elevation_scale_factor * ground_distance);
 	}
+	
+	// The transformation between map coordinates and projected coordinates
+	// must be preserved when switching from projected to local and back.
+	georef.setProjectedCRS(QString::fromLatin1(QTest::currentDataTag()), spec);
+	georef.setDeclination(20.0);
+	auto const expected_grivation = georef.getGrivation();
+	georef.setAuxiliaryScaleFactor(0.95);
+	auto const expected_combined = georef.getCombinedScaleFactor();
+	auto const map_coord = georef.toMapCoordF(sw);
+	georef.setState(Georeferencing::Local);
+	QVERIFY(georef.getProjectedCRSSpec().isEmpty());
+	// This call to setDeclination must not have side-effects.
+	georef.setDeclination(georef.getDeclination());
+	QCOMPARE(georef.getGrivation(), expected_grivation);
+	// This call to setAuxiliaryScaleFactor must not have side-effects.
+	georef.setAuxiliaryScaleFactor(georef.getAuxiliaryScaleFactor());
+	QCOMPARE(georef.getCombinedScaleFactor(), expected_combined);
+	if (QLineF(georef.toProjectedCoords(map_coord), sw).length() >= 0.000001)
+		QCOMPARE(georef.toProjectedCoords(map_coord), sw);
+	georef.setProjectedCRS(QString::fromLatin1(QTest::currentDataTag()), spec);
+	QVERIFY(!georef.getProjectedCRSSpec().isEmpty());
+	// This call to setDeclination must not have side-effects.
+	georef.setDeclination(georef.getDeclination());
+	QCOMPARE(georef.getGrivation(), expected_grivation); // setDeclination must be no-op
+	// This call to setAuxiliaryScaleFactor must not have side-effects.
+	georef.setAuxiliaryScaleFactor(georef.getAuxiliaryScaleFactor());
+	QCOMPARE(georef.getCombinedScaleFactor(), expected_combined); // setAuxiliaryScaleFactor must be no-op
+	if (QLineF(georef.toProjectedCoords(map_coord), sw).length() >= 0.000001)
+		QCOMPARE(georef.toProjectedCoords(map_coord), sw);
 }
 
 void GeoreferencingTest::testCRS_data()


### PR DESCRIPTION
Fixes the change of mapping between paper and ground when changing from a CRS to a local georeferencing and back, by retaining (fake) convergence and grid scale factor.