### PR TITLE
PaintOnTemplateTool: Add color setup page to Settings

### DIFF
--- a/code-check-wrapper.sh
+++ b/code-check-wrapper.sh
@@ -49,6 +49,7 @@ PATTERN=
 for I in \
   action_grid_bar.cpp \
   boolean_tool.cpp \
+  color_wheel_widget.cpp \
   combined_symbol.cpp \
   configure_grid_dialog.cpp \
   crs_param_widgets.cpp \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -176,6 +176,7 @@ set(Mapper_Common_SRCS
   gui/widgets/action_grid_bar.cpp
   gui/widgets/color_dropdown.cpp
   gui/widgets/color_list_widget.cpp
+  gui/widgets/color_wheel_widget.cpp
   gui/widgets/compass_display.cpp
   gui/widgets/crs_param_widgets.cpp
   gui/widgets/crs_selector.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -186,6 +186,7 @@ set(Mapper_Common_SRCS
   gui/widgets/key_button_bar.cpp
   gui/widgets/mapper_proxystyle.cpp
   gui/widgets/measure_widget.cpp
+  gui/widgets/paint_on_template_settings_page.cpp
   gui/widgets/pie_menu.cpp
   gui/widgets/segmented_button_layout.cpp
   gui/widgets/settings_page.cpp

--- a/src/gui/settings_dialog.cpp
+++ b/src/gui/settings_dialog.cpp
@@ -55,6 +55,7 @@
 #include "gui/util_gui.h"
 #include "gui/widgets/editor_settings_page.h"
 #include "gui/widgets/general_settings_page.h"
+#include "gui/widgets/paint_on_template_settings_page.h"
 #include "gui/widgets/settings_page.h"
 #include "util/backports.h" // IWYU pragma: keep
 
@@ -221,6 +222,8 @@ void SettingsDialog::addPages()
 #ifdef MAPPER_USE_SENSORS
 	addPage(new SensorsSettingsPage(this));
 #endif
+	if (Settings::getInstance().touchModeEnabled())
+		addPage(new PaintOnTemplateSettingsPage(this));
 }
 
 void SettingsDialog::addPage(SettingsPage* page)

--- a/src/gui/util_gui.cpp
+++ b/src/gui/util_gui.cpp
@@ -50,6 +50,8 @@
 #include <QTextDocument>
 #include <QVariant>
 #include <QWidget>
+#include <QToolButton>
+#include <QIcon>
 
 #include "mapper_config.h"
 #include "settings.h"
@@ -378,7 +380,26 @@ namespace Util {
 		return maybe_markup;
 	}
 
-	
+
+	namespace ToolButton
+	{
+		/**
+		 * Returns a new QToolButton with a unified appearance.
+		 */
+		QToolButton* create(const QIcon& icon, const QString& text, const char* whats_this)
+		{
+			auto* button = new QToolButton();
+			button->setToolButtonStyle(Qt::ToolButtonIconOnly);
+			button->setToolTip(text);
+			button->setIcon(icon);
+			button->setText(text);
+			if (whats_this)
+				button->setWhatsThis(OpenOrienteering::Util::makeWhatThis(whats_this));
+			return button;
+		}
+	}  // namespace ToolButton
+
+
 }  // namespace Util
 
 

--- a/src/gui/util_gui.h
+++ b/src/gui/util_gui.h
@@ -28,13 +28,16 @@
 
 class QCheckBox;
 class QDoubleSpinBox;
+class QIcon;
 class QLabel;
 class QObject;
 class QPainter;
 class QPointF;
 class QSpacerItem;
 class QSpinBox;
+class QToolButton;
 class QWidget;
+
 
 namespace OpenOrienteering {
 
@@ -377,6 +380,13 @@ namespace Util
 	 */
 	QString plainText(QString maybe_markup);
 	
+	
+	namespace ToolButton
+	{
+		QToolButton* create(const QIcon& icon, const QString& text, const char* whats_this = nullptr);
+	}  // namespace ToolButton
+
+
 }
 
 

--- a/src/gui/widgets/color_list_widget.cpp
+++ b/src/gui/widgets/color_list_widget.cpp
@@ -64,14 +64,23 @@
 
 namespace OpenOrienteering {
 
+namespace {
+
+/// Local wrapper for Util::ToolButton::create() adding the What's This bit.
+QToolButton* createToolButton(const QIcon& icon, const QString& text)
+{
+	return Util::ToolButton::create(icon, text, "color_dock_widget.html");
+}
+
+}  // anonymous namespace
+
+
 ColorListWidget::ColorListWidget(Map* map, MainWindow* window, QWidget* parent)
 : QWidget(parent)
 , map(map)
 , window(window)
 {
 	react_to_changes = true;
-	
-	setWhatsThis(Util::makeWhatThis("color_dock_widget.html"));
 	
 	// Color table
 	color_table = new QTableWidget(map->getNumColors(), 7);
@@ -91,18 +100,18 @@ ColorListWidget::ColorListWidget(Map* map, MainWindow* window, QWidget* parent)
 	duplicate_action->setIcon(QIcon(QString::fromLatin1(":/images/tool-duplicate.png")));
 	
 	// Buttons
-	auto new_button = newToolButton(QIcon(QString::fromLatin1(":/images/plus.png")), tr("New"));
+	auto new_button = createToolButton(QIcon(QString::fromLatin1(":/images/plus.png")), tr("New"));
 	new_button->setPopupMode(QToolButton::DelayedPopup); // or MenuButtonPopup
 	new_button->setMenu(new_button_menu);
-	delete_button = newToolButton(QIcon(QString::fromLatin1(":/images/minus.png")), tr("Delete"));
+	delete_button = createToolButton(QIcon(QString::fromLatin1(":/images/minus.png")), tr("Delete"));
 	
 	auto add_remove_layout = new SegmentedButtonLayout();
 	add_remove_layout->addWidget(new_button);
 	add_remove_layout->addWidget(delete_button);
 	
-	move_up_button = newToolButton(QIcon(QString::fromLatin1(":/images/arrow-up.png")), tr("Move Up"));
+	move_up_button = createToolButton(QIcon(QString::fromLatin1(":/images/arrow-up.png")), tr("Move Up"));
 	move_up_button->setAutoRepeat(true);
-	move_down_button = newToolButton(QIcon(QString::fromLatin1(":/images/arrow-down.png")), tr("Move Down"));
+	move_down_button = createToolButton(QIcon(QString::fromLatin1(":/images/arrow-down.png")), tr("Move Down"));
 	move_down_button->setAutoRepeat(true);
 	
 	auto up_down_layout = new SegmentedButtonLayout();
@@ -110,10 +119,10 @@ ColorListWidget::ColorListWidget(Map* map, MainWindow* window, QWidget* parent)
 	up_down_layout->addWidget(move_down_button);
 	
 	// TODO: In Mapper >= 0.6, switch to ColorWidget (or generic) translation context.
-	edit_button = newToolButton(QIcon(QString::fromLatin1(":/images/settings.png")), QApplication::translate("OpenOrienteering::MapEditorController", "&Edit").remove(QLatin1Char('&')));
+	edit_button = createToolButton(QIcon(QString::fromLatin1(":/images/settings.png")), QApplication::translate("OpenOrienteering::MapEditorController", "&Edit").remove(QLatin1Char('&')));
 	edit_button->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
 	
-	auto help_button = newToolButton(QIcon(QString::fromLatin1(":/images/help.png")), tr("Help"));
+	auto help_button = createToolButton(QIcon(QString::fromLatin1(":/images/help.png")), tr("Help"));
 	help_button->setAutoRaise(true);
 	
 	// The buttons row layout
@@ -195,18 +204,6 @@ void ColorListWidget::showEvent(QShowEvent* event)
 	}
 }
 
