### PR TITLE
treewide: Fix warnings reported by Clang 11

### DIFF
--- a/3rd-party/cove/libvectorizer/Concurrency.h
+++ b/3rd-party/cove/libvectorizer/Concurrency.h
@@ -46,7 +46,7 @@ namespace Concurrency {
  * is const in order to ensure thread safety also in accessing this object
  * (cf. std::shared_ptr documentation).
  */
-class Progress : public ProgressObserver
+class Progress final : public ProgressObserver
 {
 private:
 	struct Data
@@ -62,7 +62,7 @@ public:
 	Progress(Progress&& p) = delete;
 	Progress& operator=(const Progress&) = delete;
 	Progress& operator=(Progress&& p) = delete;
-	~Progress() final = default;
+	~Progress() = default;
 	
 	int getPercentage() const noexcept;
 	void setPercentage(int percentage) final;

--- a/src/core/objects/object.h
+++ b/src/core/objects/object.h
@@ -1292,7 +1292,7 @@ double ObjectPathCoord::findClosestPointTo(const MapCoordF& map_coord)
 inline
 constexpr ObjectPathCoord::operator bool() const
 {
-	return bool { object };
+	return static_cast<bool>(object);
 }
 
 }  // namespace OpenOrienteering

--- a/src/gdal/ogr_file_format.cpp
+++ b/src/gdal/ogr_file_format.cpp
@@ -502,10 +502,10 @@ namespace {
 	 * 
 	 * \see CutoutOperation::operator()
 	 */
-	class ClippingImplementation : public OgrFileImport::Clipping
+	class ClippingImplementation final : public OgrFileImport::Clipping
 	{
 	public:
-		~ClippingImplementation() final = default;
+		~ClippingImplementation() = default;
 		
 		explicit ClippingImplementation(MapCoordVector boundary)
 		: tool { BooleanTool::Intersection, nullptr }


### PR DESCRIPTION
A tiny change which will make build with Clang 11 possible in Fedora 33 and openSUSE Tumbleweed.