### PR TITLE
Georeferencing: Set reference point correctly when loading templates

### DIFF
--- a/src/fileformats/ocd_georef_fields.cpp
+++ b/src/fileformats/ocd_georef_fields.cpp
@@ -852,7 +852,7 @@ void OcdGeorefFields::setupGeoref(Georeferencing& georef,
 
 	QPointF proj_ref_point(x, y);
 	georef.setProjectedRefPoint(proj_ref_point, false, false);
-	
+	georef.setCombinedScaleFactor(1.0);
 	georef.setGrivation(qIsFinite(a) ? a : 0);
 }
 

--- a/src/fileformats/ocd_georef_fields.cpp
+++ b/src/fileformats/ocd_georef_fields.cpp
@@ -851,7 +851,7 @@ void OcdGeorefFields::setupGeoref(Georeferencing& georef,
 		applyGridAndZone(georef, i, warning_handler);
 
 	QPointF proj_ref_point(x, y);
-	georef.setProjectedRefPoint(proj_ref_point, false);
+	georef.setProjectedRefPoint(proj_ref_point, false, false);
 	
 	georef.setGrivation(qIsFinite(a) ? a : 0);
 }

--- a/src/fileformats/xml_file_format.cpp
+++ b/src/fileformats/xml_file_format.cpp
@@ -593,7 +593,7 @@ bool XMLFileImporter::importImplementation()
 			auto georef = map->getGeoreferencing();
 			auto ref_point = MapCoordF { georef.getMapRefPoint() };
 			auto new_projected = georef.toProjectedCoords(ref_point + offset_f);
-			georef.setProjectedRefPoint(new_projected, false);
+			georef.setProjectedRefPoint(new_projected, false, false);
 			map->setGeoreferencing(georef);
 		}
 	}

--- a/src/fileformats/xml_file_format.cpp
+++ b/src/fileformats/xml_file_format.cpp
@@ -594,6 +594,8 @@ bool XMLFileImporter::importImplementation()
 			auto ref_point = MapCoordF { georef.getMapRefPoint() };
 			auto new_projected = georef.toProjectedCoords(ref_point + offset_f);
 			georef.setProjectedRefPoint(new_projected, false, false);
+			georef.setCombinedScaleFactor(georef.getCombinedScaleFactor()); // keep combined scale factor
+			georef.setGrivation(georef.getGrivation());  // keep grivation, update declination
 			map->setGeoreferencing(georef);
 		}
 	}

--- a/src/gdal/ogr_file_format.cpp
+++ b/src/gdal/ogr_file_format.cpp
@@ -851,6 +851,8 @@ bool OgrFileImport::importImplementation()
 			auto ref_point = MapCoordF { georef.getMapRefPoint() };
 			auto new_projected = georef.toProjectedCoords(ref_point + offset_f);
 			georef.setProjectedRefPoint(new_projected, false, false);
+			georef.setCombinedScaleFactor(georef.getCombinedScaleFactor()); // keep combined scale factor
+			georef.setGrivation(georef.getGrivation());  // keep grivation, update declination
 			map->setGeoreferencing(georef);
 		}
 	}
@@ -971,6 +973,7 @@ ogr::unique_srs OgrFileImport::importGeoreferencing(OGRDataSourceH data_source)
 		                             .arg(latitude, 0, 'f')
 		                             .arg(longitude, 0, 'f') );
 		ortho_georef.setProjectedRefPoint({}, false, false);
+		ortho_georef.setCombinedScaleFactor(1.0);
 		ortho_georef.setDeclination(map->getGeoreferencing().getDeclination());
 		map->setGeoreferencing(ortho_georef);
 		return srsFromMap();

--- a/src/gdal/ogr_file_format.cpp
+++ b/src/gdal/ogr_file_format.cpp
@@ -850,7 +850,7 @@ bool OgrFileImport::importImplementation()
 			auto georef = map->getGeoreferencing();
 			auto ref_point = MapCoordF { georef.getMapRefPoint() };
 			auto new_projected = georef.toProjectedCoords(ref_point + offset_f);
-			georef.setProjectedRefPoint(new_projected, false);
+			georef.setProjectedRefPoint(new_projected, false, false);
 			map->setGeoreferencing(georef);
 		}
 	}
@@ -970,7 +970,7 @@ ogr::unique_srs OgrFileImport::importGeoreferencing(OGRDataSourceH data_source)
 		                             QString::fromLatin1("+proj=ortho +datum=WGS84 +ellps=WGS84 +units=m +lat_0=%1 +lon_0=%2 +no_defs")
 		                             .arg(latitude, 0, 'f')
 		                             .arg(longitude, 0, 'f') );
