### PR TITLE
Fix reproducibility issues

### DIFF
--- a/3rd-party/cove/tests/CMakeLists.txt
+++ b/3rd-party/cove/tests/CMakeLists.txt
@@ -9,6 +9,10 @@ find_package(Qt5Test ${Qt5Core_VERSION} REQUIRED)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_AUTOMOC ON)
 
+configure_file(test_config.h.in test_config.h)
+add_library(cove-test-config INTERFACE)
+target_include_directories(cove-test-config INTERFACE "${CMAKE_CURRENT_BINARY_DIR}")
+
 add_executable(cove-ParallelImageProcessingTest
   ParallelImageProcessingTest.cpp
 )
@@ -22,6 +26,9 @@ endif()
 
 add_executable(cove-PolygonTest
   PolygonTest.cpp
+)
+target_link_libraries(cove-PolygonTest
+  PRIVATE cove-test-config
 )
 add_test(
   NAME cove-PolygonTest

--- a/3rd-party/cove/tests/PolygonTest.cpp
+++ b/3rd-party/cove/tests/PolygonTest.cpp
@@ -31,12 +31,15 @@
 #include <QtTest>
 #include <QByteArray>
 #include <QDataStream>
+#include <QDir>
 #include <QFile>
 #include <QIODevice>
 #include <QImage>
 #include <QPointF>
 
 #include "libvectorizer/Polygons.h"
+
+#include "test_config.h"
 
 // Benchmarking adds significant overhead when enabled.
 // With the focus on (CI) testing, we default to disabling benchmarking
@@ -45,6 +48,11 @@
 #ifndef COVE_BENCHMARK
 #  define COVE_BENCHMARK
 #endif
+
+void PolygonTest::initTestCase()
+{
+	QDir::addSearchPath(QStringLiteral("testdata"), QDir(QString::fromUtf8(COVE_TEST_SOURCE_DIR)).absoluteFilePath(QStringLiteral("data")));
+}
 
 void PolygonTest::testJoins_data()
 {
@@ -56,8 +64,8 @@ void PolygonTest::testJoins_data()
 	QTest::addColumn<QString>("resultFile");
 
 	QTest::newRow("simple joins")
-		<< true << 5.0 << 9 << 0.0 << "data/PolygonTest1-sample.png"
-		<< "data/PolygonTest1-simple-joins-result.dat";
+		<< true << 5.0 << 9 << 0.0 << "testdata:PolygonTest1-sample.png"
+		<< "testdata:PolygonTest1-simple-joins-result.dat";
 }
 
 void PolygonTest::testJoins()
@@ -72,7 +80,7 @@ void PolygonTest::testJoins()
 	QFETCH(QString, imageFile);
 	QFETCH(QString, resultFile);
 
-	QVERIFY(sampleImage.load(QFINDTESTDATA(imageFile)));
+	QVERIFY(sampleImage.load(imageFile));
 
 	polyTracer.setSimpleOnly(simpleOnly);
 	polyTracer.setMaxDistance(maxDistance);
@@ -85,8 +93,8 @@ void PolygonTest::testJoins()
 		polys = polyTracer.createPolygonsFromImage(sampleImage);
 	}
 
