### PR TITLE
LineSymbol: Fix border line handling

### DIFF
--- a/src/core/symbols/line_symbol.cpp
+++ b/src/core/symbols/line_symbol.cpp
@@ -424,7 +424,6 @@ void LineSymbol::createBorderLines(
         const SplitPathCoord& end,
         ObjectRenderables& output) const
 {
-	const auto main_shift = 0.0005 * line_width;
 	const auto path_closed = path.isClosed();
 	
 	MapCoordVector border_flags;
@@ -450,12 +449,12 @@ void LineSymbol::createBorderLines(
 			// Left border is dashed
 			border_symbol.processDashedLine(path, start, end, path_closed, dashed_flags, dashed_coords, output);
 			border_symbol.dashed = false;	// important, otherwise more dashes might be added by createRenderables()!
-			shiftCoordinates({dashed_flags, dashed_coords}, -main_shift, border_flags, border_coords);
+			shiftCoordinatesLeft({dashed_flags, dashed_coords}, border_flags, border_coords);
 		}
 		else
 		{
 			// Solid left border
-			shiftCoordinates(path, -main_shift, border_flags, border_coords);
+			shiftCoordinatesLeft(path, border_flags, border_coords);
 		}
 		auto border_path = VirtualPath{border_flags, border_coords};
 		auto last = border_path.path_coords.update(0);
@@ -480,12 +479,12 @@ void LineSymbol::createBorderLines(
 				border_symbol.processDashedLine(path, start, end, path_closed, dashed_flags, dashed_coords, output);
 			}
 			border_symbol.dashed = false;	// important, otherwise more dashes might be added by createRenderables()!
-			shiftCoordinates({dashed_flags, dashed_coords}, main_shift, border_flags, border_coords);
+			shiftCoordinatesRight({dashed_flags, dashed_coords}, border_flags, border_coords);
 		}
 		else
 		{
 			// Solid right border
-			shiftCoordinates(path, main_shift, border_flags, border_coords);
+			shiftCoordinatesRight(path, border_flags, border_coords);
 		}
 		auto border_path = VirtualPath{border_flags, border_coords};
 		auto last = border_path.path_coords.update(0);
@@ -585,7 +584,7 @@ void LineSymbol::shiftCoordinates(const VirtualPath& path, double main_shift, do
 			double offset;
 				
 			// Determine type of corner (inner vs. outer side of corner)
-			double a = (tangent_out.x() * tangent_in.y() - tangent_in.x() * tangent_out.y()) * main_shift;
+			double a = (tangent_out.x() * tangent_in.y() - tangent_in.x() * tangent_out.y()) * shift;
 			if (a > 0.0)
 			{
 				// Outer side of corner
@@ -725,7 +724,7 @@ void LineSymbol::shiftCoordinates(const VirtualPath& path, double main_shift, do
 			
 			// Use QBezierCopy code to shift the curve, but set start and end point manually to get the correct end points (because of line joins)
 			// TODO: it may be necessary to remove some of the generated curves in the case an outer point is moved inwards
-			if (main_shift > 0.0)
+			if (shift > 0.0)
 			{
 				QBezier bezier = QBezier::fromPoints(path.coords[i+3], path.coords[i+2], path.coords[i+1], coords_i);
 				auto count = bezier.shifted(offsetCurves, MAX_OFFSET, qAbs(shift), curve_threshold);
@@ -774,10 +773,14 @@ void LineSymbol::shiftCoordinates(const VirtualPath& path, double main_shift, do
 }
 
 
-void LineSymbol::shiftCoordinates(const VirtualPath& path, double main_shift, MapCoordVector& out_flags, MapCoordVectorF& out_coords) const
+void LineSymbol::shiftCoordinatesLeft(const VirtualPath& path, MapCoordVector& out_flags, MapCoordVectorF& out_coords) const
 {
-	auto border_shift = (main_shift > 0.0) ? (0.001 * right_border.shift) : (-0.001 * border.shift);
-	shiftCoordinates(path, main_shift, border_shift, join_style, out_flags, out_coords);
+	shiftCoordinates(path, -0.0005 * line_width, -0.001 * border.shift, join_style, out_flags, out_coords);
+}
+
+void LineSymbol::shiftCoordinatesRight(const VirtualPath& path, MapCoordVector& out_flags, MapCoordVectorF& out_coords) const
+{
+	shiftCoordinates(path, 0.0005 * line_width, 0.001 * right_border.shift, join_style, out_flags, out_coords);
 }
 
 void LineSymbol::processContinuousLine(

--- a/src/core/symbols/line_symbol.h
+++ b/src/core/symbols/line_symbol.h
@@ -314,9 +314,14 @@ public:
 	);
 	
 protected:
-	void shiftCoordinates(
+	void shiftCoordinatesLeft(
 	        const VirtualPath& path,
-	        double main_shift,
+	        MapCoordVector& out_flags,
+	        MapCoordVectorF& out_coords
+	) const;
+	
+	void shiftCoordinatesRight(
+	        const VirtualPath& path,
 	        MapCoordVector& out_flags,
 	        MapCoordVectorF& out_coords
 	) const;


### PR DESCRIPTION
The path of a border line is determined by two factors: the main
offset, indicating the edge of the main line, and an explicit
additional offset.
Mapper used to rely on the main offset being non-zero in order to
distinguish left from right by the sign of the main offset.
With this change, Mapper now uses the totat offset to determine left
or right, thus allowing to use border lines with invisible main lines.
Fixes GH-1602 (wrong area border line path).