### PR TITLE
Fix build with Qt 5.15

### DIFF
--- a/src/gui/print_tool.cpp
+++ b/src/gui/print_tool.cpp
@@ -25,6 +25,7 @@
 
 #include <QMouseEvent>
 #include <QPainter>
+#include <QPainterPath>
 
 #include "core/map.h"
 #include "core/map_printer.h"


### PR DESCRIPTION
openSUSE Tumbleweed switched to Qt 5.15. As a result, Mapper stopped building there. The immediate cause is a missing `#include` in `src/gui/print_tool.cpp`.

I think this trivia change does not deserve an explicit request for review. Still, I'll wait a while before merging so that anyone concerned about the change can raise objections.