### PR TITLE
Test consistency of GPS track positioning

### DIFF
--- a/src/templates/template_track.cpp
+++ b/src/templates/template_track.cpp
@@ -343,6 +343,46 @@ void TemplateTrack::unloadTemplateFileImpl()
 	track.clear();
 }
 
+QPointF TemplateTrack::getCenter() const
+{
+	qreal left;
+	qreal right;
+	qreal top;
+	qreal bottom;
+	int count = 0;
+	for (int i = 0; i < track.getNumSegments(); ++i)
+	{
+		int size = track.getSegmentPointCount(i);
+		for (int k = 0; k < size; ++k)
+		{
+			const TrackPoint& point = track.getSegmentPoint(i, k);
+			if (count == 0)
+			{
+				left = right = point.map_coord.x();
+				top = bottom = point.map_coord.y();
+			}
+			else
+			{
+				if (point.map_coord.x() < left)
+					left = point.map_coord.x();
+				else if (right < point.map_coord.x())
+					right = point.map_coord.x();
+				if (point.map_coord.y() < bottom)
+					bottom = point.map_coord.y();
+				else if (top < point.map_coord.y())
+					top = point.map_coord.y();
+			}
+			count += 1;
+		}
+	}
+	if (count > 0)
+	{
+		QPointF cp = QPointF((left+right)/2, (bottom+top)/2);
+		return is_georeferenced ? cp : templateToMap(cp);
+	}
+	return QPointF();
+}
+
 void TemplateTrack::drawTemplate(QPainter* painter, const QRectF& /*clip_rect*/, double /*scale*/, bool on_screen, qreal opacity) const
 {
 	painter->save();

--- a/src/templates/template_track.h
+++ b/src/templates/template_track.h
@@ -79,6 +79,7 @@ public:
 	bool postLoadSetup(QWidget* dialog_parent, bool& out_center_in_view) override;
 	void unloadTemplateFileImpl() override;
 	
+	QPointF getCenter() const;
 	void drawTemplate(QPainter* painter, const QRectF& clip_rect, double scale, bool on_screen, qreal opacity) const override;
 	QRectF getTemplateExtent() const override;
 	QRectF calculateTemplateBoundingBox() const override;

--- a/test/data/templates/template-track-NA-084.xmap
+++ b/test/data/templates/template-track-NA-084.xmap
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns="http://openorienteering.org/apps/mapper/xml/v2" version="7">
+    <notes></notes>
+    <georeferencing scale="4000" declination="8.00" grivation="8.00">
+        <projected_crs id="EPSG">
+            <spec language="PROJ.4">+init=epsg:6342</spec>
+            <parameter>6342</parameter>
+            <ref_point x="500000.000000" y="4430000.000000"/>
+        </projected_crs>
+        <geographic_crs id="Geographic coordinates">
+            <spec language="PROJ.4">+proj=latlong +datum=WGS84</spec>
+            <ref_point_deg lat="40.02020698" lon="-105.00000000"/>
+        </geographic_crs>
+    </georeferencing>
+    <colors count="1">
+        <color priority="0" name="Purple" c="0.200" m="1.000" y="0.000" k="0.000" opacity="1.000">
+            <spotcolors>
+                <namedcolor>PURPLE</namedcolor>
+            </spotcolors>
+            <cmyk method="custom"/>
+            <rgb method="cmyk" r="0.800" g="0.000" b="1.000"/>
+        </color>
+    </colors>
+    <barrier version="6" required="0.6.0">
+        <symbols count="1">
+            <symbol type="2" id="0" code="1" name="Line">
+                <line_symbol color="0" line_width="100" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="0" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
+            </symbol>
+        </symbols>
+        <parts count="1" current="0">
+            <part name="default part">
+                <objects count="1">
+                    <object type="1" symbol="0">
+                        <coords count="5">
+                            <coord x="-158217" y="170205"/>
+                            <coord x="-157505" y="175272"/>
+                            <coord x="-150981" y="174356"/>
+                            <coord x="-151693" y="169288"/>
+                            <coord x="-158217" y="170205" flags="18"/>
+                        </coords>
+                        <pattern rotation="0">
+                            <coord x="0" y="0"/>
+                        </pattern>
+                    </object>
+                </objects>
+            </part>
+        </parts>
+        <templates count="1" first_front_template="1">
+            <template open="true" name="template-track-NA-2019.gpx" path="template-track-NA-2019.gpx" relpath="template-track-NA-2019.gpx" georef="true">
+                <crs_spec>+proj=latlong +datum=WGS84</crs_spec>
+            </template>
+            <defaults use_meters_per_pixel="true" meters_per_pixel="0" dpi="0" scale="0"/>
+        </templates>
+        <view>
+            <grid color="#646464" display="0" alignment="1" additional_rotation="0" unit="0" h_spacing="0.1" v_spacing="0.1" h_offset="0" v_offset="0" snapping_enabled="true"/>
+            <map_view zoom="22.6274" position_x="-153989" position_y="172450">
+                <map opacity="1" visible="true"/>
+                <templates count="1">
+                    <ref template="0" visible="true" opacity="1"/>
+                </templates>
+            </map_view>
+        </view>
+    </barrier>
+</map>

--- a/test/data/templates/template-track-NA-093-GDAL.xmap
+++ b/test/data/templates/template-track-NA-093-GDAL.xmap
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns="http://openorienteering.org/apps/mapper/xml/v2" version="9">
+    <notes></notes>
+    <georeferencing scale="4000" auxiliary_scale_factor="1.0004" declination="8" grivation="8">
+        <projected_crs id="EPSG">
+            <spec language="PROJ.4">+init=epsg:6342</spec>
+            <parameter>6342</parameter>
+            <ref_point x="500000" y="4430000"/>
+        </projected_crs>
+        <geographic_crs id="Geographic coordinates">
+            <spec language="PROJ.4">+proj=latlong +datum=WGS84</spec>
+            <ref_point_deg lat="40.02021349" lon="-105.00001013"/>
+        </geographic_crs>
+    </georeferencing>
+    <colors count="1">
+        <color priority="0" name="Purple" c="0.2" m="1" y="0" k="0" opacity="1">
+            <spotcolors>
+                <namedcolor>PURPLE</namedcolor>
+            </spotcolors>
+            <cmyk method="custom"/>
+            <rgb method="cmyk" r="0.8" g="0" b="1"/>
+        </color>
+    </colors>
+    <barrier version="6" required="0.6.0">
+        <symbols count="1">
+            <symbol type="2" id="0" code="1" name="Line">
+                <line_symbol color="0" line_width="100" minimum_length="0" join_style="1" cap_style="0" start_offset="0" end_offset="0" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
+            </symbol>
+        </symbols>
+        <parts count="1" current="0">
+            <part name="default part">
+                <objects count="1">
+                    <object type="1" symbol="0">
+                        <coords count="5">
+                            <coord x="-158217" y="170205"/>
+                            <coord x="-157505" y="175272"/>
+                            <coord x="-150981" y="174356"/>
+                            <coord x="-151693" y="169288"/>
+                            <coord x="-158217" y="170205" flags="18"/>
+                        </coords>
+                        <pattern rotation="0">
+                            <coord x="0" y="0"/>
+                        </pattern>
+                    </object>
+                </objects>
+            </part>
+        </parts>
+        <templates count="1" first_front_template="1">
+            <template type="OgrTemplate" open="true" name="template-track-NA-2019.gpx" path="template-track-NA-2019.gpx" relpath="template-track-NA-2019.gpx" georef="true">
+                <crs_spec>+proj=latlong +datum=WGS84</crs_spec>
+            </template>
+            <defaults use_meters_per_pixel="true" meters_per_pixel="0" dpi="0" scale="0"/>
+        </templates>
+        <view>
+            <grid color="#646464" display="0" alignment="1" additional_rotation="0" unit="0" h_spacing="0.1" v_spacing="0.1" h_offset="0" v_offset="0" snapping_enabled="true"/>
+            <map_view zoom="32" position_x="-154564" position_y="171849">
+                <map opacity="1" visible="true"/>
+                <templates count="1">
+                    <ref template="0" visible="true" opacity="1"/>
+                </templates>
+            </map_view>
+        </view>
+    </barrier>
+</map>

--- a/test/data/templates/template-track-NA-093-PROJ.xmap
+++ b/test/data/templates/template-track-NA-093-PROJ.xmap
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns="http://openorienteering.org/apps/mapper/xml/v2" version="9">
+    <notes></notes>
+    <georeferencing scale="4000" auxiliary_scale_factor="1.0004" declination="8" grivation="8">
+        <projected_crs id="EPSG">
+            <spec language="PROJ.4">+init=epsg:6342</spec>
+            <parameter>6342</parameter>
+            <ref_point x="500000" y="4430000"/>
+        </projected_crs>
+        <geographic_crs id="Geographic coordinates">
+            <spec language="PROJ.4">+proj=latlong +datum=WGS84</spec>
+            <ref_point_deg lat="40.02021349" lon="-105.00001013"/>
+        </geographic_crs>
+    </georeferencing>
+    <colors count="1">
+        <color priority="0" name="Purple" c="0.2" m="1" y="0" k="0" opacity="1">
+            <spotcolors>
+                <namedcolor>PURPLE</namedcolor>
+            </spotcolors>
+            <cmyk method="custom"/>
+            <rgb method="cmyk" r="0.8" g="0" b="1"/>
+        </color>
+    </colors>
+    <barrier version="6" required="0.6.0">
+        <symbols count="1">
+            <symbol type="2" id="0" code="1" name="Line">
+                <line_symbol color="0" line_width="100" minimum_length="0" join_style="1" cap_style="0" start_offset="0" end_offset="0" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
+            </symbol>
+        </symbols>
+        <parts count="1" current="0">
+            <part name="default part">
+                <objects count="1">
+                    <object type="1" symbol="0">
+                        <coords count="5">
+                            <coord x="-157978" y="170354"/>
+                            <coord x="-157266" y="175421"/>
+                            <coord x="-150742" y="174504"/>
+                            <coord x="-151454" y="169437"/>
+                            <coord x="-157978" y="170354" flags="18"/>
+                        </coords>
+                        <pattern rotation="0">
+                            <coord x="0" y="0"/>
+                        </pattern>
+                    </object>
+                </objects>
+            </part>
+        </parts>
+        <templates count="1" first_front_template="1">
+            <template type="TemplateTrack" open="true" name="template-track-NA-2019.gpx" path="template-track-NA-2019.gpx" relpath="template-track-NA-2019.gpx" georef="true">
+                <crs_spec>+proj=latlong +datum=WGS84</crs_spec>
+            </template>
+            <defaults use_meters_per_pixel="true" meters_per_pixel="0" dpi="0" scale="0"/>
+        </templates>
+        <view>
+            <grid color="#646464" display="0" alignment="1" additional_rotation="0" unit="0" h_spacing="0.1" v_spacing="0.1" h_offset="0" v_offset="0" snapping_enabled="true"/>
+            <map_view zoom="32" position_x="-154449" position_y="172553">
+                <map opacity="1" visible="true"/>
+                <templates count="1">
+                    <ref template="0" visible="true" opacity="1"/>
+                </templates>
+            </map_view>
+        </view>
+    </barrier>
+</map>

--- a/test/data/templates/template-track-NA-2019.gpx
+++ b/test/data/templates/template-track-NA-2019.gpx
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="OpenOrienteering Mapper 0.9.4">
+<trk>
+<trkseg>
+<trkpt lat="40.0149205" lon="-105.0084468"><time>2019-09-23T20:53:53Z</time><ele>1628.14</ele><hdop>1.000</hdop></trkpt>
+<trkpt lat="40.0147469" lon="-105.0084468"><time>2019-09-23T20:53:54Z</time><ele>1628.14</ele><hdop>1.000</hdop></trkpt>
+<trkpt lat="40.0147469" lon="-105.0081521"><time>2019-09-23T20:53:55Z</time><ele>1628.14</ele><hdop>1.000</hdop></trkpt>
+<trkpt lat="40.0149205" lon="-105.0081521"><time>2019-09-23T20:53:57Z</time><ele>1628.14</ele><hdop>1.000</hdop></trkpt>
+<trkpt lat="40.0149205" lon="-105.0084468"><time>2019-09-23T20:53:58Z</time><ele>1628.14</ele><hdop>1.000</hdop></trkpt>
+</trkseg>
+</trk>
+</gpx>

--- a/test/data/templates/template-track-NA.xmap
+++ b/test/data/templates/template-track-NA.xmap
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns="http://openorienteering.org/apps/mapper/xml/v2" version="9">
+    <notes></notes>
+    <georeferencing scale="4000" auxiliary_scale_factor="1.0004" declination="8" grivation="8">
+        <projected_crs id="EPSG">
+            <spec language="PROJ.4">+init=epsg:6342</spec>
+            <parameter>6342</parameter>
+            <ref_point x="500000" y="4430000"/>
+        </projected_crs>
+        <geographic_crs id="Geographic coordinates">
+            <spec language="PROJ.4">+proj=latlong +datum=WGS84</spec>
+            <ref_point_deg lat="40.02021349" lon="-105.00001013"/>
+        </geographic_crs>
+    </georeferencing>
+    <colors count="1">
+        <color priority="0" name="Purple" c="0.2" m="1" y="0" k="0" opacity="1">
+            <spotcolors>
+                <namedcolor>PURPLE</namedcolor>
+            </spotcolors>
+            <cmyk method="custom"/>
+            <rgb method="cmyk" r="0.8" g="0" b="1"/>
+        </color>
+    </colors>
+    <barrier version="6" required="0.6.0">
+        <symbols count="1">
+            <symbol type="2" id="0" code="1" name="Line">
+                <line_symbol color="0" line_width="100" minimum_length="0" join_style="1" cap_style="0" start_offset="0" end_offset="0" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
+            </symbol>
+        </symbols>
+        <parts count="1" current="0">
+            <part name="default part">
+                <objects count="4">
+                    <object type="1" symbol="0">
+                        <coords count="2">
+                            <coord x="-157121" y="175794"/>
+                            <coord x="-157952" y="169878" flags="16"/>
+                        </coords>
+                        <pattern rotation="0">
+                            <coord x="0" y="0"/>
+                        </pattern>
+                    </object>
+                    <object type="1" symbol="0">
+                        <coords count="2">
+                            <coord x="-150597" y="174877"/>
+                            <coord x="-151429" y="168961"/>
+                        </coords>
+                        <pattern rotation="0">
+                            <coord x="0" y="0"/>
+                        </pattern>
+                    </object>
+                    <object type="1" symbol="0">
+                        <coords count="2">
+                            <coord x="-157646" y="175435"/>
+                            <coord x="-150191" y="174387"/>
+                        </coords>
+                        <pattern rotation="0">
+                            <coord x="0" y="0"/>
+                        </pattern>
+                    </object>
+                    <object type="1" symbol="0">
+                        <coords count="2">
+                            <coord x="-158358" y="170367"/>
+                            <coord x="-150904" y="169320"/>
+                        </coords>
+                        <pattern rotation="0">
+                            <coord x="0" y="0"/>
+                        </pattern>
+                    </object>
+                </objects>
+            </part>
+        </parts>
+        <templates count="8" first_front_template="0">
+            <template type="TemplateTrack" open="true" name="template-track-NA-2019.gpx" path="template-track-NA-2019.gpx" relpath="template-track-NA-2019.gpx" georef="true">
+                <crs_spec>+proj=latlong +datum=WGS84</crs_spec>
+            </template>
+            <template type="TemplateTrack" open="true" name="template-track-NA-2014.gpx" path="template-track-NA-2014.gpx" relpath="template-track-NA-2014.gpx" georef="true">
+                <crs_spec>+proj=latlong +datum=WGS84</crs_spec>
+            </template>
+            <template type="TemplateTrack" open="true" name="template-track-NA-2013.gpx" path="template-track-NA-2013.gpx" relpath="template-track-NA-2013.gpx" georef="true">
+                <crs_spec>+proj=latlong +datum=WGS84</crs_spec>
+            </template>
+            <template type="TemplateTrack" open="true" name="template-track-NA-2012.gpx" path="template-track-NA-2012.gpx" relpath="template-track-NA-2012.gpx" georef="true">
+                <crs_spec>+proj=latlong +datum=WGS84</crs_spec>
+            </template>
+            <template type="TemplateTrack" open="true" name="template-track-NA-2003.gpx" path="template-track-NA-2003.gpx" relpath="template-track-NA-2003.gpx" georef="true">
+                <crs_spec>+proj=latlong +datum=WGS84</crs_spec>
+            </template>
+            <template type="TemplateTrack" open="true" name="template-track-NA-2001.gpx" path="template-track-NA-2001.gpx" relpath="template-track-NA-2001.gpx" georef="true">
+                <crs_spec>+proj=latlong +datum=WGS84</crs_spec>
+            </template>
+            <template type="TemplateTrack" open="true" name="template-track-NA-1997.gpx" path="template-track-NA-1997.gpx" relpath="template-track-NA-1997.gpx" georef="true">
+                <crs_spec>+proj=latlong +datum=WGS84</crs_spec>
+            </template>
+            <template type="OgrTemplate" open="true" name="template-track-NA-2019.gpx" path="template-track-NA-2019.gpx" relpath="template-track-NA-2019.gpx" georef="true">
+                <crs_spec>+proj=latlong +datum=WGS84</crs_spec>
+            </template>
+            <defaults use_meters_per_pixel="true" meters_per_pixel="0" dpi="0" scale="0"/>
+        </templates>
+        <view>
+            <grid color="#80646464" display="0" alignment="1" additional_rotation="0" unit="1" h_spacing="1" v_spacing="1" h_offset="0" v_offset="0" snapping_enabled="true"/>
+            <map_view zoom="16" position_x="-155208" position_y="173045">
+                <map opacity="1" visible="true"/>
+                <templates count="8">
+                    <ref template="0" visible="true" opacity="1"/>
+                    <ref template="1" visible="true" opacity="1"/>
+                    <ref template="2" visible="true" opacity="1"/>
+                    <ref template="3" visible="true" opacity="1"/>
+                    <ref template="4" visible="true" opacity="1"/>
+                    <ref template="5" visible="true" opacity="1"/>
+                    <ref template="6" visible="true" opacity="1"/>
+                    <ref template="7" visible="true" opacity="1"/>
+                </templates>
+            </map_view>
+        </view>
+    </barrier>
+</map>

--- a/test/template_t.cpp
+++ b/test/template_t.cpp
@@ -359,6 +359,64 @@ private slots:
 		QCOMPARE(qRound(latlon.latitude()), 50);
 		QCOMPARE(qRound(latlon.longitude()), 8);
 	}