-
-
-QToolButton* ColorListWidget::newToolButton(const QIcon& icon, const QString& text)
-{
-	auto button = new QToolButton();
-	button->setToolButtonStyle(Qt::ToolButtonIconOnly);
-	button->setToolTip(text);
-	button->setIcon(icon);
-	button->setText(text);
-	button->setWhatsThis(whatsThis());
-	return button;
-}
 
 void ColorListWidget::newColor()
 {

--- a/src/gui/widgets/color_list_widget.h
+++ b/src/gui/widgets/color_list_widget.h
@@ -73,8 +73,6 @@ protected slots:
 protected:
 	void showEvent(QShowEvent* event) override;
 	
-	QToolButton* newToolButton(const QIcon& icon, const QString& text);
-	
 private:
 	void addRow(int row);
 	void updateRow(int row);

--- a/src/gui/widgets/color_wheel_widget.cpp
+++ b/src/gui/widgets/color_wheel_widget.cpp
@@ -1,0 +1,436 @@
+/*
+ *    Copyright (C) 2013-2020 Mattia Basaglia
+ *    Copyright 2021 Libor Pecháček
+ *
+ *    This file is part of OpenOrienteering.
+ *
+ *    OpenOrienteering is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OpenOrienteering is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "color_wheel_widget.h"
+
+#include <QAbstractButton>
+#include <QBrush>
+#include <QConicalGradient>
+#include <QFlags>
+#include <QGradientStops>
+#include <QHBoxLayout>
+#include <QLineEdit>
+#include <QLineF>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QPainterPath>
+#include <QPalette>
+#include <QPen>
+#include <QPoint>
+#include <QPolygonF>
+#include <QPushButton>
+#include <QRect>
+#include <QRectF>
+#include <QRgb>
+#include <QSizeF>
+#include <QSizePolicy>
+#include <QString>
+#include <QVBoxLayout>
+#include <QVector>
+#include <QtGlobal>
+#include <QtMath>
+
+class QPaintEvent;
+class QResizeEvent;
+
+
+namespace OpenOrienteering {
+
+
+ColorWheel::ColorWheel(QWidget* parent)
+    : QWidget(parent)
+{
+	background_is_dark = palette().window().color().valueF() < 0.5;
+}
+
+
+ColorWheel::~ColorWheel() = default;
+
+
+// Get the user selected color
+QColor ColorWheel::color() const
+{
+	return QColor::fromHsvF(hue, sat, val);
+}
+
+
+// Set the widget selection color
+void ColorWheel::setColor(QColor c)
+{
+	auto oldh = hue;
+	// render red triangle for achromatic colors
+	hue = c.hsvHueF() >= 0 ? c.hsvHueF() : 0;
+	sat = c.hsvSaturationF();
+	val = c.valueF();
+
+	if (!qFuzzyCompare(oldh + 1, hue + 1))
+		renderValSatTriangle();
+	
+	update();
+	emit colorChanged(c);
+}
+
+
+void ColorWheel::paintEvent(QPaintEvent* event)
+{
+	Q_UNUSED(event)
+
+	QPainter painter(this);
+	painter.setRenderHint(QPainter::Antialiasing);
+	painter.translate(geometry().width() / 2, geometry().height() / 2);
+
+	// hue wheel
+	if (hue_ring.isNull())
+		renderHueRing();
+
+	painter.drawPixmap(-outerRadius(), -outerRadius(), hue_ring);
+
+	// hue selector
+	drawRingEditor(hue, painter, Qt::black);
+
+	// lum-sat triangle
+	if (inner_selector.isNull())
+		renderValSatTriangle();
+
+	qreal side = triangleSide();
+	qreal height = triangleHeight();
+
+	painter.rotate(selectorImageAngle());
+	painter.translate(selectorImageOffset());
+
+	qreal slice_h = side * val;
+	qreal ymin = side / 2 - slice_h / 2;
+
+	// clip with the triangular shape
+	auto clip = QPainterPath();
+	clip.addPolygon(QPolygonF(QVector<QPointF> { {0, side / 2},
+	                                             {height, 0},
+	                                             {height, side} }));
+	painter.setClipPath(clip);
+
+	painter.drawImage(QRectF(QPointF(0, 0), QPointF(height, side)),
+	                  inner_selector);
+	painter.setClipping(false);
+
+	// lum-sat selector
+	// we define the color of the selecto based on the background color of the
+	// widget in order to improve to contrast
+
+	auto const selector_position = QPointF(val * height, ymin + sat * slice_h);
+	auto const selector_ring_color = (background_is_dark && (val < 0.65 || sat > 0.43))
+	                           || val <= 0.5 ? Qt::white : Qt::black;
+	painter.setPen(QPen(selector_ring_color, 3));
+	painter.setBrush(Qt::NoBrush);
+	painter.drawEllipse(selector_position, selector_radius, selector_radius);
+}
+
+
+void ColorWheel::mouseMoveEvent(QMouseEvent* event)
+{
+	if (mouse_status == DragCircle)
+	{
+		hue = lineToPoint(event->pos()).angle() / 360.0;
+		renderValSatTriangle();
+	}
+	else if (mouse_status == DragInside)
+	{
+		QLineF glob_mouse_ln = lineToPoint(event->pos());
+		QLineF center_mouse_ln(QPointF(0, 0),
+		                       glob_mouse_ln.p2() - glob_mouse_ln.p1());
+
+		center_mouse_ln.setAngle(center_mouse_ln.angle() + selectorImageAngle());
+		center_mouse_ln.setP2(center_mouse_ln.p2() - selectorImageOffset());
+
+		QPointF pt = center_mouse_ln.p2();
+
+		qreal side = triangleSide();
+		val = qBound(0.0, pt.x() / triangleHeight(), 1.0);
+		qreal slice_h = side * val;
+
+		qreal ycenter = side / 2;
+		qreal ymin = ycenter - slice_h / 2;
+
+		if (slice_h > 0) sat = qBound(0.0, (pt.y() - ymin) / slice_h, 1.0);
+	}
+	else
+	{
+		return;
+	}
+
+	emit colorSelected(color());
+	emit colorChanged(color());
+	update();
+}
+
+void ColorWheel::mousePressEvent(QMouseEvent* event)
+{
+	if (event->buttons() & Qt::LeftButton)
+	{
+		setFocus();
+		QLineF ray = lineToPoint(event->pos());
+		if (ray.length() <= innerRadius())
+			mouse_status = DragInside;
+		else if (ray.length() <= outerRadius())
+			mouse_status = DragCircle;
+
+		// Update the color
+		mouseMoveEvent(event);
+	}
+}
+
+void ColorWheel::mouseReleaseEvent(QMouseEvent* event)
+{
+	mouseMoveEvent(event);
+	mouse_status = Nothing;
+	if (event->button() == Qt::LeftButton) emit editingFinished();
+}
+
+
+void ColorWheel::resizeEvent(QResizeEvent* event)
+{
+	Q_UNUSED(event)
+
+	wheel_width = qMax(outerRadius() * 0.08, 10.0);
+
+	renderHueRing();
+	renderValSatTriangle();
+}
+
+
+/// Update the outer ring that displays the hue selector
+void ColorWheel::renderHueRing()
+{
+	hue_ring = QPixmap(outerRadius() * 2, outerRadius() * 2);
+	hue_ring.fill(Qt::transparent);
+	QPainter painter(&hue_ring);
+	painter.setRenderHint(QPainter::Antialiasing);
+	painter.setCompositionMode(QPainter::CompositionMode_Source);
+
+	const int hue_stops = 24;
+	QConicalGradient gradient_hue(0, 0, 0);
+	if (gradient_hue.stops().size() < hue_stops)
+	{
+		for (auto counter = 0U; counter < hue_stops; ++counter)
+		{
+			auto a = double(counter) / (hue_stops - 1);
+			gradient_hue.setColorAt(a, QColor::fromHsvF(a, 1, 1));
+		}
+	}
+
+	painter.translate(outerRadius(), outerRadius());
+
+	painter.setPen(Qt::NoPen);
+	painter.setBrush(QBrush(gradient_hue));
+	painter.drawEllipse(QPointF(0, 0), outerRadius(), outerRadius());
+
+	painter.setBrush(Qt::transparent);
+	painter.drawEllipse(QPointF(0, 0), innerRadius(), innerRadius());
+}
+
+/**
+ * \brief renders the selector as a triangle
+ * \note It's the same as a square with the edge with value=0 collapsed to a
+ * single point
+ */
+void ColorWheel::renderValSatTriangle()
+{
+	auto size = QSizeF(triangleHeight(), triangleSide()); // selector size
+	auto max_size = 128;
+
+	if (size.height() > max_size) size *= max_size / size.height();
+
+	qreal ycenter = size.height() / 2;
+
+	QSize isize = size.toSize();
+	inner_selector = QImage(isize, QImage::Format_RGB32);
+
+	for (int x = 0; x < isize.width(); x++)
+	{
+		qreal pval = x / size.height();
+		qreal slice_h = size.height() * pval;
+		for (int y = 0; y < isize.height(); y++)
+		{
+			qreal ymin = ycenter - slice_h / 2;
+			qreal psat = qBound(0.0, (y - ymin) / slice_h, 1.0);
+			auto color = QColor::fromHsvF(hue, psat, pval);
+			inner_selector.setPixel(x, y, color.rgb());
+		}
+	}
+}
+
+
+/// Calculate outer wheel radius from widget center
+qreal ColorWheel::outerRadius() const
+{
+	auto radius = qMin(geometry().width(), geometry().height()) / 2;
+	return radius;
+}
+
+
+/// Calculate inner wheel radius from widget center
+qreal ColorWheel::innerRadius() const
+{
+	return outerRadius() - wheel_width;
+}
+
+
+/// Draw the outer color wheel marker
+void ColorWheel::drawRingEditor(double editor_hue, QPainter& painter,
+                                  QColor color)
+{
+	painter.setPen(QPen(color, 3));
+	painter.setBrush(Qt::NoBrush);
+	QLineF ray(0, 0, outerRadius(), 0);
+	ray.setAngle(editor_hue * 360);
+	QPointF h1 = ray.p2();
+	ray.setLength(innerRadius());
+	QPointF h2 = ray.p2();
+	painter.drawLine(h1, h2);
+}
+
+/// Construct line from the center to a given point
+QLineF ColorWheel::lineToPoint(const QPoint& p) const
+{
+	return QLineF(geometry().width() / 2, geometry().height() / 2,
+	              p.x(), p.y());
+}
+
+/// Rotation of the selector image
+qreal ColorWheel::selectorImageAngle() const
+{
+	return -hue * 360 - 60;
+}
+
+/// Offset of the selector image
+QPointF ColorWheel::selectorImageOffset()
+{
+	return QPointF(-innerRadius(), -triangleSide() / 2);
+}
+
+/// Calculate the side of the inner triangle
+qreal ColorWheel::triangleSide() const
+{
+	return innerRadius() * qSqrt(3);
+}
+
+/// Calculate the height of the inner triangle
+qreal ColorWheel::triangleHeight() const
+{
+	return innerRadius() * 3 / 2;
+}
+
+
+ColorPreview::ColorPreview(QWidget* parent)
+    : QFrame(parent)
+{
+	setFrameStyle(QFrame::Panel | QFrame::Plain);
+	setLineWidth(2);
+}
+
+
+/// Get widget face color
+QColor ColorPreview::color()
+{
+	return display_color;
+}
+
+
+/// Set widget face color
+void ColorPreview::setColor(QColor c)
+{
+	display_color = c;
+	update();
+}
+
+
+void ColorPreview::paintEvent(QPaintEvent* event)
+{
+	QFrame::paintEvent(event);
+
+	QPainter painter(this);
+	painter.fillRect(contentsRect(), QBrush(display_color));
+}
+
+
+QSize ColorPreview::sizeHint() const
+{
+	return QSize(24, 24);
+}
+
+
+ColorWheelDialog::ColorWheelDialog(QWidget* parent, Qt::WindowFlags f)
+    : QDialog(parent, f)
+{
+	auto* main_layout = new QVBoxLayout();
+	wheel = new ColorWheel();
+	main_layout->addWidget(wheel);
+	auto* mid_layout = new QHBoxLayout();
+	auto* color_preview = new ColorPreview();
+	color_preview->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
+	mid_layout->addWidget(color_preview);
+	text_edit = new QLineEdit();
+	text_edit->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
+	mid_layout->addWidget(text_edit);
+	main_layout->addLayout(mid_layout);
+	auto* ok_button = new QPushButton(tr("Select"));
+	ok_button->setDefault(true);
+	main_layout->addWidget(ok_button);
+	setLayout(main_layout);
+
+	connect(wheel, &ColorWheel::colorSelected, this, [this](QColor c) {
+		text_edit->setText(c.name().right(6).toUpper());
+	});
+	connect(text_edit, &QLineEdit::textEdited, this,
+	        [this](const QString& text) {
+		        const auto c = QRgb(text.toUInt(nullptr, 16));
+				wheel->setColor(c);
+	        });
+	connect(wheel, &ColorWheel::colorChanged, color_preview,
+	        &ColorPreview::setColor);
+	connect(ok_button, &QPushButton::clicked, this, &ColorWheelDialog::accept);
+}
+
+
+QColor ColorWheelDialog::currentColor() const
+{
+	return result() == QDialog::Accepted ? wheel->color() : QColor();
+}
+
+
+void ColorWheelDialog::setCurrentColor(const QColor& c)
+{
+	wheel->setColor(c);
+	text_edit->setText(c.name().right(6).toUpper());
+	// color preview receives the update from the color wheel
+}
+
+
+QColor ColorWheelDialog::getColor(const QColor& initial, QWidget* parent)
+{
+	ColorWheelDialog dlg(parent);
+	dlg.setCurrentColor(initial);
+	dlg.setWindowState((dlg.windowState() & ~(Qt::WindowMinimized | Qt::WindowFullScreen)) 
+	               | Qt::WindowMaximized);
+	dlg.exec();
+	return dlg.currentColor();
+}
+
+
+} //  namespace OpenOrienteering

