### PR TITLE
Template: Delay setTemplateAreaDirty on setup

### DIFF
--- a/src/templates/template_map.cpp
+++ b/src/templates/template_map.cpp
@@ -160,7 +160,6 @@ bool TemplateMap::loadTemplateFileImpl()
 			is_georeferenced = false;
 			transform = transformForOcd();
 			updateTransformationMatrices();
-			setTemplateAreaDirty();
 			setProperty(ocdTransformProperty(), false);
 		}
 		else if (is_georeferenced)


### PR DESCRIPTION
When configuring a template for the first time, we don't need to,
and sometimes are unable to properly, set the template area dirty
immediately after loading: the template area might be adjusted by
the postLoadSetup(), or by setupAndLoad() for center_in_view.
This is reflected by leaving the Configuring state unchanged after
successful loadTemplateFileImpl(), and by moving the resposibility
for the state change to the end of setupAndLoad().