### PR TITLE
Follow GNSS position

### DIFF
--- a/src/gui/map/map_editor.h
+++ b/src/gui/map/map_editor.h
@@ -61,6 +61,7 @@ class GPSTemporaryMarkers;
 class GPSTrackRecorder;
 class GeoreferencingDialog;
 class MainWindow;
+class MapCoordF;
 class MapEditorActivity;
 class MapEditorTool;
 class MapFindFeature;
@@ -288,6 +289,10 @@ public slots:
 	void pan();
 	/** Moves view to GPS position. */
 	void moveToGpsPos();
+	/** Activates or stops follow-position mode. */
+	void followPositionClicked(bool enable);
+	/** Follow-position mode update handler. */
+	void followPositionUpdate(OpenOrienteering::MapCoordF position);
 	/** Zooms in in the current map widget. */
 	void zoomIn();
 	/** Zooms out in the current map widget. */
@@ -701,6 +706,7 @@ private:
 	
 	QAction* pan_act;
 	QAction* move_to_gps_pos_act;
+	QAction* follow_position_act;
 	QAction* zoom_in_act;
 	QAction* zoom_out_act;
 	QAction* show_all_act;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,6 +62,10 @@
 using namespace OpenOrienteering;
 
 
+#if defined(MAPPER_USE_FAKE_POSITION_PLUGIN)
+Q_IMPORT_PLUGIN(FakePositionPlugin)
+#endif
+
 #if defined(Q_OS_WIN) && defined(MAPPER_USE_POWERSHELL_POSITION_PLUGIN)
 Q_IMPORT_PLUGIN(PowershellPositionPlugin)
 #endif

--- a/src/sensors/CMakeLists.txt
+++ b/src/sensors/CMakeLists.txt
@@ -28,6 +28,37 @@ endif()
 set(CMAKE_AUTOMOC ON)
 
 
+# FakePositionPlugin
+
+set(FAKE_POSITION_DEFINITIONS
+  PRIVATE
+    QT_NO_CAST_FROM_ASCII
+    QT_NO_CAST_TO_ASCII
+    QT_USE_QSTRINGBUILDER
+    QT_STATICPLUGIN
+)
+set(FAKE_POSITION_SOURCES )
+set(FAKE_POSITION_LINK_LIBRARIES )
+if(TARGET Qt5::Positioning)
+	list(APPEND FAKE_POSITION_DEFINITIONS
+	  PUBLIC MAPPER_USE_FAKE_POSITION_PLUGIN
+	)
+	list(APPEND FAKE_POSITION_SOURCES
+	  fake_position_plugin.cpp
+	  fake_position_plugin.json
+	  fake_position_source.cpp
+	)
+	list(APPEND FAKE_POSITION_LINK_LIBRARIES
+	  PRIVATE Qt5::Gui Qt5::Positioning
+	)
+endif()
+
+add_library(fake_position_source STATIC  ${FAKE_POSITION_SOURCES})
+target_compile_definitions(fake_position_source  ${FAKE_POSITION_DEFINITIONS})
+target_include_directories(fake_position_source  PRIVATE "${PROJECT_SOURCE_DIR}/src")
+target_link_libraries(fake_position_source  ${FAKE_POSITION_LINK_LIBRARIES})
+
+
 # OpenOrienteeringNmeaPlugin
 #
 # For testing purposes, we build this plugin on all platforms,
@@ -139,6 +170,13 @@ foreach(lib Qt5::Positioning Qt5::Sensors Qt5::SerialPort Qt5::AndroidExtras)
 		target_link_libraries(mapper-sensors  PRIVATE ${lib})
 	endif()
 endforeach()
+
+if(Mapper_DEVELOPMENT_BUILD)
+	target_link_libraries(mapper-sensors
+	  PUBLIC
+		fake_position_source
+	)
+endif()
 
 
 # Translations

--- a/src/sensors/fake_position_plugin.cpp
+++ b/src/sensors/fake_position_plugin.cpp
@@ -1,0 +1,51 @@
+/*
+ *    Copyright 2020 Kai Pastor
+ *
+ *    This file is part of OpenOrienteering.
+ *
+ *    OpenOrienteering is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OpenOrienteering is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "fake_position_plugin.h"
+
+#include "fake_position_source.h"
+
+
+namespace OpenOrienteering
+{
+
+FakePositionPlugin::FakePositionPlugin(QObject* parent)
+: QObject(parent)
+{}
+
+FakePositionPlugin::~FakePositionPlugin() = default;
+
+
+QGeoAreaMonitorSource* FakePositionPlugin::areaMonitor(QObject* /* parent */)
+{
+	return nullptr;
+}
+
+QGeoPositionInfoSource* FakePositionPlugin::positionInfoSource(QObject* parent)
+{
+	return new FakePositionSource(parent);
+}
+
+QGeoSatelliteInfoSource* FakePositionPlugin::satelliteInfoSource(QObject* /* parent */)
+{
+	return nullptr;
+}
+
+
+}  // namespace OpenOrienteering

