### PR TITLE
CombinedSymbolSettings: Block signals on symbol reset

### DIFF
--- a/src/core/symbols/combined_symbol.cpp
+++ b/src/core/symbols/combined_symbol.cpp
@@ -398,6 +398,7 @@ const Symbol::BorderHints* CombinedSymbol::borderHints() const
 void CombinedSymbol::setPart(int i, const Symbol* symbol, bool is_private)
 {
 	const auto index = std::size_t(i);
+	Q_ASSERT(index < parts.size());
 	
 	if (private_parts[index])
 		delete parts[index];

--- a/src/gui/symbols/combined_symbol_settings.cpp
+++ b/src/gui/symbols/combined_symbol_settings.cpp
@@ -153,6 +153,7 @@ void CombinedSymbolSettings::updateContents()
 	for (auto i = num_parts; i < widgets.size(); ++i)
 	{
 		auto& w = widgets[i];
+		QSignalBlocker block{w.edit};
 		w.label->setVisible(false);
 		w.edit->setSymbol(nullptr);
 		w.edit->setVisible(false);


### PR DESCRIPTION
When the number of subsymbols decreases, we must block signal
emissions while resetting obsolete symbol edits.
Fixes GH-1600 (Crash when editing combined symbols).