### PR TITLE
Georeferencing: Revise state API

### DIFF
--- a/src/fileformats/file_import_export.cpp
+++ b/src/fileformats/file_import_export.cpp
@@ -145,7 +145,7 @@ void Importer::importFailed()
 void Importer::validate()
 {
 	auto const& georef = map->getGeoreferencing();
-	if (georef.isValid() && !georef.isLocal())
+	if (georef.getState() == Georeferencing::Geospatial)
 	{
 		auto const expected = georef.getProjectedRefPoint();
 		auto const actual = georef.toProjectedCoords(georef.getGeographicRefPoint());

--- a/src/fileformats/xml_file_format.cpp
+++ b/src/fileformats/xml_file_format.cpp
@@ -695,7 +695,7 @@ void XMLFileImporter::importGeoreferencing()
 	Georeferencing georef;
 	georef.load(xml, loadSymbolsOnly());
 	map->setGeoreferencing(georef);
-	if (!georef.isValid())
+	if (georef.getState() == Georeferencing::BrokenGeospatial)
 	{
 		QString error_text = georef.getErrorText();
 		if (error_text.isEmpty())
@@ -717,7 +717,7 @@ void XMLFileImporter::importGeoreferencing()
 void XMLFileImporter::validateGeoreferencing()
 {
 	auto const& loaded_georef = map->getGeoreferencing();
-	if (!loaded_georef.isValid() || loaded_georef.isLocal())
+	if (loaded_georef.getState() != Georeferencing::Geospatial)
 		return;
 	
 	// Check for georeferencings with inconsistent declination/grivation,

--- a/src/gdal/ogr_file_format.cpp
+++ b/src/gdal/ogr_file_format.cpp
@@ -737,7 +737,7 @@ ogr::unique_srs OgrFileImport::srsFromMap()
 {
 	auto srs = ogr::unique_srs(OSRNewSpatialReference(nullptr));
 	auto& georef = map->getGeoreferencing();
-	if (georef.isValid() && !georef.isLocal())
+	if (georef.getState() == Georeferencing::Geospatial)
 	{
 		OSRSetProjCS(srs.get(), "Projected map SRS");
 		OSRSetWellKnownGeogCS(srs.get(), "WGS84");
@@ -1721,7 +1721,7 @@ MapCoord OgrFileImport::fromProjected(double x, double y) const
 // static
 bool OgrFileImport::checkGeoreferencing(const QString& path, const Georeferencing& georef)
 {
-	if (georef.isLocal() || !georef.isValid())
+	if (georef.getState() != Georeferencing::Geospatial)
 		return false;
 	
 	GdalManager();

--- a/src/gdal/ogr_template.cpp
+++ b/src/gdal/ogr_template.cpp
@@ -67,10 +67,9 @@ namespace {
 	{
 		// Keep a configured local reference point from initial_georef?
 		auto data_crs_spec = data_georef.getProjectedCRSSpec();
-		if ((!initial_georef.isValid() || initial_georef.isLocal())
+		if (initial_georef.getState() != Georeferencing::Geospatial
 		    && initial_georef.getProjectedRefPoint() != QPointF{}
-		    && data_georef.isValid()
-		    && !data_georef.isLocal()
+		    && data_georef.getState() == Georeferencing::Geospatial
 		    && data_georef.getProjectedRefPoint() == QPointF{}
 		    && data_georef.getMapRefPoint() == MapCoord{}
 		    && data_crs_spec.contains(QLatin1String("+proj=ortho"))
@@ -237,10 +236,10 @@ try
 	
 	auto data_georef = std::unique_ptr<Georeferencing>();
 	auto& initial_georef = map->getGeoreferencing();
-	if (!initial_georef.isValid() || initial_georef.isLocal())
+	if (initial_georef.getState() != Georeferencing::Geospatial)
 	{
 		data_georef = getDataGeoreferencing(template_path, initial_georef);
-		if (data_georef && data_georef->isValid() && !data_georef->isLocal())
+		if (data_georef && data_georef->getState() == Georeferencing::Geospatial)
 		{
 			// If yes, does the user want to use this for the map?
 			auto keep_projected = false;
@@ -258,7 +257,7 @@ try
 	}
 	
 	auto& georef = map->getGeoreferencing();  // initial_georef might be outdated.
-	if (georef.isValid() && !georef.isLocal())
+	if (georef.getState() == Georeferencing::Geospatial)
 	{
 		// The map has got a proper georeferencing.
 		// Can the template's SRS be converted to the map's CRS?

--- a/src/gui/georeferencing_dialog.cpp
+++ b/src/gui/georeferencing_dialog.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2019 Kai Pastor
+ *    Copyright 2012-2020 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -31,7 +31,6 @@
 #include <QCheckBox>
 #include <QCursor>
 #include <QDate>
-#include <QDebug>
 #include <QDesktopServices>  // IWYU pragma: keep
 #include <QDialogButtonBox>
 #include <QDoubleSpinBox>
@@ -131,7 +130,7 @@ GeoreferencingDialog::GeoreferencingDialog(
  , allow_no_georeferencing(allow_no_georeferencing)
  , tool_active(false)
  , declination_query_in_progress(false)
- , grivation_locked(!initial_georef->isValid() || initial_georef->getState() != Georeferencing::Normal)
+ , grivation_locked(initial_georef->getState() != Georeferencing::Geospatial)
  , scale_factor_locked(grivation_locked)
 {
 	setWindowTitle(tr("Map Georeferencing"));
@@ -193,7 +192,7 @@ GeoreferencingDialog::GeoreferencingDialog(
 	
 	keep_projected_radio = new QRadioButton(tr("Projected coordinates"));
 	keep_geographic_radio = new QRadioButton(tr("Geographic coordinates"));
-	if (georef->getState() == Georeferencing::Normal && georef->isValid())
+	if (georef->getState() == Georeferencing::Geospatial)
 	{
 		keep_geographic_radio->setChecked(true);
 	}
@@ -334,10 +333,8 @@ void GeoreferencingDialog::georefStateChanged()
 		keep_geographic_radio->setEnabled(false);
 		keep_projected_radio->setChecked(true);
 		break;
-	default:
-		qDebug() << "Unhandled georeferencing state:" << georef->getState();
-		Q_FALLTHROUGH();
-	case Georeferencing::Normal:
+	case Georeferencing::BrokenGeospatial:
+	case Georeferencing::Geospatial:
 		projectionChanged();
 		keep_geographic_radio->setEnabled(true);
 	}
@@ -374,7 +371,7 @@ void GeoreferencingDialog::projectionChanged()
 	            lat_edit, lon_edit
 	);
 	
-	if (georef->getState() == Georeferencing::Normal)
+	if (georef->getState() == Georeferencing::Geospatial)
 	{
 		const std::vector< QString >& parameters = georef->getProjectedCRSParameters();
 		auto temp = CRSTemplateRegistry().find(georef->getProjectedCRSId());
@@ -430,7 +427,7 @@ void GeoreferencingDialog::auxiliaryFactorChanged()
 
 void GeoreferencingDialog::requestDeclination(bool no_confirm)
 {
-	if (georef->isLocal())
+	if (georef->getState() != Georeferencing::Geospatial)
 		return;
 	
 	/// \todo Move URL (template) to settings.
@@ -506,7 +503,7 @@ void GeoreferencingDialog::showHelp()
 
 void GeoreferencingDialog::reset()
 {
-	scale_factor_locked = grivation_locked = ( !initial_georef->isValid() || initial_georef->getState() != Georeferencing::Normal );
+	scale_factor_locked = grivation_locked = ( initial_georef->getState() != Georeferencing::Geospatial );
 	*georef.data() = *initial_georef;
 	reset_button->setEnabled(false);
 }
@@ -566,7 +563,7 @@ void GeoreferencingDialog::accept()
 	
 	if (rotate || stretch)
 	{
-		if (georef->isLocal() && !map->getGeoreferencing().isLocal())
+		if (georef->getState() == Georeferencing::Local && map->getGeoreferencing().getState() != Georeferencing::Local)
 		{
 			// When switching the map to a local georeferencing, templates may
 			// switch to a non-georeferenced mode. Rotating and stretching
@@ -575,7 +572,7 @@ void GeoreferencingDialog::accept()
 			// scale factors and rotation as before.
 			auto const& map_georef = map->getGeoreferencing();
 			Georeferencing local_georef { map_georef };
-			local_georef.setState(Georeferencing::Local);
+			local_georef.setLocalState();
 			local_georef.setDeclination(map_georef.getDeclination());
 			local_georef.setAuxiliaryScaleFactor(map_georef.getAuxiliaryScaleFactor());
 			map->setGeoreferencing(local_georef);
@@ -609,7 +606,7 @@ void GeoreferencingDialog::updateWidgets()
 	
 	updateDeclinationButton();
 	
-	buttons_box->button(QDialogButtonBox::Ok)->setEnabled(georef->isValid());
+	buttons_box->button(QDialogButtonBox::Ok)->setEnabled(georef->getState() != Georeferencing::BrokenGeospatial);
 }
 
 void GeoreferencingDialog::updateDeclinationButton()
@@ -658,7 +655,7 @@ void GeoreferencingDialog::crsEdited()
 		Q_FALLTHROUGH();
 	case Georeferencing::Local:
 		// Local
-		georef_copy.setState(Georeferencing::Local);
+		georef_copy.setLocalState();
 		grivation_locked = true;
 		updateGrivation();
 		scale_factor_locked = true;
@@ -667,8 +664,10 @@ void GeoreferencingDialog::crsEdited()
 	case -1:
 		// CRS from list
 		Q_ASSERT(crs_template);
+		if (spec.isEmpty())
+			spec = QStringLiteral(" ");  // intentionally non-empty: enforce non-local state.
 		georef_copy.setProjectedCRS(crs_template->id(), spec, crs_selector->parameters());
-		georef_copy.setState(Georeferencing::Normal); // Allow invalid spec
+		Q_ASSERT(georef_copy.getState() != Georeferencing::Local);
 		if (keep_geographic_radio->isChecked())
 			georef_copy.setGeographicRefPoint(georef->getGeographicRefPoint(), !grivation_locked, !scale_factor_locked);
 		else

--- a/src/gui/map/map_dialog_scale.cpp
+++ b/src/gui/map/map_dialog_scale.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2019 Kai Pastor
+ *    Copyright 2019-2020 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -61,7 +61,7 @@ ScaleMapDialog::ScaleMapDialog(QWidget* parent, Map* map) : QDialog(parent, Qt::
 	
 	//: Scaling center point
 	center_georef_radio = new QRadioButton(tr("Georeferencing reference point"));
-	if (!map->getGeoreferencing().isValid())
+	if (map->getGeoreferencing().getState() == Georeferencing::Local)
 		center_georef_radio->setEnabled(false);
 	layout->addRow(center_georef_radio);
 	
@@ -95,7 +95,7 @@ ScaleMapDialog::ScaleMapDialog(QWidget* parent, Map* map) : QDialog(parent, Qt::
 	layout->addRow(adjust_objects_check);
 	
 	adjust_georeferencing_check = new QCheckBox(tr("Adjust georeferencing reference point"));
-	if (map->getGeoreferencing().isValid())
+	if (map->getGeoreferencing().getState() == Georeferencing::Geospatial)
 		adjust_georeferencing_check->setChecked(true);
 	else
 		adjust_georeferencing_check->setEnabled(false);

--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -1064,7 +1064,7 @@ void MapEditorController::createActions()
 	
 	touch_cursor_action = newCheckAction("touchcursor", tr("Enable touch cursor"), map_widget, SLOT(enableTouchCursor(bool)), "tool-touch-cursor.png", QString{}, "toolbars.html#touch_cursor"); // TODO: write documentation
 	gps_display_action = newCheckAction("gpsdisplay", tr("Enable GPS display"), this, SLOT(enableGPSDisplay(bool)), "tool-gps-display.png", QString{}, "toolbars.html#gps_display"); // TODO: write documentation
-	gps_display_action->setEnabled(map->getGeoreferencing().isValid() && ! map->getGeoreferencing().isLocal());
+	gps_display_action->setEnabled(map->getGeoreferencing().getState() == Georeferencing::Geospatial);
 	gps_distance_rings_action = newCheckAction("gpsdistancerings", tr("Enable GPS distance rings"), this, SLOT(enableGPSDistanceRings(bool)), "gps-distance-rings.png", QString{}, "toolbars.html#gps_distance_rings"); // TODO: write documentation
 	gps_distance_rings_action->setEnabled(false);
 	draw_point_gps_act = newToolAction("drawpointgps", tr("Set point object at GPS position"), this, SLOT(drawPointGPSClicked()), "draw-point-gps.png", QString{}, "toolbars.html#tool_draw_point_gps"); // TODO: write documentation
@@ -2073,7 +2073,7 @@ void MapEditorController::projectionChanged()
 	
 	projected_coordinates_act->setText(geo.getProjectedCoordinatesName());
 	
-	bool enable_geographic = !geo.isLocal();
+	bool enable_geographic = geo.getState() == Georeferencing::Geospatial;
 	geographic_coordinates_act->setEnabled(enable_geographic);
 	geographic_coordinates_dms_act->setEnabled(enable_geographic);
 	if (!enable_geographic &&
@@ -2316,7 +2316,7 @@ void MapEditorController::georeferencingDialogFinished()
 	georeferencing_dialog.take()->deleteLater();
 	map->updateAllMapWidgets();
 	
-	bool gps_display_possible = map->getGeoreferencing().isValid() && ! map->getGeoreferencing().isLocal();
+	bool gps_display_possible = map->getGeoreferencing().getState() == Georeferencing::Geospatial;
 	if (!gps_display_possible)
 	{
 		gps_display_action->setChecked(false);

--- a/src/gui/map/rotate_map_dialog.cpp
+++ b/src/gui/map/rotate_map_dialog.cpp
@@ -62,7 +62,7 @@ RotateMapDialog::RotateMapDialog(const Map& map, QWidget* parent, Qt::WindowFlag
 	
 	//: Rotation center point
 	center_georef_radio = new QRadioButton(tr("Georeferencing reference point"));
-	if (!map.getGeoreferencing().isValid())
+	if (map.getGeoreferencing().getState() == Georeferencing::Local)
 		center_georef_radio->setEnabled(false);
 	layout->addRow(center_georef_radio);
 	
@@ -83,14 +83,14 @@ RotateMapDialog::RotateMapDialog(const Map& map, QWidget* parent, Qt::WindowFlag
 	layout->addRow(Util::Headline::create(tr("Options")));
 	
 	adjust_georeferencing_check = new QCheckBox(tr("Adjust georeferencing reference point"));
-	if (map.getGeoreferencing().isValid())
+	if (map.getGeoreferencing().getState() == Georeferencing::Geospatial)
 		adjust_georeferencing_check->setChecked(true);
 	else
 		adjust_georeferencing_check->setEnabled(false);
 	layout->addRow(adjust_georeferencing_check);
 	
 	adjust_declination_check = new QCheckBox(tr("Adjust georeferencing declination"));
-	if (map.getGeoreferencing().isValid())
+	if (map.getGeoreferencing().getState() == Georeferencing::Geospatial)
 		adjust_declination_check->setChecked(true);
 	else
 		adjust_declination_check->setEnabled(false);

--- a/src/gui/map/stretch_map_dialog.cpp
+++ b/src/gui/map/stretch_map_dialog.cpp
@@ -54,13 +54,13 @@ StretchMapDialog::StretchMapDialog(const Map& map, double stretch_factor, QWidge
 	
 	//: Scaling center point
 	center_origin_radio = new QRadioButton(tr("Map coordinate system origin"));
-	if (!map.getGeoreferencing().isValid())
+	if (map.getGeoreferencing().getState() == Georeferencing::Local)
 		center_origin_radio->setChecked(true);
 	layout->addRow(center_origin_radio);
 	
 	//: Scaling center point
 	center_georef_radio = new QRadioButton(tr("Georeferencing reference point"));
-	if (map.getGeoreferencing().isValid())
+	if (map.getGeoreferencing().getState() != Georeferencing::Local)
 		center_georef_radio->setChecked(true);
 	else
 		center_georef_radio->setEnabled(false);
@@ -82,7 +82,7 @@ StretchMapDialog::StretchMapDialog(const Map& map, double stretch_factor, QWidge
 	layout->addRow(Util::Headline::create(tr("Options")));
 	
 	adjust_georeferencing_check = new QCheckBox(tr("Adjust georeferencing reference point"));
-	if (map.getGeoreferencing().isValid())
+	if (map.getGeoreferencing().getState() == Georeferencing::Geospatial)
 		adjust_georeferencing_check->setChecked(true);
 	else
 		adjust_georeferencing_check->setEnabled(false);

--- a/src/gui/select_crs_dialog.cpp
+++ b/src/gui/select_crs_dialog.cpp
@@ -65,7 +65,7 @@ SelectCRSDialog::SelectCRSDialog(
 	setWindowTitle(tr("Select coordinate reference system"));
 	
 	crs_selector = new CRSSelector(georef, nullptr);
-	if (georef.isLocal())
+	if (georef.getState() != Georeferencing::Geospatial)
 	{
 		crs_selector->clear();
 		crs_selector->addCustomItem(tr("Local"), SpecialCRS::Local);
@@ -93,7 +93,7 @@ SelectCRSDialog::SelectCRSDialog(
 	crs_selector->setDialogLayout(form_layout);
 	
 	auto const& crs_spec = options.effective.crs_spec;
-	if (georef.isLocal())
+	if (georef.getState() != Georeferencing::Geospatial)
 	    crs_selector->setCurrentIndex(0);
 	else if (crs_spec.isEmpty())
 		crs_selector->setCurrentIndex(crs_selector->findData(SpecialCRS::SameAsMap));

--- a/src/gui/widgets/template_list_widget.cpp
+++ b/src/gui/widgets/template_list_widget.cpp
@@ -499,7 +499,7 @@ void TemplateListWidget::updateButtons()
 		else if (current_row >= 0)
 		{
 			// map row
-			is_georeferenced = map.getGeoreferencing().isValid() && !map.getGeoreferencing().isLocal();
+			is_georeferenced = map.getGeoreferencing().getState() == Georeferencing::Geospatial;
 		}
 		
 		edit_button->setEnabled(edit_enabled);

--- a/src/templates/template_map.cpp
+++ b/src/templates/template_map.cpp
@@ -204,7 +204,7 @@ bool TemplateMap::loadTemplateFileImpl()
 bool TemplateMap::postLoadSetup(QWidget* /* dialog_parent */, bool& out_center_in_view)
 {
 	auto const is_unconfigured = [](auto const& georef) {
-		return georef.isLocal() && georef.toProjectedCoords(MapCoordF{}) == QPointF{};
+		return georef.getState() != Georeferencing::Geospatial && georef.toProjectedCoords(MapCoordF{}) == QPointF{};
 	};
 	out_center_in_view = is_unconfigured(templateMap()->getGeoreferencing());
 	return true;
@@ -451,11 +451,9 @@ bool TemplateMap::georeferencedStateSupported() const
 		return success;
 	};
 	return !block_georeferencing
-	       && map->getGeoreferencing().isValid()
-	       && !map->getGeoreferencing().isLocal()
+	       && map->getGeoreferencing().getState() == Georeferencing::Geospatial
 	       && templateMap()
-	       && templateMap()->getGeoreferencing().isValid()
-	       && !templateMap()->getGeoreferencing().isLocal()
+	       && templateMap()->getGeoreferencing().getState() == Georeferencing::Geospatial
 	       && test_transform(templateMap()->getGeoreferencing(), map->getGeoreferencing());
 }
 

--- a/src/templates/template_track.cpp
+++ b/src/templates/template_track.cpp
@@ -291,7 +291,7 @@ bool TemplateTrack::postLoadSetup(QWidget* dialog_parent, bool& /*out_center_in_
 			tr("Load the track in georeferenced or non-georeferenced mode?"),
 			QDialogButtonBox::Abort);
 		QString georef_text = tr("Positions the track according to the map's georeferencing settings.");
-		if (!map->getGeoreferencing().isValid())
+		if (map->getGeoreferencing().getState() != Georeferencing::Geospatial)
 			georef_text += QLatin1Char(' ') + tr("These are not configured yet, so they will be shown as the next step.");
 		QAbstractButton* georef_button = georef_dialog.addCommandButton(tr("Georeferenced"), georef_text);
 		QAbstractButton* non_georef_button = georef_dialog.addCommandButton(tr("Non-georeferenced"), tr("Projects the track using an orthographic projection with center at the track's coordinate average. Allows adjustment of the transformation and setting the map georeferencing using the adjusted track position."));
@@ -307,8 +307,7 @@ bool TemplateTrack::postLoadSetup(QWidget* dialog_parent, bool& /*out_center_in_
 	
 	// If the track is loaded as georeferenced and the transformation parameters
 	// were not set yet, it must be done now
-	if (is_georeferenced &&
-		(!map->getGeoreferencing().isValid() || map->getGeoreferencing().isLocal()))
+	if (is_georeferenced && map->getGeoreferencing().getState() != Georeferencing::Geospatial)
 	{
 		// Set default for real world reference point as some average of the track coordinates
 		Georeferencing georef(map->getGeoreferencing());
@@ -317,7 +316,7 @@ bool TemplateTrack::postLoadSetup(QWidget* dialog_parent, bool& /*out_center_in_
 		// Show the parameter dialog
 		GeoreferencingDialog dialog(dialog_parent, map, &georef);
 		dialog.setKeepGeographicRefCoords();
-		if (dialog.exec() == QDialog::Rejected || map->getGeoreferencing().isLocal())
+		if (dialog.exec() == QDialog::Rejected || map->getGeoreferencing().getState() != Georeferencing::Geospatial)
 			return false;
 	}
 	

--- a/test/file_format_t.cpp
+++ b/test/file_format_t.cpp
@@ -206,7 +206,7 @@ namespace
 		const auto& actual_georef = actual.getGeoreferencing();
 		const auto& expected_georef = expected.getGeoreferencing();
 		QCOMPARE(actual_georef.getScaleDenominator(), expected_georef.getScaleDenominator());
-		QCOMPARE(actual_georef.isLocal(), expected_georef.isLocal());
+		QCOMPARE(actual_georef.getState(), expected_georef.getState());
 		QCOMPARE(actual_georef.getCombinedScaleFactor(), expected_georef.getCombinedScaleFactor());
 		QCOMPARE(actual_georef.getAuxiliaryScaleFactor(), expected_georef.getAuxiliaryScaleFactor());
 		QCOMPARE(actual_georef.getDeclination(), expected_georef.getDeclination());
@@ -429,11 +429,11 @@ namespace
 		QVERIFY2(qAbs(actual_point.x() - expected_point.x()) < 1.0, qPrintable(test_label.arg(actual_point.x()).arg(expected_point.x())));
 		QVERIFY2(qAbs(actual_point.y() - expected_point.y()) < 1.0, qPrintable(test_label.arg(actual_point.y()).arg(expected_point.y())));
 		
-		if (!actual_georef.isLocal())
-		{
-			QCOMPARE(actual_georef.isLocal(), expected_georef.isLocal());
+		if (format_id != "OCD8")
+			QCOMPARE(int(actual_georef.getState()), int(expected_georef.getState()));
+		
+		if (actual_georef.getState() == Georeferencing::Geospatial)
 			QCOMPARE(actual_georef.toGeographicCoords(actual_point), expected_georef.toGeographicCoords(actual_point));
-		}
 		
 		// Colors
 		QVERIFY2(actual.getNumColors() >= expected.getNumColors(), qPrintable(test_label.arg(actual.getNumColors()).arg(expected.getNumColors())));
@@ -905,7 +905,7 @@ void FileFormatTest::ogrExportTest()
 	{
 		Map map;
 		QVERIFY(map.loadFrom(map_filepath));
-		QVERIFY(map.getGeoreferencing().isValid());
+		QCOMPARE(map.getGeoreferencing().getState(), Georeferencing::Geospatial);
 		
 		auto const exported_latlon = map.getGeoreferencing().getGeographicRefPoint();
 		QCOMPARE(qRound(exported_latlon.latitude()), latitude);
@@ -928,7 +928,7 @@ void FileFormatTest::ogrExportTest()
 		auto importer = format->makeImporter(ogr_filepath, &map, nullptr);
 		QVERIFY(bool(importer));
 		QVERIFY(importer->doImport());
-		QVERIFY(map.getGeoreferencing().isValid());
+		QCOMPARE(map.getGeoreferencing().getState(), Georeferencing::Geospatial);
 		
 		auto const imported_latlon = map.getGeoreferencing().getGeographicRefPoint();
 		QCOMPARE(qRound(imported_latlon.latitude()), latitude);

--- a/test/georeferencing_t.cpp
+++ b/test/georeferencing_t.cpp
@@ -123,8 +123,6 @@ void GeoreferencingTest::initTestCase()
 void GeoreferencingTest::testEmptyProjectedCRS()
 {
 	Georeferencing new_georef;
-	QVERIFY(new_georef.isValid());
-	QVERIFY(new_georef.isLocal());
 	QCOMPARE(new_georef.getState(), Georeferencing::Local);
 	QCOMPARE(new_georef.getScaleDenominator(), 1000u);
 	QCOMPARE(new_georef.getCombinedScaleFactor(), 1.0);
@@ -135,6 +133,27 @@ void GeoreferencingTest::testEmptyProjectedCRS()
 	QCOMPARE(new_georef.getConvergence(), 0.0);
 	QCOMPARE(new_georef.getMapRefPoint(), MapCoord(0, 0));
 	QCOMPARE(new_georef.getProjectedRefPoint(), QPointF(0.0, 0.0));
+}
+
+void GeoreferencingTest::testStateChanges()
+{
+	Georeferencing georef;
+	QCOMPARE(georef.getState(), Georeferencing::Local);
+	// From local to broken
+	georef.setProjectedCRS(QStringLiteral("Broken"), QStringLiteral("+init=epsg:BROKEN"));
+	QCOMPARE(georef.getState(), Georeferencing::BrokenGeospatial);
+	// From broken to geospatial
+	georef.setProjectedCRS(QStringLiteral("UTM 32"), utm32_spec);
+	QCOMPARE(georef.getState(), Georeferencing::Geospatial);
+	// From geospatial to broken
+	georef.setProjectedCRS(QStringLiteral("Broken"), QStringLiteral("+init=epsg:BROKEN"));
+	QCOMPARE(georef.getState(), Georeferencing::BrokenGeospatial);
+	// From broken to broken
+	georef.setProjectedCRS(QStringLiteral("Broken"), {});
+	QCOMPARE(georef.getState(), Georeferencing::BrokenGeospatial);
+	// From broken to local
+	georef.setLocalState();
+	QCOMPARE(georef.getState(), Georeferencing::Local);
 }
 
 void GeoreferencingTest::testGridScaleFactor_data()
@@ -160,11 +179,11 @@ void GeoreferencingTest::testGridScaleFactor()
 	
 	Georeferencing georef;
 	georef.setProjectedCRS(QString::fromLatin1(QTest::currentDataTag()), spec);
-	QVERIFY2(georef.isValid(), georef.getErrorText().toLatin1());
+	QCOMPARE(georef.getState(), Georeferencing::Geospatial);
 	
 	auto const latlon = LatLon{lat, lon};
 	georef.setGeographicRefPoint(latlon);
-	QVERIFY2(georef.isValid(), georef.getErrorText().toLatin1());
+	QCOMPARE(georef.getState(), Georeferencing::Geospatial);
 	
 	// Verify scale_x
 	auto const east = georef.getProjectedRefPoint() + QPointF{500.0, 0.0};
@@ -231,7 +250,7 @@ void GeoreferencingTest::testGridScaleFactor()
 	
 	// See that the auxiliary scale factor is preserved when the CRS changes.
 	georef.setProjectedCRS(QString::fromLatin1(QTest::currentDataTag()), utm32_spec);
-	QVERIFY2(georef.isValid(), georef.getErrorText().toLatin1());
+	QCOMPARE(georef.getState(), Georeferencing::Geospatial);
 	QCOMPARE(georef.getAuxiliaryScaleFactor(), elevation_scale_factor);
 	map_distance = QLineF{georef.toMapCoordF(sw), georef.toMapCoordF(ne)}.length();
 	ground_distance = map_distance * georef.getScaleDenominator() / 1000;
@@ -248,7 +267,7 @@ void GeoreferencingTest::testGridScaleFactor()
 	georef.setAuxiliaryScaleFactor(0.95);
 	auto const expected_combined = georef.getCombinedScaleFactor();
 	auto const map_coord = georef.toMapCoordF(sw);
-	georef.setState(Georeferencing::Local);
+	georef.setLocalState();
 	QVERIFY(georef.getProjectedCRSSpec().isEmpty());
 	// This call to setDeclination must not have side-effects.
 	georef.setDeclination(georef.getDeclination());
@@ -353,7 +372,7 @@ void GeoreferencingTest::testCRSTemplates()
 	
 	Georeferencing georef;
 	georef.setProjectedCRS(QStringLiteral("EPSG"), epsg_template->specificationTemplate().arg(QStringLiteral("5514")), { QStringLiteral("5514") });
-	QVERIFY(georef.isValid());
+	QCOMPARE(georef.getState(), Georeferencing::Geospatial);
 	QCOMPARE(georef.getProjectedCoordinatesName(), QStringLiteral("EPSG 5514 coordinates"));
 }
 

--- a/test/georeferencing_t.h
+++ b/test/georeferencing_t.h
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2012-2015, 2019 Kai Pastor
+ *    Copyright 2012-2020 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -41,6 +41,11 @@ private slots:
 	 * Tests the behaviour for unset projected CRS.
 	 */
 	void testEmptyProjectedCRS();
+	
+	/**
+	 * Tests supported state changes.
+	 */
+	void testStateChanges();
 	
 	/**
 	 * Tests the effect of a grid scale factor.

--- a/test/template_t.cpp
+++ b/test/template_t.cpp
@@ -169,7 +169,7 @@ private slots:
 		QVERIFY(map.loadFrom(QStringLiteral("testdata:templates/world-file.xmap"), &view));
 		
 		const auto& georef = map.getGeoreferencing();
-		QVERIFY(georef.isValid());
+		QCOMPARE(georef.getState(), Georeferencing::Geospatial);
 		
 		QCOMPARE(map.getNumTemplates(), 1);
 		auto temp = map.getTemplate(0);
@@ -251,7 +251,7 @@ private slots:
 		QVERIFY(map.loadFrom(QStringLiteral("testdata:templates/geotiff.xmap"), &view));
 		
 		const auto& georef = map.getGeoreferencing();
-		QVERIFY(georef.isValid());
+		QCOMPARE(georef.getState(), Georeferencing::Geospatial);
 		
 		QCOMPARE(map.getNumTemplates(), 1);
 		auto temp = map.getTemplate(0);
@@ -395,7 +395,7 @@ private slots:
 		QVERIFY(map.loadFrom(map_file, &view));
 		
 		auto const& georef = map.getGeoreferencing();
-		QVERIFY(georef.isValid());
+		QCOMPARE(georef.getState(), Georeferencing::Geospatial);
 		QVERIFY(std::abs(georef.getGrivation()) >= 0.01);
 		
 		QVERIFY(map.getNumTemplates() > template_index);


### PR DESCRIPTION
Preparatory work for template class changes and for more georeferencing changes:

Strictly use an enum value to distinguish local, geospatial, and
invalid geospatial states of georeferencing.
This is complemented by making setState() a private member.

There was no simple test if a georeferencing was geospatial AND valid.
Mapper code had to combine isValid() && !isLocal() to test for this
state. By consistently using the state enum, and adding a state for
invalid geospatial references, code is logically simpler and more
expressive.

Note that the existing state checks were not translated literally,
but adjustments were made where the original seemed to not match
the required context.