--- a/src/sensors/fake_position_plugin.h
+++ b/src/sensors/fake_position_plugin.h
@@ -1,0 +1,58 @@
+/*
+ *    Copyright 2020 Kai Pastor
+ *
+ *    This file is part of OpenOrienteering.
+ *
+ *    OpenOrienteering is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OpenOrienteering is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPENORIENTEERING_FAKE_POSITION_PLUGIN_H
+#define OPENORIENTEERING_FAKE_POSITION_PLUGIN_H
+
+#include <QGeoPositionInfoSourceFactory>
+#include <QObject>
+#include <QString>
+
+class QGeoAreaMonitorSource;
+class QGeoPositionInfoSource;
+class QGeoSatelliteInfoSource;
+
+namespace OpenOrienteering
+{
+
+/**
+ * A plugin for properly registering FakePositionSource.
+ */
+class FakePositionPlugin : public QObject, public QGeoPositionInfoSourceFactory 
+{
+	Q_OBJECT
+	Q_PLUGIN_METADATA(IID "org.qt-project.qt.position.sourcefactory/5.0"
+	                  FILE "fake_position_plugin.json")
+	Q_INTERFACES(QGeoPositionInfoSourceFactory)
+public:
+	FakePositionPlugin(QObject* parent = nullptr);
+	FakePositionPlugin(const FakePositionPlugin&) = delete;
+	FakePositionPlugin(FakePositionPlugin&&) = delete;
+	FakePositionPlugin& operator=(const FakePositionPlugin&) = delete;
+	FakePositionPlugin&& operator=(FakePositionPlugin&&) = delete;
+	~FakePositionPlugin() override;
+	QGeoAreaMonitorSource* areaMonitor(QObject* parent) override;
+	QGeoPositionInfoSource* positionInfoSource(QObject* parent) override;
+	QGeoSatelliteInfoSource* satelliteInfoSource(QObject* parent) override;
+};
+
+
+}  // namespace OpenOrienteering
+
+#endif  // OPENORIENTEERING_FAKE_POSITION_PLUGIN_H

--- a/src/sensors/fake_position_plugin.json
+++ b/src/sensors/fake_position_plugin.json
@@ -1,0 +1,9 @@
+{
+    "Keys":      ["fake"],
+    "Provider":  "Fake position",
+    "Position":  true,
+    "Satellite": false,
+    "Monitor":   false,
+    "Priority":  900,
+    "Testable":  true
+}