+	
+	void templateTypesConsistentTest_data()
+	{
+		QTest::addColumn<QString>("map_file");
+		QTest::addColumn<int>("template_index");
+
+		QTest::newRow("TemplateTrack georef")     << QStringLiteral("testdata:templates/template-track.xmap") << 0;
+		QTest::newRow("TemplateTrack OGR georef") << QStringLiteral("testdata:templates/template-track.xmap") << 2;
+		QTest::newRow("TemplateTrack NAD83")      << QStringLiteral("testdata:templates/template-track-NA.xmap") << 0;
+		QTest::newRow("TemplateTrack OGR NAD83")  << QStringLiteral("testdata:templates/template-track-NA.xmap") << 7;
+	}
+	
+	void templateTypesConsistentTest()
+	{
+		GdalManager().setFormatEnabled(GdalManager::GPX, false);
+		
+		QFETCH(QString, map_file);
+		QFETCH(int, template_index);
+		
+		QPointF template_track_center;
+		{
+			Map map;
+			MapView view{ &map };
+			QVERIFY(map.loadFrom(map_file, &view));
+
+			QVERIFY(map.getNumTemplates() > template_index);
+			auto const* temp = map.getTemplate(template_index);
+			QCOMPARE(temp->getTemplateType(), "TemplateTrack");
+			QCOMPARE(temp->getTemplateState(), Template::Unloaded);
+			QVERIFY(map.getTemplate(template_index)->loadTemplateFile());
+			QCOMPARE(temp->getTemplateState(), Template::Loaded);
+
+			template_track_center = center(temp);
+		}
+
+		GdalManager().setFormatEnabled(GdalManager::GPX, true);
+		
+		QPointF ogr_template_center;
+		{
+			Map map;
+			MapView view{ &map };
+			QVERIFY(map.loadFrom(map_file, &view));
+
+			QVERIFY(map.getNumTemplates() > template_index);
+			auto const* temp = map.getTemplate(template_index);
+			QCOMPARE(temp->getTemplateType(), "OgrTemplate");
+			QCOMPARE(temp->getTemplateState(), Template::Unloaded);
+			QVERIFY(map.getTemplate(template_index)->loadTemplateFile());
+			QCOMPARE(temp->getTemplateState(), Template::Loaded);
+
+			ogr_template_center = center(temp);
+		
+		}
+		if (QLineF(ogr_template_center, template_track_center).length() > 0.1) // 40 cm
+			QCOMPARE(ogr_template_center, template_track_center);
+		else
+			QVERIFY2(true, "Centers do match");
+	}
 #endif
 	
 	void templateRotationTest_data()