--- a/src/gui/widgets/color_wheel_widget.h
+++ b/src/gui/widgets/color_wheel_widget.h
@@ -1,0 +1,173 @@
+/*
+ *    Copyright (C) 2013-2020 Mattia Basaglia
+ *    Copyright 2021 Libor Pecháček
+ *
+ *    This file is part of OpenOrienteering.
+ *
+ *    OpenOrienteering is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OpenOrienteering is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPENORIENTEERING_COLOR_WHEEL_WIDGET_H
+#define OPENORIENTEERING_COLOR_WHEEL_WIDGET_H
+
+#include <QColor>
+#include <QDialog>
+#include <QFrame>
+#include <QImage>
+#include <QLineF>
+#include <QObject>
+#include <QPixmap>
+#include <QPointF>
+#include <QSize>
+#include <QString>
+#include <QWidget>
+#include <Qt>
+#include <QtGlobal>
+
+class QLineEdit;
+class QLineF;
+class QMouseEvent;
+class QPaintEvent;
+class QPainter;
+class QPoint;
+class QPointF;
+class QResizeEvent;
+
+namespace OpenOrienteering {
+
+
+/**
+ * \brief Display an analog widget that allows the selection of a HSV color
+ *
+ * It has an outer wheel to select the Hue and an intenal square to select
+ * Saturation and Lightness.
+ */
+class ColorWheel : public QWidget
+{
+	Q_OBJECT
+public:
+	explicit ColorWheel(QWidget* parent = 0);
+	~ColorWheel();
+
+	/// Get current color
+	QColor color() const;
+
+public slots:
+
+	/// Set current color
+	void setColor(QColor c);
+
+signals:
+	/**
+	 * Emitted when the user selects a color or setColor is called
+	 */
+	void colorChanged(QColor);
+
+	/**
+	 * Emitted when the user selects a color
+	 */
+	void colorSelected(QColor);
+
+	/**
+	 * Emitted when the user releases from dragging
+	 */
+	void editingFinished();
+
+protected:
+	enum MouseStatus
+	{
+		Nothing,
+		DragCircle,
+		DragInside
+	};
+
+	qreal hue = {};
+	qreal sat = {};
+	qreal val = {};
+	MouseStatus mouse_status = Nothing;
+	bool background_is_dark = {};
+
+	unsigned int wheel_width = 20;
+	static constexpr qreal selector_radius = 6;
+
+	QPixmap hue_ring;
+	QImage inner_selector;
+
+	void paintEvent(QPaintEvent*event) override;
+	void mouseMoveEvent(QMouseEvent*event) override;
+	void mousePressEvent(QMouseEvent*event) override;
+	void mouseReleaseEvent(QMouseEvent*event) override;
+	void resizeEvent(QResizeEvent*event) override;
+
+	void renderHueRing();
+	void renderValSatTriangle();
+	qreal outerRadius() const;
+	void drawRingEditor(double editor_hue, QPainter& painter, QColor color);
+	qreal innerRadius() const;
+	QLineF lineToPoint(const QPoint& p) const;
+	qreal selectorImageAngle() const;
+	QPointF selectorImageOffset();
+	qreal triangleSide() const;
+	qreal triangleHeight() const;
+};
+
+
+/**
+ * \brief A helper widget that displays chosen color on its face.
+ *
+ * Intended as a color preview area in ColorWheelDialog.
+ */
+class ColorPreview : public QFrame
+{
+	Q_OBJECT
+
+public:
+	ColorPreview(QWidget* parent = nullptr);
+	virtual void paintEvent(QPaintEvent* event) override;
+	virtual QSize sizeHint() const override;
+	QColor color();
+
+public slots:
+	void setColor(QColor c);
+
+private:
+	QColor display_color;
+};
+
+
+/**
+ * \brief A minimalistic color selection dialog intended for on mobile devices.
+ *
+ * It offers a color wheel, color preview in a rectangle and input field for
+ * a direct text entry. The programming interface tries to mimic QColorDialog.
+ */
+class ColorWheelDialog : public QDialog
+{
+	Q_OBJECT
+public:
+	ColorWheelDialog(QWidget* parent = nullptr,
+	                 Qt::WindowFlags f = Qt::WindowFlags());
+	QColor currentColor() const;
+	void setCurrentColor(const QColor& c);
+	static QColor getColor(const QColor& initial, QWidget* parent = nullptr);
+
+private:
+	ColorWheel* wheel = {};
+	QLineEdit* text_edit = {};
+};
+
+
+} //  namespace OpenOrienteering
+
+#endif

