### PR TITLE
Fix positioning of georeferenced OCD templates, simplified

### DIFF
--- a/src/fileformats/ocd_file_import.cpp
+++ b/src/fileformats/ocd_file_import.cpp
@@ -31,6 +31,7 @@
 #include <type_traits>
 #include <vector>
 
+#include <Qt>
 #include <QtGlobal>
 #include <QtMath>
 #include <QtNumeric>
@@ -74,6 +75,7 @@
 #include "fileformats/ocd_types_v12.h"  // IWYU pragma: keep
 #include "fileformats/ocd_types_v2018.h"
 #include "templates/template.h"
+#include "templates/template_map.h"
 #include "templates/template_placeholder.h"
 #include "util/encoding.h"
 #include "util/util.h"
@@ -902,6 +904,7 @@ void OcdFileImport::importTemplate(const QString& param_string)
 	double scale_y = 1.0;
 	int dimming = 0;
 	bool visible = false;
+	bool explicit_positioning = false;
 	
 	while (i >= 0)
 	{
@@ -916,11 +919,13 @@ void OcdFileImport::importTemplate(const QString& param_string)
 			// empty item
 			break;
 		case 'x':
+			explicit_positioning = true;
 			value = param_value.toDouble(&ok);
 			if (ok)
 				templ->setTemplateX(qRound64(value*1000*scale_factor));
 			break;
 		case 'y':
+			explicit_positioning = true;
 			value = param_value.toDouble(&ok);
 			if (ok)
 				templ->setTemplateY(-qRound64(value*1000*scale_factor));
@@ -928,16 +933,19 @@ void OcdFileImport::importTemplate(const QString& param_string)
 		case 'a':
 		case 'b':
 			// TODO: use the distinct angles correctly, not just the average
+			explicit_positioning = true;
 			rotation += param_value.toDouble(&ok);
 			if (ok)
 				++num_rotation_params;
 			break;
 		case 'u':
+			explicit_positioning = true;
 			value = param_value.toDouble(&ok);
 			if (ok && qAbs(value) >= 0.0000000001)
 				scale_x = value;
 			break;
 		case 'v':
+			explicit_positioning = true;
 			value = param_value.toDouble(&ok);
 			if (ok && qAbs(value) >= 0.0000000001)
 				scale_y = value;
@@ -954,11 +962,20 @@ void OcdFileImport::importTemplate(const QString& param_string)
 		i = next_i;
 	}
 	
-	if (num_rotation_params)
-		templ->setTemplateRotation(Georeferencing::degToRad(rotation / num_rotation_params));
-	
-	templ->setTemplateScaleX(scale_x * scale_factor);
-	templ->setTemplateScaleY(scale_y * scale_factor);
+	if (explicit_positioning)
+	{
+		if (num_rotation_params)
+			templ->setTemplateRotation(Georeferencing::degToRad(rotation / num_rotation_params));
+		
+		templ->setTemplateScaleX(scale_x * scale_factor);
+		templ->setTemplateScaleY(scale_y * scale_factor);
+	}
+	else if (clean_path.endsWith(QLatin1String(".ocd"), Qt::CaseInsensitive))
+	{
+		// OCD templates must use the map's scale and georeferencing.
+		// The transformation must be determined after loading the template.
+		templ->setProperty(TemplateMap::ocdTransformProperty(), true);
+	}
 	
 	auto const template_pos = std::min(0, map->getFirstFrontTemplate() - 1);
 	map->addTemplate(template_pos, std::unique_ptr<Template>{templ});

--- a/src/templates/template_map.cpp
+++ b/src/templates/template_map.cpp
@@ -102,6 +102,15 @@ bool TemplateMap::loadTemplateFileImpl()
 	if (new_template_valid)
 	{
 		template_map = std::move(new_template_map);
+		
+		if (property(ocdTransformProperty()).toBool())
+		{
+			// Update the transformation without signalling dirty state.
+			transform = transformForOcd();
+			updateTransformationMatrices();
+			setTemplateAreaDirty();
+			setProperty(ocdTransformProperty(), false);
+		}
 	}
 	else if (importer)
 	{
@@ -245,6 +254,25 @@ void TemplateMap::calculateTransformation()
 		qDebug("updateTransform() failed");
 		/// \todo proper error message
 	}
+}
+
+
+TemplateTransform TemplateMap::transformForOcd() const
+{
+	auto t = transform;
+	if (templateMap())
+	{
+		auto const template_origin = templateMap()->getGeoreferencing().toProjectedCoords(MapCoordF{});
+		auto const offset = getMap()->getGeoreferencing().toMapCoords(template_origin);
+		t = {offset.nativeX(), offset.nativeY()};
+	}
+	return t;
+}
+
+const char* TemplateMap::ocdTransformProperty()
+{
+	static const char* name = "TemplateMap::transformForOcd";
+	return name;
 }
 
 

--- a/src/templates/template_map.h
+++ b/src/templates/template_map.h
@@ -103,6 +103,27 @@ protected:
 	
 	void calculateTransformation();
 	
