### PR TITLE
GeoreferencingTest: Use "WGS 84" as CRS ID

### DIFF
--- a/test/georeferencing_t.cpp
+++ b/test/georeferencing_t.cpp
@@ -281,7 +281,7 @@ void GeoreferencingTest::testCRS_data()
 	        << QStringLiteral("+init=epsg:4258")
 	        << true;
 	QTest::newRow("WGS 84")
-	        << QStringLiteral("WGS84")
+	        << QStringLiteral("WGS 84")  // not "WGS84"
 	        << QStringLiteral("+init=epsg:4326")
 	        << true;
 	QTest::newRow("WGS 84 (G730)")


### PR DESCRIPTION
Before PROJ 7.0.0, "WGS84" used to identify a geographic CRS (by
approximate match on "WGS 84"). Since 7.0.0, it identifies a datum
instead (by exact match).
Cf. https://github.com/OSGeo/PROJ/issues/2216.