### PR TITLE
OgrFileImport: Initialize data_srs on construction

### DIFF
--- a/src/gdal/ogr_file_format_p.h
+++ b/src/gdal/ogr_file_format_p.h
@@ -349,7 +349,7 @@ private:
 	
 	ogr::unique_srs map_srs;
 	
-	OGRSpatialReferenceH data_srs;
+	OGRSpatialReferenceH data_srs = {};
 	
 	ogr::unique_transformation data_transform;
 	


### PR DESCRIPTION
This commit fixes a bug found by Valgrind. This is a minimal fix to the issue at hand, which raises a question of to what degree we want to adhere to the ES.20 (Always initialize an object) guideline. `OgrFileImport` class contains, in its `private:` section, an even mix of constructor-initialized members and member-initialized ones. For instance, the `default_*_symbol` members are initialized in the single class constructor, and the many POD members (`empty_geometries`, `no_transformation`, ...) have default member initializers. `OGRSpatialReferenceH`, which is a pointer in disguise, fell through the cracks.

Do we want to routinely provide in-class default member initializers for anything that might potentially be a POD, or do we stick to the current habits and rely on specialized tools to spot the bugs?