--- a/test/template_t.cpp
+++ b/test/template_t.cpp
@@ -274,6 +274,8 @@ private slots:
 		QTest::newRow("TemplateTrack non-georef")     << QStringLiteral("testdata:templates/template-track.xmap") << 1;
 		QTest::newRow("TemplateTrack OGR georef")     << QStringLiteral("testdata:templates/template-track.xmap") << 2;
 		QTest::newRow("TemplateTrack OGR non-georef") << QStringLiteral("testdata:templates/template-track.xmap") << 3;
+		QTest::newRow("TemplateTrack from v0.8.4")    << QStringLiteral("testdata:templates/template-track-NA-084.xmap") << 0;
+		QTest::newRow("TemplateTrack from v0.9.3")    << QStringLiteral("testdata:templates/template-track-NA-093-PROJ.xmap") << 0;
 	}
 	
 	void templateTrackTest()
@@ -315,6 +317,8 @@ private slots:
 		QTest::newRow("TemplateTrack OGR non-georef") << QStringLiteral("testdata:templates/template-track.xmap") << 3;
 		QTest::newRow("OgrTemplate basic")            << QStringLiteral("testdata:templates/ogr-template.xmap")   << 0;
 		QTest::newRow("OgrTemplate compatibility")    << QStringLiteral("testdata:templates/ogr-template.xmap")   << 1;