--- a/src/gui/widgets/paint_on_template_settings_page.cpp
+++ b/src/gui/widgets/paint_on_template_settings_page.cpp
@@ -24,7 +24,9 @@
 
 #include <QAbstractButton>
 #include <QAbstractItemView>
+#include <QApplication>
 #include <QBrush>
+#include <QClipboard>
 #include <QColor>
 #include <QColorDialog>  // IWYU pragma: keep
 #include <QFlags>
@@ -185,11 +187,28 @@ PaintOnTemplateSettingsPage::PaintOnTemplateSettingsPage(QWidget* parent)
 
 	auto* apply_preset_button = new QPushButton(tr("Activate preset"), presets_box);
 	presets_layout->addWidget(apply_preset_button, row, 0, 1, 1);
+	auto* c_p_buttons_layout = new QHBoxLayout();
+	c_p_buttons_layout->addItem(new QSpacerItem(0, 0, QSizePolicy::Expanding, QSizePolicy::Minimum));
+	auto* copy_preset_button = new QPushButton(tr("Copy"), presets_box);
+	c_p_buttons_layout->addWidget(copy_preset_button);
+	auto* paste_preset_button = new QPushButton(tr("Paste"), presets_box);
+	c_p_buttons_layout->addWidget(paste_preset_button);
+	presets_layout->addItem(c_p_buttons_layout, row, 2, 1, 1);
+
 	layout->addWidget(presets_box);
 
 	connect(move_up_button, &QAbstractButton::clicked, this, &PaintOnTemplateSettingsPage::moveColorUp);
 	connect(move_down_button, &QAbstractButton::clicked, this, &PaintOnTemplateSettingsPage::moveColorDown);
 
