### PR TITLE
MapEditorController: Fix window state saving

### DIFF
--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -1631,7 +1631,7 @@ void MapEditorController::detach()
 
 void MapEditorController::setWindowStateChanged()
 {
-	if (!window_state_changed && !mobile_mode && mode != SymbolEditor)
+	if (!window_state_changed)
 	{
 		window_state_changed = true;
 		QTimer::singleShot(10, this, &MapEditorController::saveWindowState);
@@ -1640,7 +1640,7 @@ void MapEditorController::setWindowStateChanged()
 
 void MapEditorController::saveWindowState()
 {
-	if (window_state_changed)
+	if (!mobile_mode && mode != SymbolEditor)
 	{
 		QSettings settings;
 		settings.beginGroup(QString::fromUtf8(metaObject()->className()));

--- a/src/gui/map/map_editor.h
+++ b/src/gui/map/map_editor.h
@@ -568,23 +568,26 @@ public slots:
 	void setViewOptionsEnabled(bool enabled = true);
 	
 	/**
-	 * Indicates a change of the current toolbar and dock widget positions,
-	 * and schedules saving.
+	 * Indicates a change of the current toolbar and dock widget visibilities
+	 * and locations, and schedules saving.
 	 */
 	void setWindowStateChanged();
 	
 private:
 	/**
-	 * Immediately saves the window state if needed.
+	 * Saves the window state in the permanent settings.
 	 * 
-	 * This will save the current toolbar and dock widget positions if the
-	 * window state is marked as changed.
-	 * After saving, it marks the state as clean.
+	 * The window state consists of current toolbar and dock widget visibility
+	 * and locations.
+	 * 
+	 * This function does nothing in mobile mode or symbol editor mode.
 	 */
 	void saveWindowState();
 	
 	/**
 	 * Restores previously saved toolbar and dock widget positions.
+	 * 
+	 * This function does nothing in mobile mode or symbol editor mode.
 	 */
 	void restoreWindowState();
 	


### PR DESCRIPTION
While we use (some) dock widget location changes as triggers for
saving window state, other state changes happen without being
recorded immediately. Thus we need to rely on saveWindowState()
always saving the current state when called from detach() when
the map editor is in "normal" mode.
Resolves GH-1647 (unable to permanently restore missing toolbars).