--- a/src/sensors/fake_position_source.cpp
+++ b/src/sensors/fake_position_source.cpp
@@ -1,0 +1,122 @@
+/*
+ *    Copyright 2013 Thomas Schöps
+ *    Copyright 2018-2020 Kai Pastor
+ *
+ *    This file is part of OpenOrienteering.
+ *
+ *    OpenOrienteering is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OpenOrienteering is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifdef QT_POSITIONING_LIB
+
+#include "fake_position_source.h"
+
+#include <algorithm>
+
+#include <QtGlobal>
+#include <QtMath>
+#include <QDateTime>
+#include <QGeoCoordinate>
+#include <QGeoPositionInfo>
+#include <QTime>
+#include <QTimerEvent>
+
+
+namespace OpenOrienteering
+{
+
+QGeoCoordinate FakePositionSource::initial_reference  {};
+
+// static
+void FakePositionSource::setReferencePoint(const QGeoCoordinate &reference)
+{
+	FakePositionSource::initial_reference = reference;
+}
+
+
+FakePositionSource::~FakePositionSource() = default;
+
+FakePositionSource::FakePositionSource(QObject* object)
+: FakePositionSource(initial_reference, object)
+{}
+
+FakePositionSource::FakePositionSource(const QGeoCoordinate& reference, QObject* object)
+: QGeoPositionInfoSource(object)
+, reference(reference)
+{}
+
+
+QGeoPositionInfoSource::Error FakePositionSource::error() const
+{
+	return NoError;
+}
+
+QGeoPositionInfo FakePositionSource::lastKnownPosition(bool /*fromSatellitePositioningMethodsOnly*/) const
+{
+	return info;
+}
+
+int FakePositionSource::minimumUpdateInterval() const
+{
+	return 500;
+}
+
+QGeoPositionInfoSource::PositioningMethods FakePositionSource::supportedPositioningMethods() const
+{
+	return SatellitePositioningMethods;
+}
+
+void FakePositionSource::requestUpdate(int /*timeout*/)
+{
+	const auto now = QDateTime::currentDateTime();
+	const auto offset = now.time().msecsSinceStartOfDay() / qreal(20000);
+	const auto position = QGeoCoordinate {
+	                      reference.latitude() + 0.001 * qSin(offset),
+	                      reference.longitude() + 0.001 * qCos(offset * 1.1),
+	                      reference.altitude() + 10 * qSin(1 + offset / 10) };
+	info = {position, now};
+	info.setAttribute(QGeoPositionInfo::HorizontalAccuracy, 12 + 7 * qSin(2 + offset));
+	emit positionUpdated(info);
+}
+
+void FakePositionSource::startUpdates()
+{
+	if (!timer_id)
+	{
+		timer_id = startTimer(std::max(minimumUpdateInterval(), updateInterval()));
+	}
+}
+
+void FakePositionSource::stopUpdates()
+{
+	if (timer_id)
+	{
+		killTimer(timer_id);
+		timer_id = 0;
+	}
+}
+
+void FakePositionSource::timerEvent(QTimerEvent* e)
+{
+	if (e->timerId() == timer_id)
+	{
+		requestUpdate(0);
+	}
+}
+
+
+}  // namespace OpenOrienteering
+
+
+#endif // QT_POSITIONING_LIB

--- a/src/sensors/fake_position_source.h
+++ b/src/sensors/fake_position_source.h
@@ -1,0 +1,84 @@
+/*
+ *    Copyright 2018-2020 Kai Pastor
+ *
+ *    This file is part of OpenOrienteering.
+ *
+ *    OpenOrienteering is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OpenOrienteering is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#ifndef OPENORIENTEERING_FAKE_POSITION_SOURCE_H
+#define OPENORIENTEERING_FAKE_POSITION_SOURCE_H
+
+#include <QGeoCoordinate>
+#include <QGeoPositionInfo>
+#include <QGeoPositionInfoSource>
+#include <QObject>
+#include <QString>
+
+class QTimerEvent;
+
+namespace OpenOrienteering
+{
+
+
+/**
+ * A position info source that provides fake data.
+ * 
+ * This is a development tool providing fake positions near an initial
+ * reference point.
+ */
+class FakePositionSource : public QGeoPositionInfoSource
+{
+	Q_OBJECT
+	
+public:
+	/**
+	 * Sets an initial reference point for objects constructed without
+	 * explicit reference coordinate parameter.
+	 */
+	static void setReferencePoint(const QGeoCoordinate& reference);
+	
+	~FakePositionSource() override;
+	FakePositionSource(QObject* object);
+	FakePositionSource(const QGeoCoordinate& reference, QObject* object);
+	
+	FakePositionSource(const FakePositionSource&) = delete;
+	FakePositionSource(FakePositionSource&&) = delete;
+	FakePositionSource& operator=(const FakePositionSource&) = delete;
+	FakePositionSource& operator=(FakePositionSource&&) = delete;
+	
+	QGeoPositionInfoSource::Error error() const override;
+	QGeoPositionInfo lastKnownPosition(bool fromSatellitePositioningMethodsOnly) const override;
+	int minimumUpdateInterval() const override;
+	QGeoPositionInfoSource::PositioningMethods supportedPositioningMethods() const override;
+	
+	void requestUpdate(int timeout) override;
+	void startUpdates() override;
+	void stopUpdates() override;
+	
+protected:
+	void timerEvent(QTimerEvent* e) override;
+	
+private:
+	static QGeoCoordinate initial_reference;
+	QGeoCoordinate reference;
+	QGeoPositionInfo info;
+	int timer_id = 0;
+};
+
+
+}  // namespace OpenOrienteering
+
+#endif  // OPENORIENTEERING_FAKE_POSITION_SOURCE_H

--- a/src/sensors/gps_display.cpp
+++ b/src/sensors/gps_display.cpp
@@ -47,9 +47,6 @@ Q_DECLARE_METATYPE(QGeoPositionInfo)  // QTBUG-65937
 #include <QPen>
 #include <QPoint>
 #include <QPointF>
