### PR TITLE
Revert "MainWindow: Shorten event processing on message"

### DIFF
--- a/src/gui/main_window.cpp
+++ b/src/gui/main_window.cpp
@@ -533,7 +533,10 @@ void MainWindow::showStatusBarMessage(const QString& text, int timeout)
 void MainWindow::showStatusBarMessageImmediately(const QString& text, int timeout)
 {
 	showStatusBarMessage(text, timeout);
-	QApplication::processEvents(QEventLoop::ExcludeUserInputEvents, 10 /* ms */);
+	// Make sure that paint events reach the user screen, by processing events
+	// until the queue is empty, including events appended during processing.
+	// In the worst case, this will stop after 100 ms.
+	QApplication::processEvents(QEventLoop::ExcludeUserInputEvents, 100 /* ms */);
 }
 
 void MainWindow::clearStatusBarMessage()


### PR DESCRIPTION
This reverts commit 1fde405d1b914da06ba5f7ad999170d8edfb0c9a (and adds a comment), in order to make template loading notifications more reliable on slower Android devices.