-		ortho_georef.setProjectedRefPoint({}, false);
+		ortho_georef.setProjectedRefPoint({}, false, false);
 		ortho_georef.setDeclination(map->getGeoreferencing().getDeclination());
 		map->setGeoreferencing(ortho_georef);
 		return srsFromMap();

--- a/src/gdal/ogr_template.cpp
+++ b/src/gdal/ogr_template.cpp
@@ -193,7 +193,7 @@ std::unique_ptr<Georeferencing> OgrTemplate::makeOrthographicGeoreferencing(cons
 		georef->setProjectedCRS(QString{},
 		                             QString::fromLatin1("+proj=ortho +datum=WGS84 +ellps=WGS84 +units=m +lat_0=%1 +lon_0=%2 +no_defs")
 		                             .arg(center.latitude()).arg(center.longitude()));
-		georef->setProjectedRefPoint({}, false);
+		georef->setProjectedRefPoint({}, false, false);
 	}
 	else
 	{
@@ -367,7 +367,7 @@ try
 					explicit_georef = std::make_unique<Georeferencing>();
 					explicit_georef->setScaleDenominator(int(map_georef.getScaleDenominator()));
 					explicit_georef->setProjectedCRS(QString{}, projected_crs_spec);
-					explicit_georef->setProjectedRefPoint({}, false);
+					explicit_georef->setProjectedRefPoint({}, false, false);
 				}
 			}
 		}

--- a/src/gdal/ogr_template.cpp
+++ b/src/gdal/ogr_template.cpp
@@ -194,6 +194,8 @@ std::unique_ptr<Georeferencing> OgrTemplate::makeOrthographicGeoreferencing(cons
 		                             QString::fromLatin1("+proj=ortho +datum=WGS84 +ellps=WGS84 +units=m +lat_0=%1 +lon_0=%2 +no_defs")
 		                             .arg(center.latitude()).arg(center.longitude()));
 		georef->setProjectedRefPoint({}, false, false);
+		georef->setCombinedScaleFactor(1.0);
+		georef->setGrivation(0.0);
 	}
 	else
 	{
@@ -368,6 +370,8 @@ try
 					explicit_georef->setScaleDenominator(int(map_georef.getScaleDenominator()));
 					explicit_georef->setProjectedCRS(QString{}, projected_crs_spec);
 					explicit_georef->setProjectedRefPoint({}, false, false);
+					explicit_georef->setCombinedScaleFactor(1.0);
+					explicit_georef->setGrivation(0.0);
 				}
 			}
 		}

--- a/src/templates/template_image.cpp
+++ b/src/templates/template_image.cpp
@@ -235,6 +235,8 @@ bool TemplateImage::postLoadConfiguration(QWidget* dialog_parent, bool& out_cent
 				calculateGeoreferencing();
 				auto const center_pixel = MapCoordF(0.5 * (image.width() - 1), 0.5 * (image.height() - 1));
 				initial_georef.setProjectedRefPoint(georef->toProjectedCoords(center_pixel));
+				initial_georef.setCombinedScaleFactor(1.0);
+				initial_georef.setGrivation(0.0);
 			}
 			
 			GeoreferencingDialog dialog(dialog_parent, map, &initial_georef, false);

--- a/src/templates/template_track.cpp
+++ b/src/templates/template_track.cpp
@@ -609,6 +609,8 @@ void TemplateTrack::applyProjectedCrsSpec()
 	georef.setScaleDenominator(int(map->getScaleDenominator()));
 	georef.setProjectedCRS(QString{}, projected_crs_spec);
 	georef.setProjectedRefPoint({});
+	georef.setCombinedScaleFactor(1.0);
+	georef.setGrivation(0.0);
 	track.changeMapGeoreferencing(georef);
 }
 

--- a/test/georef_ocd_mapping_t.cpp
+++ b/test/georef_ocd_mapping_t.cpp
@@ -266,7 +266,7 @@ private slots:
 		}
 
 		georef.setProjectedCRS(georef_result.crs_id, spec, crs_params);
-		georef.setProjectedRefPoint(georef_result.ref_point, false);
+		georef.setProjectedRefPoint(georef_result.ref_point, false, false);
 		georef.setScaleDenominator(georef_result.scale);
 		georef.setDeclination(georef_result.declination);
 		georef.setGrivation(georef_result.grivation);


### PR DESCRIPTION
When loading a template from an OCAD file, etc. and setting the projected reference point, hold on to the received combined scale factor rather than update it based on the auxiliary scale factor and grid scale factor.

This appears to fix #1620. 