### PR TITLE
PaintOnTemplateFeature: Use menu instead of dialog

### DIFF
--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -1315,14 +1315,10 @@ void MapEditorController::createMenuAndToolbars()
 	toolbar_drawing->addAction(draw_text_act);
 	toolbar_drawing->addSeparator();
 	
-	auto* paint_on_template_button = new QToolButton();
-	paint_on_template_button->setCheckable(true);
-	paint_on_template_button->setDefaultAction(paint_feature->paintAction());
-	paint_on_template_button->setPopupMode(QToolButton::MenuButtonPopup);
-	auto* paint_on_template_menu = new QMenu(paint_on_template_button);
-	paint_on_template_menu->addAction(paint_feature->selectAction());
-	paint_on_template_button->setMenu(paint_on_template_menu);
-	toolbar_drawing->addWidget(paint_on_template_button);
+	auto* paint_action = paint_feature->paintAction();
+	toolbar_drawing->addAction(paint_action);
+	if (auto* button = qobject_cast<QToolButton*>(toolbar_drawing->widgetForAction(paint_action)))
+		button->setPopupMode(QToolButton::MenuButtonPopup);
 	
 	// Editing toolbar
 	toolbar_editing = window->addToolBar(tr("Editing"));
@@ -1497,12 +1493,11 @@ void MapEditorController::createMobileGUI()
 	
 	bottom_action_bar->addAction(gps_temporary_point_act, 1, col++);
 
-	bottom_action_bar->addAction(paint_feature->paintAction(), 0, col);
-	auto* paint_on_template_button = bottom_action_bar->getButtonForAction(paint_feature->paintAction());
-	auto* mobile_paint_on_template_menu = new QMenu(paint_on_template_button);
-	mobile_paint_on_template_menu->addAction(paint_feature->selectAction());
-	paint_on_template_button->setMenu(mobile_paint_on_template_menu);
-
+	auto* paint_action = paint_feature->paintAction();
+	bottom_action_bar->addAction(paint_action, 0, col);
+	if (auto* button = bottom_action_bar->getButtonForAction(paint_action))
+		button->setPopupMode(QToolButton::DelayedPopup);
+	
 	// Right side
 	bottom_action_bar->addActionAtEnd(mobile_symbol_selector_action, 0, 1, 2, 2);
 	auto* button = bottom_action_bar->getButtonForAction(mobile_symbol_selector_action);

--- a/src/templates/paint_on_template_feature.h
+++ b/src/templates/paint_on_template_feature.h
@@ -25,11 +25,13 @@
 #include <QString>
 
 class QAction;
-class QDialog;
+class QActionGroup;
 class QImage;
-class QListWidget;
+class QMenu;
 class QPointF;
 class QRectF;
+class QToolButton;
+class QWidget;
 
 namespace OpenOrienteering {
 
@@ -84,11 +86,6 @@ public:
 	 */
 	QAction* paintAction() { return paint_action; }
 	
-	/**
-	 * The action which lets the use choose a template, or create a new template.
-	 */
-	QAction* selectAction() { return select_action; }
-	
 	
 protected:
 	/**
@@ -101,31 +98,20 @@ protected:
 	 */
 	void paintClicked(bool checked);
 	
-	/**
-	 * Reacts on triggering the paint action.
-	 */
-	void selectTemplateClicked();
 	
 	/**
-	 * Returns a template selected by the user.
+	 * Creates a menu of actions which start painting on new or existing templates.
 	 * 
-	 * May return nullptr when cancelled, or on error.
+	 * When the given action is null, the menu is initially empty. It gets filled
+	 * or updated when the the action is hovered.
 	 */
-	Template* selectTemplate() const;
-	
-	
-	/**
-	 * Creates the user interface and behaviour of the select-template dialog.
-	 * 
-	 * The selected_template parameter determines where the dialog will store
-	 * the selected template when the user closes the dialog.
-	 */
-	void initTemplateDialog(QDialog& dialog, Template*& selected_template) const;
+	QMenu* makeTemplateMenu(QAction* action, QWidget* parent);
 	
 	/**
-	 * Fills a QListWidget with template options.
+	 * Refreshes the contents of the template menu, based on the current view and template state.
 	 */
-	void initTemplateListWidget(QListWidget& list_widget) const;
+	void refreshTemplateMenu(QMenu* menu, QActionGroup* action_group);
+	
 	
 	/**
 	 * Sets up a new or existing template image, and returns it.
@@ -154,10 +140,14 @@ protected:
 	 */
 	QRectF viewedRect() const;
 	
+	/**
+	 * Returns the first toolbutton associated with the paint action, or nullptr.
+	 */
+	QToolButton* buttonForPaintAction();
+	
 private:
 	MapEditorController& controller;
 	QAction* paint_action = nullptr;      // child of this
-	QAction* select_action = nullptr;     // child of this
 	Template* last_template = nullptr;
 	
 	Q_DISABLE_COPY(PaintOnTemplateFeature)


### PR DESCRIPTION
... for selecting and templates.

(Split from GH-1706. Needs style udpdates for acceptable usability on Android.)

![scribbling-3](https://user-images.githubusercontent.com/13567791/91018206-96e8b900-e5ef-11ea-8893-140f25a96216.png) 
Template selection moved to scribble mode button (press-and-hold). Only templates in the current viewport, relative position indicated as icon.