-	//    saveResults(polys, QFINDTESTDATA(resultFile));
-	compareResults(polys, QFINDTESTDATA(resultFile));
+	// saveResults(polys, resultFile);
+	compareResults(polys, resultFile);
 }
 
 void PolygonTest::saveResults(const cove::PolygonList& polys,

--- a/3rd-party/cove/tests/PolygonTest.h
+++ b/3rd-party/cove/tests/PolygonTest.h
@@ -26,6 +26,8 @@ class PolygonTest : public QObject
 {
 	Q_OBJECT
 private slots:
+	void initTestCase();
+	
 	void testJoins_data();
 	void testJoins();
 

--- a/3rd-party/cove/tests/test_config.h.in
+++ b/3rd-party/cove/tests/test_config.h.in
@@ -1,0 +1,25 @@
+/*
+ *    Copyright 2020 Kai Pastor
+ *    
+ *    This file is part of OpenOrienteering.
+ * 
+ *    OpenOrienteering is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ * 
+ *    OpenOrienteering is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ * 
+ *    You should have received a copy of the GNU General Public License
+ *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef COVE_TEST_CONFIG_H
+#define COVE_TEST_CONFIG_H
+
+#define COVE_TEST_SOURCE_DIR "@CMAKE_CURRENT_SOURCE_DIR@"
+
+#endif

--- a/doc/manual/CMakeLists.txt
+++ b/doc/manual/CMakeLists.txt
@@ -171,10 +171,16 @@ if(Mapper_MANUAL_QTHELP)
 	  DOC "The path of the sqlite3 executable"
 	)
 	if (DEFINED ENV{SOURCE_DATE_EPOCH} AND SQLITE3_EXECUTABLE)
-		file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/timestamp.sql"
-		  "update 'SettingsTable' set Value='$ENV{SOURCE_DATE_EPOCH}' where Key='CreationTime';\n"
-		  "delete from 'SettingsTable' where Key='LastRegisterTime';\n"
-		)
+		if(Qt5Core_VERSION VERSION_LESS 5.12.0)
+			file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/timestamp.sql"
+			  "UPDATE 'SettingsTable' SET Value='$ENV{SOURCE_DATE_EPOCH}' where Key='CreationTime';\n"
+			  "DELETE FROM 'SettingsTable' WHERE Key='LastRegisterTime';\n"
+			)
+		else()
+			file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/timestamp.sql"
+			  "UPDATE TimeStampTable SET TimeStamp=strftime('%Y-%m-%dT%H:%M:%S',datetime($ENV{SOURCE_DATE_EPOCH},'unixepoch'));\n"
+			)
+		endif()
 		set(source_date_commands
 	      COMMAND ${SQLITE3_EXECUTABLE} "${Mapper_HELP_COLLECTION}" < "timestamp.sql"
 		)

--- a/test/autosave_t.cpp
+++ b/test/autosave_t.cpp
@@ -22,6 +22,7 @@
 #include <QtGlobal>
 #include <QtTest>
 #include <QCoreApplication>
+#include <QMetaObject>
 #include <QString>
 
 #include "settings.h"
@@ -71,11 +72,10 @@ AutosaveTest::AutosaveTest(QObject* parent)
 : QObject(parent)
 , autosave_interval(0.02) // 0.02 min = 1.2 s
 {
-	// The default settings format for Windows (registry) needs an organization.
+	// Use distinct QSettings
 	QCoreApplication::setOrganizationName(QString::fromLatin1("OpenOrienteering.org"));
-	// Set distinct application name in order to use distinct settings.
-	// Autosave objects must not be constructed before this!
-	QCoreApplication::setApplicationName(QString::fromLatin1("Tests"));
+	QCoreApplication::setApplicationName(QString::fromLatin1(metaObject()->className()));
+	QVERIFY2(QDir::home().exists(), "The home dir must be writable in order to use QSettings.");
 }
 
 void AutosaveTest::initTestCase()

--- a/test/file_format_t.cpp
+++ b/test/file_format_t.cpp
@@ -40,6 +40,7 @@
 #include <QIODevice>
 #include <QLatin1Char>
 #include <QLatin1String>
+#include <QMetaObject>
 #include <QPageSize>
 #include <QPoint>
 #include <QPointF>
@@ -509,8 +510,10 @@ namespace
 
 void FileFormatTest::initTestCase()
 {
+	// Use distinct QSettings
 	QCoreApplication::setOrganizationName(QString::fromLatin1("OpenOrienteering.org"));
-	QCoreApplication::setApplicationName(QString::fromLatin1("FileFormatTest"));
+	QCoreApplication::setApplicationName(QString::fromLatin1(metaObject()->className()));
+	QVERIFY2(QDir::home().exists(), "The home dir must be writable in order to use QSettings.");
 	
 	doStaticInitializations();
 	

--- a/test/symbol_set_t.cpp
+++ b/test/symbol_set_t.cpp
@@ -38,6 +38,7 @@
 #include <QIODevice>
 #include <QLatin1Char>
 #include <QLatin1String>
+#include <QMetaObject>
 #include <QPagedPaintDevice>
 #include <QPrinter>
 #include <QRectF>
@@ -727,8 +728,10 @@ void saveIfDifferent(QFile& file, QByteArray& new_data, const QByteArray& existi
 
 void SymbolSetTool::initTestCase()
 {
+	// Use distinct QSettings
 	QCoreApplication::setOrganizationName(QString::fromLatin1("OpenOrienteering.org"));
-	QCoreApplication::setApplicationName(QString::fromLatin1("SymbolSetTool"));
+	QCoreApplication::setApplicationName(QString::fromLatin1(metaObject()->className()));
+	QVERIFY2(QDir::home().exists(), "The home dir must be writable in order to use QSettings.");
 	
 	doStaticInitializations();
 	

--- a/test/template_t.cpp
+++ b/test/template_t.cpp
@@ -95,8 +95,11 @@ Q_OBJECT
 private slots:
 	void initTestCase()
 	{
+		// Use distinct QSettings
 		QCoreApplication::setOrganizationName(QString::fromLatin1("OpenOrienteering.org"));
 		QCoreApplication::setApplicationName(QString::fromLatin1(metaObject()->className()));
+		QVERIFY2(QDir::home().exists(), "The home dir must be writable in order to use QSettings.");
+		
 		Q_INIT_RESOURCE(resources);
 		doStaticInitializations();
 		// Static map initializations

--- a/test/track_t.cpp
+++ b/test/track_t.cpp
@@ -30,6 +30,7 @@
 #include <QFileInfo>
 #include <QIODevice>
 #include <QLatin1String>
+#include <QMetaObject>
 #include <QObject>
 #include <QString>
 
@@ -52,8 +53,11 @@ class TrackTest : public QObject
 private slots:
 	void initTestCase()
 	{
+		// Use distinct QSettings
 		QCoreApplication::setOrganizationName(QString::fromLatin1("OpenOrienteering.org"));
-		QCoreApplication::setApplicationName(QString::fromLatin1("TrackTest"));
+		QCoreApplication::setApplicationName(QString::fromLatin1(metaObject()->className()));
+		QVERIFY2(QDir::home().exists(), "The home dir must be writable in order to use QSettings.");
+		
 		QDir::addSearchPath(QStringLiteral("testdata"), QDir(QString::fromUtf8(MAPPER_TEST_SOURCE_DIR)).absoluteFilePath(QStringLiteral("data")));
 		doStaticInitializations();
 	}


### PR DESCRIPTION
The manual issue affects all binary packages which include the manual (Qt Help format).
The QFINDTESTDATA() issue doesn't affect binary packages, but test executables. In this sense, it is more or less a false positive.