### PR TITLE
PaintOnTemplateTool: Add drawing preservation mode

### DIFF
--- a/src/templates/paint_on_template_tool.h
+++ b/src/templates/paint_on_template_tool.h
@@ -112,6 +112,7 @@ private:
 	static int erase_width;
 	
 	Q_DISABLE_COPY(PaintOnTemplateTool)
+	void storePaintToolStatus();
 };
 
 

--- a/src/templates/paint_on_template_tool.h
+++ b/src/templates/paint_on_template_tool.h
@@ -83,6 +83,9 @@ protected:
 public:
 	bool fillAreas() const { return fill_areas; }
 	void setFillAreas(bool enabled);
+
+	bool preserveDrawing() const { return preserve_drawing; }
+	void setpreserveDrawing(bool enabled);
 	
 	const QColor& color() const { return paint_color; }
 	void setColor(const QColor& color);
@@ -97,6 +100,8 @@ private:
 	ErasingOptions erasing = {};
 	bool dragging = false;
 	bool fill_areas = false;
+	bool preserve_drawing = false;
+	bool overlay_drawing_mode = false;
 	QColor paint_color = Qt::black;
 	QRectF map_bbox;
 	std::vector<MapCoordF> coords;

--- a/src/templates/template.h
+++ b/src/templates/template.h
@@ -145,7 +145,9 @@ public:
 	enum ScribbleOption
 	{
 		NoScribbleOptions = 0,
-		FilledAreas	= 1<<0,  ///< Fill area defined by the scribble line
+		FilledAreas       = 1<<0,  ///< Fill area defined by the scribble line.
+		PreserveDrawing	  = 1<<1,  ///< Draw only in free areas.
+		OverlayDrawing	  = 1<<2,  ///< Compose new drawing with the underlying one.
 	};
 	Q_DECLARE_FLAGS(ScribbleOptions, ScribbleOption)
 	

--- a/src/templates/template_image.cpp
+++ b/src/templates/template_image.cpp
@@ -578,6 +578,11 @@ void TemplateImage::drawOntoTemplateImpl(MapCoordF* coords, int num_coords, cons
 	painter.setPen(pen);
 	painter.setRenderHint(QPainter::Antialiasing);
 
+	if (mode.testFlag(PreserveDrawing))
+		painter.setCompositionMode(QPainter::CompositionMode_DestinationAtop);
+	else if (mode.testFlag(OverlayDrawing))
+		painter.setCompositionMode(QPainter::CompositionMode_Multiply);
+
 	if (mode.testFlag(FilledAreas))
 	{
 		painter.setBrush(QBrush(color));


### PR DESCRIPTION
Extends GH-1242 (Fill areas in scribble mode) - follow up to https://github.com/OpenOrienteering/mapper/pull/1652#issuecomment-645804058.