+public:
+	/**
+	 * Returns the template transformation for a pure OCD configuration.
+	 * 
+	 * OCD templates in OCD files must use the map's scale and georeferencing.
+	 * Only the template file's grid parameters are taken into account, i.e.
+	 * the template OCD file must be loaded in order to get this transform.
+	 * 
+	 * If template_map is null (i.e. the template is not in loaded state), this
+	 * function returns the current transformation.
+	 */
+	TemplateTransform transformForOcd() const;
+	
+	/**
+	 * The name of the QObject property which activates a pure OCD transformation.
+	 * 
+	 * When this property is set for a TemplateMap, it applies transformForOCD()
+	 * upon first loading of the file, and resets the property after loading.
+	 */
+	static const char* ocdTransformProperty();
+	
 private:
 	std::unique_ptr<Map> template_map;
 	

--- a/src/templates/template_placeholder.cpp
+++ b/src/templates/template_placeholder.cpp
@@ -23,8 +23,10 @@
 #include <utility>
 
 #include <QByteArray>
+#include <QList>
 #include <QRectF>
 #include <QStringRef>
+#include <QVariant>
 #include <QXmlStreamReader>
 #include <QXmlStreamWriter>
 
@@ -117,7 +119,15 @@ std::unique_ptr<Template> TemplatePlaceholder::makeActualTemplate() const
 	}
 	QXmlStreamReader reader(buffer);
 	reader.readNextStartElement();  // <template ...>
-	return Template::loadTemplateConfiguration(reader, *map, maybe_open);
+	
+	auto actual_template = Template::loadTemplateConfiguration(reader, *map, maybe_open);
+	if (actual_template)
+	{
+		auto const property_names = dynamicPropertyNames();
+		for (auto const& name : property_names)
+			actual_template->setProperty(name, property(name));
+	}
+	return actual_template;
 }
 
 bool TemplatePlaceholder::isRasterGraphics() const

--- a/src/templates/template_placeholder.cpp
+++ b/src/templates/template_placeholder.cpp
@@ -28,6 +28,8 @@
 #include <QXmlStreamReader>
 #include <QXmlStreamWriter>
 
+#include <util/util.h>
+
 // IWYU pragma: no_include <qxmlstream.h>
 
 namespace OpenOrienteering {
@@ -125,6 +127,16 @@ bool TemplatePlaceholder::isRasterGraphics() const
 
 void TemplatePlaceholder::drawTemplate(QPainter* /*painter*/, const QRectF& /*clip_rect*/, double /*scale*/, bool /*on_screen*/, qreal /*opacity*/) const
 {}
+
+
+void TemplatePlaceholder::setTemplateAreaDirty()
+{}
+
+QRectF TemplatePlaceholder::getTemplateExtent() const
+{
+	return infiniteRectF();
+}
+
 
 void TemplatePlaceholder::saveTypeSpecificTemplateConfiguration(QXmlStreamWriter& xml) const
 {

--- a/src/templates/template_placeholder.h
+++ b/src/templates/template_placeholder.h
@@ -41,7 +41,7 @@ class Map;
 
 
 /**
- * Placeholder for templates which are not loaded regularly.
+ * Placeholder for templates which are not loaded regularly/immediately.
  */
 class TemplatePlaceholder : public Template
 {
@@ -63,9 +63,18 @@ public:
 	std::unique_ptr<Template> makeActualTemplate() const;
 	
 	
+	/** Always returns true. The placeholder doesn't know the actual property. */
 	bool isRasterGraphics() const override;
 	
-    void drawTemplate(QPainter* painter, const QRectF& clip_rect, double scale, bool on_screen, qreal opacity) const override;
+	/** Does nothing. */
+	void drawTemplate(QPainter* painter, const QRectF& clip_rect, double scale, bool on_screen, qreal opacity) const override;
+	
+	
+	/** Does nothing. */
+	void setTemplateAreaDirty() override;
+	
+	/** As the actual extent is unknown, returns an very large rectangle. */
+	QRectF getTemplateExtent() const override;
 	
 	
 protected:

--- a/src/templates/template_placeholder.h
+++ b/src/templates/template_placeholder.h
@@ -42,6 +42,10 @@ class Map;
 
 /**
  * Placeholder for templates which are not loaded regularly/immediately.
+ * 
+ * This class can be used e.g. by file format implementations to setup template
+ * configuration without binding early to a particular template implementation
+ * class.
  */
 class TemplatePlaceholder : public Template
 {
@@ -60,6 +64,22 @@ public:
 	const char* getTemplateType() const override;
 	
 	
+	/**
+	 * Create the instance of the actual template implementation class.
+	 * 
+	 * This function can be called as soon as the template configuration is
+	 * complete and the template path is validated, so that the contents of
+	 * the template resource can be taken into account for choosing a template
+	 * implementation class.
+	 * 
+	 * In addition to the regular configuration which is passed via XML, this
+	 * function also copies all dynamic `property` values from the placeholder
+	 * QObject to the actual template implementation object. This can be used
+	 * to set additional configuration hints. However, these properties are
+	 * copied only after finishing XML configuration. It is possible to pick
+	 * them up at data loading time, or by watching out for
+	 * QDynamicPropertyChangeEvent.
+	 */
 	std::unique_ptr<Template> makeActualTemplate() const;
 	
 	


### PR DESCRIPTION
A much simpler approach to handling the positioning of georeferenced OCD templates.
Replaces GH-1648.