+	connect(copy_preset_button, &QPushButton::clicked,
+	        this, [this]() {
+		QApplication::clipboard()->setText(custom_string_edit->text());
+	} );
+	connect(paste_preset_button, &QPushButton::clicked,
+	        this, [this]() { 
+		custom_string_edit->setText(QApplication::clipboard()->text());
+		preset_buttons.back()->setChecked(true);
+	} );
 	connect(apply_preset_button, &QPushButton::clicked,
 	        this, &PaintOnTemplateSettingsPage::applyPresets);
 	connect(custom_string_edit, &QLineEdit::textEdited,

--- a/src/gui/widgets/paint_on_template_settings_page.cpp
+++ b/src/gui/widgets/paint_on_template_settings_page.cpp
@@ -1,0 +1,364 @@
+/*
+ *    Copyright 2021 Libor Pecháček
+ *
+ *    This file is part of OpenOrienteering.
+ *
+ *    OpenOrienteering is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OpenOrienteering is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "paint_on_template_settings_page.h"
+
+#include <array>
+#include <vector>
+
+#include <QAbstractButton>
+#include <QAbstractItemView>
+#include <QBrush>
+#include <QColor>
+#include <QColorDialog>  // IWYU pragma: keep
+#include <QFlags>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QIcon>
+#include <QLatin1Char>
+#include <QLatin1String>
+#include <QLineEdit>
+#include <QList>
+#include <QPushButton>
+#include <QRadioButton>
+#include <QSizePolicy>
+#include <QSpacerItem>
+#include <QString>
+#include <QTableWidget>
+#include <QTableWidgetItem>
+#include <QToolButton>
+#include <QVBoxLayout>
+#include <Qt>
+#include <QtGlobal>
+
+#include "gui/map/map_editor.h"
+#include "gui/util_gui.h"
+#include "gui/widgets/color_wheel_widget.h"  // IWYU pragma: keep
+#include "gui/widgets/segmented_button_layout.h"
+#include "gui/widgets/settings_page.h"
+#include "settings.h"
+
+class QWidget;
+
+
+namespace OpenOrienteering {
+
+namespace {
+
+struct ColorPresetEntry {
+	const char* name;
+	const char* color_string;
+};
+
+
+constexpr std::array<ColorPresetEntry, 2> color_presets = {
+    //: Paint on template color preset entry name.
+    ColorPresetEntry {
+        QT_TRANSLATE_NOOP("OpenOrienteering::PaintOnTemplateSettingsPage", "Traditional"),
+        "FF0000,FFFF00,00FF00,DB00D8,0000FF,D15C00,000000"
+    },
+    //: Paint on template color preset entry name.
+    ColorPresetEntry {
+        QT_TRANSLATE_NOOP("OpenOrienteering::PaintOnTemplateSettingsPage", "Revised 2020"),
+        "A9AA7E,A5FFE5,E1FEA1,FE0000,00A400,0000FE,D15C00"
+    },
+};
+
+
+void fillTableRow(QTableWidget * table, int row, QColor color)
+{
+	auto* text_cell = new QTableWidgetItem(color.name().right(6).toUpper());
+	text_cell->setFlags(text_cell->flags() ^ Qt::ItemIsEditable);
+	table->setItem(row, 0, text_cell);
+
+	auto* color_cell = new QTableWidgetItem();
+	color_cell->setFlags(color_cell->flags() ^ Qt::ItemIsEditable);
+	color_cell->setBackground(QBrush(color));
+	table->setItem(row, 1, color_cell);
+}
+
+
+QColor spawnColorDialog(const QColor &initial = Qt::white, QWidget *parent = nullptr)
+{
+#ifdef Q_OS_ANDROID
+	        return ColorWheelDialog::getColor(initial, parent);
+#else
+	        return QColorDialog::getColor(initial, parent);
+#endif
+}
+
+}  // anonymous namespace
+
+
+PaintOnTemplateSettingsPage::PaintOnTemplateSettingsPage(QWidget* parent)
+    : SettingsPage(parent)
+{
+	auto* layout = new QVBoxLayout(this);
+
+	color_table = new QTableWidget(0, 2);
+	color_table->verticalHeader()->hide();
+	auto* header_view = color_table->horizontalHeader();
+	header_view->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+	header_view->setSectionResizeMode(1, QHeaderView::Stretch);
+	header_view->setVisible(false);
+	color_table->setSelectionMode(QAbstractItemView::SingleSelection);
+	layout->addWidget(color_table);
+
+	auto* add_button = Util::ToolButton::create(QIcon(QString::fromLatin1(":/images/plus.png")), tr("Add color..."));
+	delete_button = Util::ToolButton::create(QIcon(QString::fromLatin1(":/images/minus.png")), tr("Remove"));
+	delete_button->setEnabled(false);
+
+	auto* add_remove_layout = new SegmentedButtonLayout();
+	add_remove_layout->addWidget(add_button);
+	add_remove_layout->addWidget(delete_button);
+
+	move_up_button = Util::ToolButton::create(QIcon(QString::fromLatin1(":/images/arrow-up.png")), tr("Move Up"));
+	move_up_button->setAutoRepeat(true);
+	move_up_button->setEnabled(false);
+	move_down_button = Util::ToolButton::create(QIcon(QString::fromLatin1(":/images/arrow-down.png")), tr("Move Down"));
+	move_down_button->setAutoRepeat(true);
+	move_down_button->setEnabled(false);
+
+	auto* up_down_layout = new SegmentedButtonLayout();
+	up_down_layout->addWidget(move_up_button);
+	up_down_layout->addWidget(move_down_button);
+
+	edit_button = Util::ToolButton::create(QIcon(QString::fromLatin1(":/images/settings.png")),
+	                            ::OpenOrienteering::MapEditorController::tr("&Edit").remove(QLatin1Char('&')));
+	edit_button->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
+	edit_button->setEnabled(false);
+
+	auto* list_buttons_layout = new QHBoxLayout();
+	list_buttons_layout->setContentsMargins(0,0,0,0);
+	list_buttons_layout->addLayout(add_remove_layout);
+	list_buttons_layout->addLayout(up_down_layout);
+	list_buttons_layout->addWidget(edit_button);
+	list_buttons_layout->addSpacerItem(new QSpacerItem(0, 0, QSizePolicy::Expanding));
+	layout->addLayout(list_buttons_layout);
+
+	connect(add_button, &QAbstractButton::clicked, this, &PaintOnTemplateSettingsPage::addColor);
+	connect(color_table, &QTableWidget::itemSelectionChanged, this, [this]() {
+		auto const enabled = !color_table->selectedItems().empty();
+		delete_button->setEnabled(enabled);
+		edit_button->setEnabled(enabled);
+		move_up_button->setEnabled(enabled);
+		move_down_button->setEnabled(enabled);
+	});
+	connect(edit_button, &QAbstractButton::clicked, this, &PaintOnTemplateSettingsPage::editColor);
+	connect(delete_button, &QAbstractButton::clicked, this, &PaintOnTemplateSettingsPage::dropColor);
+
+	auto* presets_box = new QGroupBox(tr("Available palette presets"), this);
+	auto* presets_layout = new QGridLayout(presets_box);
+
+	auto row = 0U;
+	preset_buttons.reserve(color_presets.size() + 1);
+	for (const auto& entry : color_presets)
+	{
+		auto* preset_button = new QRadioButton(tr(entry.name), presets_box);
+		preset_buttons.emplace_back(preset_button);
+		presets_layout->addWidget(preset_button, row++, 0, 1, 2);
+	}
+
+	auto* custom = new QRadioButton(tr("Custom string"), presets_box);
+	preset_buttons.emplace_back(custom);
+	presets_layout->addWidget(custom, row, 0, 1, 1);
+	custom_string_edit = new QLineEdit(presets_box);
+	presets_layout->addWidget(custom_string_edit, row++, 2, 1, 1);
+
+	auto* apply_preset_button = new QPushButton(tr("Activate preset"), presets_box);
+	presets_layout->addWidget(apply_preset_button, row, 0, 1, 1);
+	layout->addWidget(presets_box);
+
+	connect(move_up_button, &QAbstractButton::clicked, this, &PaintOnTemplateSettingsPage::moveColorUp);
+	connect(move_down_button, &QAbstractButton::clicked, this, &PaintOnTemplateSettingsPage::moveColorDown);
+
+	connect(apply_preset_button, &QPushButton::clicked,
+	        this, &PaintOnTemplateSettingsPage::applyPresets);
+	connect(custom_string_edit, &QLineEdit::textEdited,
+	        this, [this]() { preset_buttons.back()->setChecked(true); });
+
+	setLayout(layout);
+
+	initializePage(Settings::getInstance().paintOnTemplateColors());
+}
+
+
+PaintOnTemplateSettingsPage::~PaintOnTemplateSettingsPage() = default;
+
+
+QString PaintOnTemplateSettingsPage::title() const
+{
+	return tr("Paint on template");
+}
+
+
+std::vector<QColor> PaintOnTemplateSettingsPage::getWorkingColorsFromPage()
+{
+	auto new_colors = std::vector<QColor>();
+	auto const color_count = color_table->rowCount();
+	new_colors.reserve(color_count);
+
+	for (auto row = 0; row < color_count; ++row)
+		new_colors.emplace_back(color_table->item(row, 1)->background().color());
+
+	return new_colors;
+}
+
+
+void PaintOnTemplateSettingsPage::apply()
+{
+	Settings::getInstance().setPaintOnTemplateColors(getWorkingColorsFromPage());
+}
+
+
+void PaintOnTemplateSettingsPage::reset()
+{
+	initializePage(Settings::getInstance().paintOnTemplateColors());
+}
+
+
+void PaintOnTemplateSettingsPage::initializePage(const std::vector<QColor>& working_colors)
+{
+	color_table->clear();
+	color_table->setRowCount(working_colors.size());
+
+	for (auto row = 0U; row < working_colors.size(); ++row)
+		fillTableRow(color_table, row, working_colors[row]);
+
+	updateCustomColorsString();
+}
+
+
+void PaintOnTemplateSettingsPage::applyPresets()
+{
+	auto button_num = 0U;
+	for (const auto* preset_button : preset_buttons)
+	{
+		if (preset_button->isChecked())
+			break;
+		button_num++;
+	}
+
+	if (button_num < color_presets.size())
+	{
+		initializePage(Settings::colorsStringToVector(QLatin1String(color_presets[button_num].color_string)));
+	}
+	else if (button_num == color_presets.size() && !custom_string_edit->text().isEmpty())
+	{
+		initializePage(Settings::colorsStringToVector(custom_string_edit->text()));
+	}
+}
+
+
+void PaintOnTemplateSettingsPage::updateCustomColorsString()
+{
+	custom_string_edit->setText(Settings::colorsVectorToString(getWorkingColorsFromPage()));
+}
+
+
+void PaintOnTemplateSettingsPage::addColor(bool clicked)
+{
+	Q_UNUSED(clicked);
+
+	auto const new_color = spawnColorDialog({}, this);
+
+	if (new_color.isValid())
+	{
+		auto current_row = color_table->currentRow();
+		auto row = current_row >= 0 ? current_row+1 : color_table->rowCount();
+		color_table->insertRow(row);
+		fillTableRow(color_table, row, new_color);
+		color_table->setCurrentCell(row, 0);
+		updateCustomColorsString();
+	}
+}
+
+
+void PaintOnTemplateSettingsPage::dropColor(bool clicked)
+{
+	Q_UNUSED(clicked);
+
+	auto current_row = color_table->currentRow();
+
+	if (current_row < 0)
+		return;
+
+	color_table->removeRow(current_row);
+	color_table->setCurrentCell(-1, 0);
+
+	updateCustomColorsString();
+}
+
+
+void PaintOnTemplateSettingsPage::moveColor(const std::function<bool(int)>& is_within_bounds,
+                                           int amount)
+{
+	auto current_row = color_table->currentRow();
+
+	if (!is_within_bounds(current_row))
+		return;
+
+	auto* const text_cell = color_table->takeItem(current_row, 0);
+	auto* const color_cell = color_table->takeItem(current_row, 1);
+	color_table->removeRow(current_row);
+
+	auto const new_row = current_row + amount;
+	color_table->insertRow(new_row);
+	color_table->setItem(new_row, 0, text_cell);
+	color_table->setItem(new_row, 1, color_cell);
+	color_table->setCurrentCell(new_row, 0);
+
+	updateCustomColorsString();
+}
+
+
+void PaintOnTemplateSettingsPage::moveColorUp(bool clicked)
+{
+	Q_UNUSED(clicked);
+
+	moveColor([](int row_number)->bool { return row_number > 0; }, -1);
+}
+
+void PaintOnTemplateSettingsPage::moveColorDown(bool clicked)
+{
+	Q_UNUSED(clicked);
+
+	moveColor([this](int row_number)->bool { return row_number < color_table->rowCount()-1; }, 1);
+}
+
+
+void PaintOnTemplateSettingsPage::editColor(bool clicked)
+{
+	Q_UNUSED(clicked);
+
+	auto const color = color_table->item(color_table->currentRow(), 1)->background().color();
+
+	auto const new_color = spawnColorDialog(color, this);
+
+	if (new_color.isValid())
+	{
+		fillTableRow(color_table, color_table->currentRow(), new_color);
+		updateCustomColorsString();
+	}
+}
+
+
+}  // namespace OpenOrienteering

--- a/src/gui/widgets/paint_on_template_settings_page.h
+++ b/src/gui/widgets/paint_on_template_settings_page.h
@@ -1,0 +1,81 @@
+/*
+ *    Copyright 2021 Libor Pecháček
+ *
+ *    This file is part of OpenOrienteering.
+ *
+ *    OpenOrienteering is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OpenOrienteering is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPENORIENTEERING_PAINT_ON_TEMPLATE_SETTINGS_PAGE_H
+#define OPENORIENTEERING_PAINT_ON_TEMPLATE_SETTINGS_PAGE_H
+
+#include <functional>
+#include <vector>
+
+#include <QObject>
+#include <QString>
+
+#include "settings_page.h"
+
+class QColor;
+class QLineEdit;
+class QTableWidget;
+class QRadioButton;
+class QToolButton;
+class QWidget;
+
+
+namespace OpenOrienteering {
+
+
+class PaintOnTemplateSettingsPage : public SettingsPage
+{
+	Q_OBJECT
+
+public:
+	explicit PaintOnTemplateSettingsPage(QWidget* parent = nullptr);
+	~PaintOnTemplateSettingsPage();
+	QString title() const override;
+	void apply() override;
+	void reset() override;
+
+public slots:
+	void editColor(bool clicked);
+	void moveColorUp(bool clicked);
+	void moveColorDown(bool clicked);
+	void dropColor(bool clicked);
+	void addColor(bool clicked);
+
+protected:
+	QTableWidget* color_table = {};
+	std::vector<QRadioButton*> preset_buttons;
+	QLineEdit* custom_string_edit = {};
+	QToolButton* delete_button;
+	QToolButton* edit_button;
+	QToolButton* move_up_button;
+	QToolButton* move_down_button;
+
+	void initializePage(const std::vector<QColor>& working_colors);
+	void applyPresets();
+	void updateCustomColorsString();
+	std::vector<QColor> getWorkingColorsFromPage();
+
+private:
+	void moveColor(const std::function<bool (int)>& is_within_bounds, int amount);
+};
+
+
+}  // namespace OpenOrienteering
+
+#endif // OPENORIENTEERING_PAINT_ON_TEMPLATE_SETTINGS_PAGE_H

--- a/src/gui/widgets/tag_select_widget.cpp
+++ b/src/gui/widgets/tag_select_widget.cpp
@@ -50,6 +50,17 @@
 
 namespace OpenOrienteering {
 
+namespace {
+
+/// Local wrapper for Util::ToolButton::create() adding the What's This bit.
+QToolButton* createToolButton(const QIcon& icon, const QString& text)
+{
+	return Util::ToolButton::create(icon, text, "find_objects.html#query-editor");
+}
+
+}  // anonymous namespace
+
+
 // ### TagSelectWidget ###
 
 TagSelectWidget::TagSelectWidget(QWidget* parent)
@@ -89,18 +100,18 @@ TagSelectWidget::~TagSelectWidget() = default;
 
 QWidget* TagSelectWidget::makeButtons(QWidget* parent)
 {
-	auto* add_button = newToolButton(QIcon(QString::fromLatin1(":/images/plus.png")), tr("Add Row"));
-	delete_button = newToolButton(QIcon(QString::fromLatin1(":/images/minus.png")), tr("Remove Row"));
+	auto* add_button = createToolButton(QIcon(QString::fromLatin1(":/images/plus.png")), tr("Add Row"));
+	delete_button = createToolButton(QIcon(QString::fromLatin1(":/images/minus.png")), tr("Remove Row"));
 	delete_button->setEnabled(false);
 	
 	auto* add_remove_layout = new SegmentedButtonLayout();
 	add_remove_layout->addWidget(add_button);
 	add_remove_layout->addWidget(delete_button);
 
-	move_up_button = newToolButton(QIcon(QString::fromLatin1(":/images/arrow-up.png")), tr("Move Up"));
+	move_up_button = createToolButton(QIcon(QString::fromLatin1(":/images/arrow-up.png")), tr("Move Up"));
 	move_up_button->setAutoRepeat(true);
 	move_up_button->setEnabled(false);
-	move_down_button = newToolButton(QIcon(QString::fromLatin1(":/images/arrow-down.png")), tr("Move Down"));
+	move_down_button = createToolButton(QIcon(QString::fromLatin1(":/images/arrow-down.png")), tr("Move Down"));
 	move_down_button->setAutoRepeat(true);
 	move_down_button->setEnabled(false);
 
@@ -124,20 +135,6 @@ QWidget* TagSelectWidget::makeButtons(QWidget* parent)
 	
 	return list_buttons_group;
 }
-
-
-
-QToolButton* TagSelectWidget::newToolButton(const QIcon& icon, const QString& text)
-{
-	auto* button = new QToolButton();
-	button->setToolButtonStyle(Qt::ToolButtonIconOnly);
-	button->setToolTip(text);
-	button->setIcon(icon);
-	button->setText(text);
-	button->setWhatsThis(Util::makeWhatThis("find_objects.html#query-editor"));
-	return button;
-}
-
 
 
 void TagSelectWidget::showEvent(QShowEvent* event)

--- a/src/gui/widgets/tag_select_widget.h
+++ b/src/gui/widgets/tag_select_widget.h
@@ -23,7 +23,6 @@
 #define OPENORIENTEERING_TAG_SELECT_WIDGET_H
 
 #include <QtGlobal>
-#include <QIcon>
 #include <QObject>
 #include <QString>
 #include <QTableWidget>
@@ -60,11 +59,6 @@ protected:
 	void showEvent(QShowEvent* event) override;
 	
 private:
-	/**
-	 * Returns a new QToolButton with a unified appearance.
-	 */
-	QToolButton* newToolButton(const QIcon& icon, const QString& text);
-	
 	void addRow();
 	void deleteRow();
 	void moveRow(bool up);

--- a/src/gui/widgets/tags_widget.cpp
+++ b/src/gui/widgets/tags_widget.cpp
@@ -62,7 +62,7 @@ TagsWidget::TagsWidget(Map* map, MapView* main_view, MapEditorController* contro
 	
 	layout->addWidget(tags_table);
 	
-	auto help_button = newToolButton(QIcon(QString::fromLatin1(":/images/help.png")), tr("Help"));
+	auto help_button = Util::ToolButton::create(QIcon(QString::fromLatin1(":/images/help.png")), tr("Help"));
 	help_button->setAutoRaise(true);
 	
 	auto all_buttons_layout = new QHBoxLayout();
@@ -91,17 +91,6 @@ TagsWidget::TagsWidget(Map* map, MapView* main_view, MapEditorController* contro
 
 TagsWidget::~TagsWidget() = default;
 
-
-
-QToolButton* TagsWidget::newToolButton(const QIcon& icon, const QString& text)
-{
-	auto button = new QToolButton();
-	button->setToolButtonStyle(Qt::ToolButtonIconOnly);
-	button->setToolTip(text);
-	button->setIcon(icon);
-	button->setText(text);
-	return button;
-}
 
 // slot
 void TagsWidget::showHelp()

--- a/src/gui/widgets/tags_widget.h
+++ b/src/gui/widgets/tags_widget.h
@@ -71,11 +71,6 @@ protected slots:
 	void showHelp();
 	
 protected:
-	/**
-	 * Returns a new QToolButton with a unified appearance.
-	 */
-	QToolButton* newToolButton(const QIcon& icon, const QString& text);
-	
 	/** 
 	 * Sets up the last row: blank cells, right one not editable.
 	 */

--- a/src/gui/widgets/template_list_widget.cpp
+++ b/src/gui/widgets/template_list_widget.cpp
@@ -104,6 +104,8 @@
 #endif
 
 
+namespace OpenOrienteering {
+
 namespace {
 
 QVariant makeCheckBoxDecorator(QStyle* style, const QSize& size)
@@ -121,24 +123,14 @@ QVariant makeCheckBoxDecorator(QStyle* style, const QSize& size)
 	return pixmap;
 }
 
-/**
- * Returns a new QToolButton with a unified appearance.
- */
-QToolButton* newToolButton(const QIcon& icon, const QString& text)
+/// Local wrapper for Util::ToolButton::create() adding the What's This bit.
+QToolButton* createToolButton(const QIcon& icon, const QString& text)
 {
-	auto* button = new QToolButton();
-	button->setToolButtonStyle(Qt::ToolButtonIconOnly);
-	button->setToolTip(text);
-	button->setIcon(icon);
-	button->setText(text);
-	button->setWhatsThis(OpenOrienteering::Util::makeWhatThis("templates.html#setup"));
-	return button;
+	return Util::ToolButton::create(icon, text, "templates.html#setup");
 }
 
-}
+}  // anonymous namespace
 
-
-namespace OpenOrienteering {
 
 // ### TemplateListWidget ###
 
@@ -256,19 +248,19 @@ TemplateListWidget::TemplateListWidget(Map& map, MapView& main_view, MapEditorCo
 	current_action->setDisabled(true);
 #endif
 	
-	auto* new_button = newToolButton(QIcon(QString::fromLatin1(":/images/plus.png")), tr("Add template..."));
+	auto* new_button = createToolButton(QIcon(QString::fromLatin1(":/images/plus.png")), tr("Add template..."));
 	new_button->setPopupMode(QToolButton::InstantPopup);
 	new_button->setMenu(new_button_menu);
 	
-	delete_button = newToolButton(QIcon(QString::fromLatin1(":/images/minus.png")), tr("Remove"));
+	delete_button = createToolButton(QIcon(QString::fromLatin1(":/images/minus.png")), tr("Remove"));
 	
 	auto* add_remove_layout = new SegmentedButtonLayout();
 	add_remove_layout->addWidget(new_button);
 	add_remove_layout->addWidget(delete_button);
 	
-	move_up_button = newToolButton(QIcon(QString::fromLatin1(":/images/arrow-up.png")), tr("Move Up"));
+	move_up_button = createToolButton(QIcon(QString::fromLatin1(":/images/arrow-up.png")), tr("Move Up"));
 	move_up_button->setAutoRepeat(true);
-	move_down_button = newToolButton(QIcon(QString::fromLatin1(":/images/arrow-down.png")), tr("Move Down"));
+	move_down_button = createToolButton(QIcon(QString::fromLatin1(":/images/arrow-down.png")), tr("Move Down"));
 	move_down_button->setAutoRepeat(true);
 	
 	auto* up_down_layout = new SegmentedButtonLayout();
@@ -277,10 +269,10 @@ TemplateListWidget::TemplateListWidget(Map& map, MapView& main_view, MapEditorCo
 	
 	move_by_hand_action = new QAction(QIcon(QString::fromLatin1(":/images/move.png")), tr("Move by hand"), this);
 	move_by_hand_action->setCheckable(true);
-	move_by_hand_button = newToolButton(move_by_hand_action->icon(), move_by_hand_action->text());
+	move_by_hand_button = createToolButton(move_by_hand_action->icon(), move_by_hand_action->text());
 	move_by_hand_button->setDefaultAction(move_by_hand_action);
 	move_by_hand_button->setVisible(!mobile_mode);
-	adjust_button = newToolButton(QIcon(QString::fromLatin1(":/images/georeferencing.png")), tr("Adjust..."));
+	adjust_button = createToolButton(QIcon(QString::fromLatin1(":/images/georeferencing.png")), tr("Adjust..."));
 	adjust_button->setCheckable(true);
 	adjust_button->setVisible(!mobile_mode);
 	
@@ -298,7 +290,7 @@ TemplateListWidget::TemplateListWidget(Map& map, MapView& main_view, MapEditorCo
 	vectorize_action = nullptr;
 #endif /* WITH_COVE */
 
-	edit_button = newToolButton(QIcon(QString::fromLatin1(":/images/settings.png")),
+	edit_button = createToolButton(QIcon(QString::fromLatin1(":/images/settings.png")),
 	                            ::OpenOrienteering::MapEditorController::tr("&Edit").remove(QLatin1Char('&')));
 	edit_button->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
 	edit_button->setPopupMode(QToolButton::InstantPopup);
@@ -329,7 +321,7 @@ TemplateListWidget::TemplateListWidget(Map& map, MapView& main_view, MapEditorCo
 	
 	if (!mobile_mode)
 	{
-		auto help_button = newToolButton(QIcon(QString::fromLatin1(":/images/help.png")), tr("Help"));
+		auto help_button = createToolButton(QIcon(QString::fromLatin1(":/images/help.png")), tr("Help"));
 		help_button->setAutoRaise(true);
 		all_buttons_layout->addWidget(help_button);
 		connect(help_button, &QAbstractButton::clicked, this, &TemplateListWidget::showHelp);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -28,12 +28,17 @@
 #include <QApplication>
 #endif
 #include <QByteArray>
+#include <QColor>
 #include <QGuiApplication>
+#include <QLatin1Char>
 #include <QLatin1String>
 #include <QLocale>
+#include <QRgb>
 #include <QScreen>
 #include <QSettings>
 #include <QStringList>
+#include <QStringRef>
+#include <QVector>
 
 
 namespace OpenOrienteering {
@@ -161,6 +166,9 @@ Settings::Settings()
 	// Set antialiasing default depending on screen pixels per inch
 	registerSetting(MapDisplay_Antialiasing, "MapDisplay/antialiasing", Util::isAntialiasingRequired(getSetting(General_PixelsPerInch).toReal()));
 	
+	// Paint On Template tool settings
+	registerSetting(PaintOnTemplateTool_Colors, "PaintOnTemplateTool/colors", QLatin1String("FF0000,FFFF00,00FF00,DB00D9,0000FF,D15C00,000000"));
+
 	QSettings settings;
 	
 #ifndef Q_OS_ANDROID
@@ -391,6 +399,41 @@ void Settings::setNmeaSerialPort(const QString& name)
 		QSettings().setValue(QLatin1String("Sensors/nmea_serialport"), name);
 		emit settingsChanged();
 	}
+}
+
+std::vector<QColor> Settings::colorsStringToVector(QString config_string)
+{
+	auto const color_strings = config_string.splitRef(QLatin1Char(','));
+
+	auto colors = std::vector<QColor>();
+	colors.reserve(color_strings.size());
+
+	// we don't bother about malformed strings and accept the resulting zero
+	for (const auto& color_string : color_strings)
+		colors.emplace_back(QRgb(color_string.toUInt(nullptr, 16)));
+
+	return colors;
+}
+
+std::vector<QColor> Settings::paintOnTemplateColors() const
+{
+	return colorsStringToVector(getSetting(PaintOnTemplateTool_Colors).toString());
+}
+
+QString Settings::colorsVectorToString(const std::vector<QColor>& new_colors)
+{
+	auto strings = QStringList {};
+	strings.reserve(new_colors.size());
+
+	for (auto const& color : new_colors)
+		strings.append(color.name().right(6).toUpper());
+
+	return strings.join(QLatin1Char(','));
+}
+
+void Settings::setPaintOnTemplateColors(const std::vector<QColor>& new_colors)
+{
+	setSetting(PaintOnTemplateTool_Colors, colorsVectorToString(new_colors));
 }
 
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -22,12 +22,15 @@
 #ifndef OPENORIENTEERING_SETTINGS_H
 #define OPENORIENTEERING_SETTINGS_H
 
+#include <vector>
+
 #include <QtGlobal>
 #include <QHash>
 #include <QObject>
 #include <QString>
 #include <QVariant>
 
+class QColor;
 class QSettings;
 
 
@@ -72,6 +75,7 @@ public:
 		General_StartDragDistance,
 		HomeScreen_TipsVisible,
 		HomeScreen_CurrentTip,
+		PaintOnTemplateTool_Colors,
 		END_OF_SETTINGSENUM /* Don't add items below this line. */
 	};
 	
@@ -207,6 +211,16 @@ public:
 	 */
 	void setNmeaSerialPort(const QString& name);
 	
+	/// Returns a vector of colors for paint on template tool.
+	std::vector<QColor> paintOnTemplateColors() const;
+	/// Saves the paint on template tool color vector to settings.
+	void setPaintOnTemplateColors(const std::vector<QColor>& new_colors);
+	/// Helper method for conversion of config string to vector of color.
+	/// In use by the configuration settings page.
+	static std::vector<QColor> colorsStringToVector(QString config_string);
+	/// Helper method for conversion of vector of colors to config string.
+	/// In use by the configuration settings page.
+	static QString colorsVectorToString(const std::vector<QColor>& new_colors);
 	
 signals:
 	void settingsChanged();

--- a/src/templates/paint_on_template_tool.cpp
+++ b/src/templates/paint_on_template_tool.cpp
@@ -195,16 +195,8 @@ ActionGridBar* PaintOnTemplateTool::makeToolBar()
 	auto* toolbar = new ActionGridBar(ActionGridBar::Horizontal, 2);
 	auto* color_options = new QActionGroup(this);
 	
-	int count = 0;
-	static QColor const default_colors[] = {
-	    qRgb(255,   0,   0),
-	    qRgb(255, 255,   0),
-	    qRgb(  0, 255,   0),
-	    qRgb(219,   0, 216),
-	    qRgb(  0,   0, 255),
-	    qRgb(209,  92,   0),
-	    qRgb(  0,   0,   0),
-	};
+	auto const default_colors = Settings::getInstance().paintOnTemplateColors();
+	auto count = (default_colors.size() + 1) % 2; // align colors with the other icons
 	for (auto const& color: default_colors)
 	{
 		QPixmap pixmap(icon_size, icon_size);


### PR DESCRIPTION
Let's give a shot to this implementation of the scribble color settings dialog. It may feel rough but at the same time it might be "just right". Comments are welcome especially in the following areas:

* Are the scribble colors device-dependent or map-dependent? I.e. should the setting be stored on the device on in the map file?
* Is the user interface usable on mobile devices?