-#if MAPPER_DEVELOPMENT_BUILD
-#  include <QTime>
-#endif
 #include <QTimer>  // IWYU pragma: keep
 #include <QTimerEvent>
 
@@ -62,6 +59,9 @@ Q_DECLARE_METATYPE(QGeoPositionInfo)  // QTBUG-65937
 #include "sensors/compass.h"
 #include "util/backports.h"  // IWYU pragma: keep
 
+#if defined(MAPPER_USE_FAKE_POSITION_PLUGIN)
+#include "sensors/fake_position_source.h"
+#endif
 
 namespace OpenOrienteering {
 
@@ -118,6 +118,13 @@ GPSDisplay::GPSDisplay(MapWidget* widget, const Georeferencing& georeferencing, 
 	Q_UNUSED(register_metatype)
 #endif
 	
+#if defined(MAPPER_USE_FAKE_POSITION_PLUGIN)
+	{
+		auto const ref = georeferencing.getGeographicRefPoint();
+		FakePositionSource::setReferencePoint({ref.latitude(), ref.longitude(), 400});
+	}
+#endif
+	
 	auto const & settings = Settings::getInstance();
 	auto const nmea_serialport = settings.nmeaSerialPort();
 	if (!nmea_serialport.isEmpty())
@@ -145,12 +152,6 @@ GPSDisplay::GPSDisplay(MapWidget* widget, const Georeferencing& georeferencing, 
 	connect(source, &QGeoPositionInfoSource::positionUpdated, this, &GPSDisplay::positionUpdated, Qt::QueuedConnection);
 	connect(source, QOverload<QGeoPositionInfoSource::Error>::of(&QGeoPositionInfoSource::error), this, &GPSDisplay::error);
 	connect(source, &QGeoPositionInfoSource::updateTimeout, this, &GPSDisplay::updateTimeout);
-#elif defined(MAPPER_DEVELOPMENT_BUILD)
-	// DEBUG
-	auto* debug_timer = new QTimer(this);
-	connect(debug_timer, &QTimer::timeout, this, &GPSDisplay::debugPositionUpdate);
-	debug_timer->start(500);
-	visible = true;
 #endif
 
 	widget->setGPSDisplay(this);
@@ -421,39 +422,6 @@ void GPSDisplay::updateTimeout()
 		emit positionUpdatesInterrupted();
 		updateMapWidget();
 	}
-}
-
-void GPSDisplay::debugPositionUpdate()
-{
-#if MAPPER_DEVELOPMENT_BUILD
-	if (!visible)
-		return;
-	
-	QTime now = QTime::currentTime();
-	const auto offset = now.msecsSinceStartOfDay() / qreal(10 * 1000);
-	const auto accuracy = float(12 + 7 * qSin(2 + offset));
-	const auto altitude = 400 + 10 * qSin(1 + offset / 10);
-	
-	const auto coord = MapCoordF(30 * qSin(0.5 * offset), 30 * qCos(0.53 * offset));
-	emit mapPositionUpdated(coord, accuracy);
-	
-	if (georeferencing.isValid() && ! georeferencing.isLocal())
-	{
-		bool ok;
-		LatLon latLon = georeferencing.toGeographicCoords(coord, &ok);
-		if (ok)
-		{
-			emit latLonUpdated(latLon.latitude(), latLon.longitude(), altitude, accuracy);
-		}
-	}
-	
-	gps_updated = true;
-	tracking_lost = false;
-	has_valid_position = true;
-	latest_gps_coord = coord;
-	latest_gps_coord_accuracy = accuracy;
-	updateMapWidget();
-#endif
 }
 
 MapCoordF GPSDisplay::calcLatestGPSCoord(bool& ok)

--- a/src/sensors/gps_display.h
+++ b/src/sensors/gps_display.h
@@ -122,7 +122,6 @@ private slots:
     void positionUpdated(const QGeoPositionInfo& info);
 	void error();
 	void updateTimeout();
-	void debugPositionUpdate();
 	
 private:
 	MapCoordF calcLatestGPSCoord(bool& ok);


### PR DESCRIPTION
This is an (even more) simplifed version of a mode which makes the view follow the GNSS position.
- I prefer to call it "Follow-position mode" instead of "Tourist mode".
- It moves the viewport, but never changes zoom.
- I dropped the icon for now, although its quite nice indeed.

For easier desktop testing, I added a pending rewrite of the dummy position source.