### PR TITLE
PaintOnTemplateTool: Use ActionGridBar for "palette"

### DIFF
--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -507,11 +507,11 @@ void MapEditorController::showPopupWidget(QWidget* child_widget, const QString& 
 {
 	if (mobile_mode)
 	{
-		// FIXME: This is used for KeyButtonBar only
-		//        and not related to mobile_mode!
+		// This is used for KeyButtonBar, but also for template painting toolbar.
 		QSize size = child_widget->sizeHint();
 		QRect map_widget_rect = map_widget->rect();
 		
+		// Binding child_widget lifetime directly to map_widget
 		child_widget->setParent(map_widget);
 		child_widget->setGeometry(
 			qMax(0, qRound(map_widget_rect.center().x() - 0.5f * size.width())),
@@ -531,6 +531,9 @@ void MapEditorController::showPopupWidget(QWidget* child_widget, const QString& 
 		dock_widget->setFloating(true);
 		dock_widget->show();
 		dock_widget->setGeometry(window->geometry().left() + 40, window->geometry().top() + 100, dock_widget->width(), dock_widget->height());
+		
+		// Binding child_widget lifetime to map_widget via deletion of dock_widget
+		connect(map_widget, &QObject::destroyed, dock_widget, [dock_widget]() { delete dock_widget; });
 	}
 }
 

--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -519,6 +519,10 @@ void MapEditorController::showPopupWidget(QWidget* child_widget, const QString& 
 			qMin(size.width(), map_widget_rect.width()),
 			qMin(size.height(), map_widget_rect.height())
 			);
+		// Not being part of the layout, widgets must explicitly draw the background.
+		// But for KeyButtonBar, it is enough that the buttons draw their background.
+		if (!qobject_cast<KeyButtonBar*>(child_widget))
+			child_widget->setAutoFillBackground(true);
 		child_widget->show();
 	}
 	else

--- a/src/gui/widgets/action_grid_bar.cpp
+++ b/src/gui/widgets/action_grid_bar.cpp
@@ -132,8 +132,18 @@ ActionGridBar::ButtonDisplay ActionGridBar::buttonDisplay(const QToolButton* but
 
 QSize ActionGridBar::sizeHint() const
 {
-	auto extent = row_count * button_size_px;
-	return {extent, extent};
+	int actions_at_begin = -1;
+	int actions_at_end = -1;
+	for (auto const& item : items)
+	{
+		if (item.at_end)
+			actions_at_end = std::max(actions_at_end, item.col);
+		else
+			actions_at_begin = std::max(actions_at_begin, item.col);
+	}
+	auto const dynamic_size = (actions_at_begin + actions_at_end + 2) * button_size_px;
+	auto const fixed_size = rowCount() * button_size_px;
+	return direction == Horizontal ? QSize{ dynamic_size, fixed_size } : QSize{ fixed_size, dynamic_size };
 }
 
 void ActionGridBar::overflowActionClicked()

--- a/src/gui/widgets/mapper_proxystyle.cpp
+++ b/src/gui/widgets/mapper_proxystyle.cpp
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2013-2016, 2019 Kai Pastor
+ *    Copyright 2013-2020 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -32,6 +32,7 @@
 #include <QVariant>
 #include <QWidget>
 
+#include "settings.h"
 #include "gui/scaling_icon_engine.h"
 #include "gui/widgets/segmented_button_layout.h"
 
@@ -64,12 +65,19 @@ bool Q_DECL_UNUSED isDockWidgetRelated(const QWidget* widget)
 MapperProxyStyle::MapperProxyStyle(QStyle* base_style)
  : QProxyStyle(base_style)
 {
-	; // Nothing
+	auto& settings = Settings::getInstance();
+	onSettingsChanged(settings);
+	connect(&settings, &Settings::settingsChanged, this, [this]() {
+		onSettingsChanged(*qobject_cast<Settings*>(sender()));
+	});
 }
 
-MapperProxyStyle::~MapperProxyStyle()
+MapperProxyStyle::~MapperProxyStyle() = default;
+
+
+void MapperProxyStyle::onSettingsChanged(const Settings& settings)
 {
-	; // Nothing, not inlined
+	touch_mode = settings.touchModeEnabled();
 }
 
 void MapperProxyStyle::drawPrimitive(QStyle::PrimitiveElement element, const QStyleOption* option, QPainter* painter, const QWidget* widget) const

--- a/src/gui/widgets/mapper_proxystyle.cpp
+++ b/src/gui/widgets/mapper_proxystyle.cpp
@@ -96,6 +96,18 @@ void MapperProxyStyle::drawPrimitive(QStyle::PrimitiveElement element, const QSt
 			drawSegmentedButton(segment, overridden_element, option, painter, widget);
 			return;
 		}
+		if (touch_mode
+		    && element == PE_PanelButtonTool
+		    && option
+		    && option->state & State_On)
+		{
+			auto const& window_color = option->palette.window().color();
+			auto const fill = QBrush(qGray(window_color.rgb()) > 127 ? window_color.darker(125) : window_color.lighter(125));
+			painter->setPen(Qt::NoPen);
+			painter->setBrush(fill);
+			painter->drawRoundedRect(option->rect, 5.0, 5.0, Qt::AbsoluteSize);
+			return;
+		}
 		break;
 		
 #ifdef Q_OS_ANDROID

--- a/src/gui/widgets/mapper_proxystyle.h
+++ b/src/gui/widgets/mapper_proxystyle.h
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2013, 2016, 2019 Kai Pastor
+ *    Copyright 2013-2020 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -34,6 +34,8 @@ class QStyleOption;
 class QWidget;
 
 namespace OpenOrienteering {
+
+class Settings;
 
 
 /**
@@ -120,6 +122,10 @@ public:
 	
 private:
 	void drawSegmentedButton(int segment, PrimitiveElement element, const QStyleOption* option, QPainter* painter, const QWidget* widget) const;
+	
+	void onSettingsChanged(const Settings& settings);
+	
+	bool touch_mode = false;
 	
 	Q_DISABLE_COPY(MapperProxyStyle)
 };

--- a/src/templates/paint_on_template_tool.cpp
+++ b/src/templates/paint_on_template_tool.cpp
@@ -77,7 +77,6 @@ void PaintOnTemplateTool::init()
 	
 	widget = new PaintOnTemplatePaletteWidget(false);
 	editor->showPopupWidget(widget, tr("Color selection"));
-	connect(editor->getMainWidget(), &QObject::destroyed, widget, [this]() { editor->deletePopupWidget(widget); });
 	connect(widget, &PaintOnTemplatePaletteWidget::colorSelected, this, &PaintOnTemplateTool::colorSelected);
 	connect(widget, &PaintOnTemplatePaletteWidget::undoSelected, this, &PaintOnTemplateTool::undoSelected);
 	connect(widget, &PaintOnTemplatePaletteWidget::redoSelected, this, &PaintOnTemplateTool::redoSelected);

--- a/src/templates/paint_on_template_tool.cpp
+++ b/src/templates/paint_on_template_tool.cpp
@@ -114,7 +114,7 @@ ActionGridBar* PaintOnTemplateTool::makeToolBar()
 			paint_color = color;
 			action->setChecked(true);
 		}
-		connect(action, &QAction::triggered, this, [this, color](bool checked) { if (checked) colorSelected(color); });
+		connect(action, &QAction::triggered, this, [this, color](bool checked) { if (checked) setColor(color); });
 		++count;
 	}
 	
@@ -164,7 +164,7 @@ void PaintOnTemplateTool::setFillAreas(bool enabled)
 }
 
 // slot
-void PaintOnTemplateTool::colorSelected(const QColor& color)
+void PaintOnTemplateTool::setColor(const QColor& color)
 {
 	paint_color = color;
 	

--- a/src/templates/paint_on_template_tool.h
+++ b/src/templates/paint_on_template_tool.h
@@ -27,6 +27,7 @@
 #include <Qt>
 #include <QtGlobal>
 #include <QColor>
+#include <QFlags>
 #include <QObject>
 #include <QPointer>
 #include <QRectF>
@@ -55,6 +56,13 @@ class PaintOnTemplateTool : public MapEditorTool
 {
 Q_OBJECT
 public:
+	enum ErasingOption {
+		NoErasing = 0,
+		ExplicitErasing = 1,
+		RightMouseButtonErasing = 2
+	};
+	Q_DECLARE_FLAGS(ErasingOptions, ErasingOption)
+	
 	PaintOnTemplateTool(MapEditorController* editor, QAction* tool_action);
 	~PaintOnTemplateTool() override;
 	
@@ -86,8 +94,8 @@ protected:
 	ActionGridBar* makeToolBar();
 	
 private:
+	ErasingOptions erasing = {};
 	bool dragging = false;
-	bool erasing  = false;
 	bool fill_areas = false;
 	QColor paint_color = Qt::black;
 	QRectF map_bbox;
@@ -103,5 +111,9 @@ private:
 
 
 }  // namespace OpenOrienteering
+
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(OpenOrienteering::PaintOnTemplateTool::ErasingOptions)
+
 
 #endif

--- a/src/templates/paint_on_template_tool.h
+++ b/src/templates/paint_on_template_tool.h
@@ -30,9 +30,7 @@
 #include <QObject>
 #include <QPointer>
 #include <QRectF>
-#include <QSize>
 #include <QString>
-#include <QWidget>
 
 #include "core/map_coord.h"
 #include "tools/tool.h"
@@ -40,15 +38,13 @@
 class QAction;
 class QCursor;
 class QMouseEvent;
-class QPaintEvent;
 class QPainter;
-class QRect;
 
 namespace OpenOrienteering {
 
+class ActionGridBar;
 class MapEditorController;
 class MapWidget;
-class PaintOnTemplatePaletteWidget;
 class Template;
 
 
@@ -77,67 +73,30 @@ protected:
 	void templateAboutToBeDeleted(int pos, Template* temp);
 	
 public:
+	bool fillAreas() const { return fill_areas; }
+	void setFillAreas(bool enabled);
+	
 	void colorSelected(const QColor& color);
 	void undoSelected();
 	void redoSelected();
+
+protected:
+	ActionGridBar* makeToolBar();
 	
 private:
 	bool dragging = false;
 	bool erasing  = false;
+	bool fill_areas = false;
 	QColor paint_color = Qt::black;
 	QRectF map_bbox;
 	std::vector<MapCoordF> coords;
 	
 	Template* temp = nullptr;
-	QPointer<PaintOnTemplatePaletteWidget> widget;
+	QPointer<ActionGridBar> widget;
 	
 	static int erase_width;
 	
 	Q_DISABLE_COPY(PaintOnTemplateTool)
-};
-
-
-
-/**
- * A color selection widget for PaintOnTemplateTool.
- */
-class PaintOnTemplatePaletteWidget : public QWidget
-{
-Q_OBJECT
-public:
-	PaintOnTemplatePaletteWidget(bool close_on_selection);
-	~PaintOnTemplatePaletteWidget() override;
-
-	QColor getSelectedColor();
-	bool getFillShapes() { return fill_shapes; }
-	
-	QSize sizeHint() const override;
-	
-signals:
-	void colorSelected(const QColor& color);
-	void undoSelected();
-	void redoSelected();
-	
-protected:
-	void paintEvent(QPaintEvent* event) override;
-	void mousePressEvent(QMouseEvent* event) override;
-	void mouseReleaseEvent(QMouseEvent* event) override;
-	
-private:
-	int getNumFieldsX() const;
-	int getNumFieldsY() const;
-	QColor getFieldColor(int x, int y) const;
-	bool isEmptyField(int x, int y) const;
-	bool isFillShapesField(int x, int y) const;
-	bool isUndoField(int x, int y) const;
-	bool isRedoField(int x, int y) const;
-	
-	void drawIcon(QPainter* painter, const QString& resource_path, const QRect& field_rect);
-	
-	Qt::MouseButtons::Int pressed_buttons;
-	int selected_color;
-	bool fill_shapes = false;
-	bool close_on_selection;
 };
 
 

--- a/src/templates/paint_on_template_tool.h
+++ b/src/templates/paint_on_template_tool.h
@@ -76,7 +76,9 @@ public:
 	bool fillAreas() const { return fill_areas; }
 	void setFillAreas(bool enabled);
 	
-	void colorSelected(const QColor& color);
+	const QColor& color() const { return paint_color; }
+	void setColor(const QColor& color);
+	
 	void undoSelected();
 	void redoSelected();
 


### PR DESCRIPTION
Replace the former proprietary `PaintOnTemplatePaletteWidget` by usage of the generic `ActionGridBar` (cf. GH-1673). This change facilitates development of scribbling features.