+		QTest::newRow("TemplateTrack from v0.8.4")    << QStringLiteral("testdata:templates/template-track-NA-084.xmap") << 0;
+		QTest::newRow("OGRTemplate from v0.9.3")      << QStringLiteral("testdata:templates/template-track-NA-093-GDAL.xmap") << 0;
 	}
 	
 	void ogrTemplateTest()

--- a/test/template_t.cpp
+++ b/test/template_t.cpp
@@ -67,19 +67,10 @@ using namespace OpenOrienteering;
 namespace
 {
 
-QPointF center(const TemplateTrack* temp)
-{
-	QPicture picture;
-	QPainter painter(&picture);
-	temp->drawTracks(&painter, false);
-	painter.end();
-	return QRectF(picture.boundingRect()).center();
-}
-
 QPointF center(const Template* temp)
 {
 	if (auto* template_track = qobject_cast<const TemplateTrack*>(temp))
-		return center(template_track);
+		return template_track->getCenter();
 	return temp->templateToMap(temp->getTemplateExtent().center());
 }
 
@@ -306,7 +297,7 @@ private slots:
 		QCOMPARE(temp->getTemplateState(), Template::Loaded);
 
 		auto const expected_center = map.calculateExtent().center();
-		if (QLineF(center(temp), expected_center).length() > 0.5)
+		if (QLineF(center(temp), expected_center).length() > 0.125) // 50 cm
 			QCOMPARE(center(temp), expected_center);
 		else
 			QVERIFY2(true, "Centers do match");
@@ -345,7 +336,7 @@ private slots:
 		QCOMPARE(temp->getTemplateState(), Template::Loaded);
 
 		auto const expected_center = map.calculateExtent().center();
-		if (QLineF(center(temp), expected_center).length() > 0.5)
+		if (QLineF(center(temp), expected_center).length() > 0.25) // 1 m
 			QCOMPARE(center(temp), expected_center);
 		else
 			QVERIFY2(true, "Centers do match");


### PR DESCRIPTION
This adds tests to `template_t `'s `templateTrackTest` and `ogrTemplateTest` which

- Check that an object created from a GPX track using v0.8.4 remains in the same position relative to the track.
- Check that an object created from a GPX track using v0.9.3 remains in the same position relative to the track.

It also adds `templateTypesConsistentTest` which checks that a track is positioned the same, independent of whether GDAL loading of GPX tracks is enabled.

These tests use maps georeferenced with EPSG:6342 which is based on the NAD 83 (2011) datum. They check for the issues mentioned in the discussion of #1709 "GPX tracks display in different position on desktop vs. Android (regression)" and thus several of them fail as of v0.9.4.

The tolerances used in these tests have been changed arbitrarily, to better demonstrate the tests' effectiveness. 