### PR TITLE
Add CRS selection for geospatial vector data (`OgrTemplate`)

### DIFF
--- a/code-check-wrapper.sh
+++ b/code-check-wrapper.sh
@@ -100,6 +100,7 @@ for I in \
   template_list_widget.cpp \
   template_map.cpp \
   template_placeholder.cpp \
+  template_positioning_dialog.cpp \
   template_table_model.cpp \
   template_t.cpp \
   template_tool \

--- a/code-check-wrapper.sh
+++ b/code-check-wrapper.sh
@@ -51,6 +51,7 @@ for I in \
   boolean_tool.cpp \
   combined_symbol.cpp \
   configure_grid_dialog.cpp \
+  coordinate_system.cpp \
   crs_param_widgets.cpp \
   crs_template.cpp \
   crs_template_implementation.cpp \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,6 +85,7 @@ set(Mapper_Common_SRCS
   
   core/app_permissions.cpp
   core/autosave.cpp
+  core/coordinate_system.cpp
   core/crs_template.cpp
   core/crs_template_implementation.cpp
   core/georeferencing.cpp

--- a/src/core/coordinate_system.cpp
+++ b/src/core/coordinate_system.cpp
@@ -1,0 +1,23 @@
+/*
+ *    Copyright 2020 Kai Pastor
+ *
+ *    This file is part of OpenOrienteering.
+ *
+ *    OpenOrienteering is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OpenOrienteering is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "coordinate_system.h"
+
+// header-only ATM

--- a/src/core/coordinate_system.h
+++ b/src/core/coordinate_system.h
@@ -1,0 +1,41 @@
+/*
+ *    Copyright 2020 Kai Pastor
+ *
+ *    This file is part of OpenOrienteering.
+ *
+ *    OpenOrienteering is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OpenOrienteering is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#ifndef OPENORIENTEERING_COORDINATE_SYSTEM_H
+#define OPENORIENTEERING_COORDINATE_SYSTEM_H
+
+namespace OpenOrienteering {
+
+namespace CoordinateSystem {
+
+/**
+ * Identifies the domain of a coordinate system.
+ */
+enum Domain {
+	DomainMap,          ///< Data refers to map (paper) coordinates, base: 1 mm.
+	DomainGround,       ///< Data refers to (real) ground coordinates, base 1 m.
+};
+
+
+}  // namespace CoordinateSystem
+
+}  // namespace OpenOrienteering
+
+#endif

--- a/src/core/coordinate_system.h
+++ b/src/core/coordinate_system.h
@@ -31,6 +31,7 @@ namespace CoordinateSystem {
 enum Domain {
 	DomainMap,          ///< Data refers to map (paper) coordinates, base: 1 mm.
 	DomainGround,       ///< Data refers to (real) ground coordinates, base 1 m.
+	DomainGeospatial,   ///< Data is georeferenced, base depending on CRS (possibly degrees!).
 };
 
 

--- a/src/gdal/ogr_file_format.cpp
+++ b/src/gdal/ogr_file_format.cpp
@@ -686,21 +686,21 @@ bool OgrFileImport::canRead(const QString& path)
 }
 
 
-OgrFileImport::OgrFileImport(const QString& path, Map* map, MapView* view, UnitType unit_type)
+OgrFileImport::OgrFileImport(const QString& path, Map* map, MapView* view, CoordinateSystem::Domain cs_domain)
  : Importer(path, map, view)
  , manager{ OGR_SM_Create(nullptr) }
- , unit_type{ unit_type }
+ , cs_domain{ cs_domain }
 {
 	GdalManager manager;
 	manager.configure();
 	
-	switch (unit_type)
+	switch (cs_domain)
 	{
-	case UnitOnPaper:
+	case CoordinateSystem::DomainMap:
 		to_map_coord = &OgrFileImport::fromDrawing;
 		break;
 		
-	case UnitOnGround:
+	case CoordinateSystem::DomainGround:
 		to_map_coord = &OgrFileImport::fromProjected;
 		break;
 	}
@@ -1343,7 +1343,7 @@ std::unique_ptr<OgrFileImport::Clipping> OgrFileImport::getLayerClipping(OGRLaye
 
 bool OgrFileImport::setSRS(OGRSpatialReferenceH srs)
 {
-	if (unit_type == UnitOnPaper)
+	if (cs_domain == CoordinateSystem::DomainMap)
 	{
 		return true;
 	}

--- a/src/gdal/ogr_file_format.cpp
+++ b/src/gdal/ogr_file_format.cpp
@@ -701,6 +701,7 @@ OgrFileImport::OgrFileImport(const QString& path, Map* map, MapView* view, Coord
 		break;
 		
 	case CoordinateSystem::DomainGround:
+	case CoordinateSystem::DomainGeospatial:
 		to_map_coord = &OgrFileImport::fromProjected;
 		break;
 	}
@@ -1355,8 +1356,18 @@ bool OgrFileImport::setSRS(OGRSpatialReferenceH srs)
 	
 	if (!srs)
 	{
-		data_srs = {};
-		data_transform = {};
+		if (cs_domain == CoordinateSystem::DomainGround)
+		{
+			// Ground CS data doesn't need a SRS.
+			data_srs = {};
+			data_transform = {};
+		}
+		else
+		{
+			// Geospatial data is required to have a SRS.
+			++no_transformation;
+			return false;
+		}
 	}
 	else if (data_srs != srs)
 	{

--- a/src/gdal/ogr_file_format_p.h
+++ b/src/gdal/ogr_file_format_p.h
@@ -38,6 +38,7 @@
 #include <ogr_srs_api.h>
 // IWYU pragma: no_include <ogr_core.h>
 
+#include "core/coordinate_system.h"
 #include "core/map_coord.h"
 #include "core/symbols/symbol.h"
 #include "fileformats/file_import_export.h"
@@ -208,15 +209,6 @@ public:
 	static bool canRead(const QString& path);
 	
 	/**
-	 * The unit type indicates the coordinate system the data units refers to.
-	 */
-	enum UnitType
-	{
-		UnitOnGround,  ///< Data refers to real dimensions. Includes geograghic CS.
-		UnitOnPaper    ///< Data refers to dimensions in the (printed) map.
-	};
-	
-	/**
 	 * A Pointer to a function which creates a MapCoordF from double coordinates.
 	 */
 	using MapCoordConstructor = MapCoord (OgrFileImport::*)(double, double) const;
@@ -224,7 +216,7 @@ public:
 	/**
 	 * Constructs a new importer.
 	 */
-	OgrFileImport(const QString& path, Map *map, MapView *view, UnitType unit_type = UnitOnGround);
+	OgrFileImport(const QString& path, Map *map, MapView *view, CoordinateSystem::Domain unit_type = CoordinateSystem::DomainGround);
 	
 	~OgrFileImport() override;
 	
@@ -379,7 +371,7 @@ private:
 	int unsupported_geometry_type = 0;
 	int too_few_coordinates = 0;
 	
-	UnitType unit_type;
+	CoordinateSystem::Domain cs_domain;
 	
 	bool georeferencing_import_enabled = true;
 	bool clip_layers;

--- a/src/gdal/ogr_template.cpp
+++ b/src/gdal/ogr_template.cpp
@@ -60,6 +60,8 @@ namespace {
 		const auto crs_spec           = QLatin1String("crs_spec");
 		const auto georeferencing     = QLatin1String("georeferencing");
 		const auto projected_crs_spec = QLatin1String("projected_crs_spec");
+		const auto srs                = QLatin1String("srs");
+		const auto map                = QLatin1String("map");
 	}
 	
 	
@@ -462,6 +464,12 @@ bool OgrTemplate::loadTypeSpecificTemplateConfiguration(QXmlStreamReader& xml)
 		projected_crs_spec = xml.readElementText();
 		template_track_compatibility = true;
 	}
+	else if (xml.name() == literal::srs)
+	{
+		auto srs = xml.readElementText();
+		if (srs == literal::map)
+			cs_domain = CoordinateSystem::DomainMap;
+	}
 	else
 	{
 		xml.skipCurrentElement();
@@ -516,6 +524,10 @@ void OgrTemplate::saveTypeSpecificTemplateConfiguration(QXmlStreamWriter& xml) c
 		xml.writeTextElement(literal::crs_spec, track_crs_spec);
 		if (!projected_crs_spec.isEmpty())
 			xml.writeTextElement(literal::projected_crs_spec, projected_crs_spec);
+	}
+	else if (cs_domain == CoordinateSystem::DomainMap)
+	{
+		xml.writeTextElement(literal::srs, literal::map);
 	}
 	else if (explicit_georef)
 	{

--- a/src/gdal/ogr_template.cpp
+++ b/src/gdal/ogr_template.cpp
@@ -290,17 +290,9 @@ try
 		return false;
 	
 	center_in_view  = dialog.centerOnView();
-	auto const use_real_coords = dialog.useRealCoords();
-	if (use_real_coords)
-	{
-		cs_domain = CoordinateSystem::DomainGround;
-		transform.template_scale_x = transform.template_scale_y = dialog.getUnitScale();
-		updateTransformationMatrices();
-	}
-	else
-	{
-		cs_domain = CoordinateSystem::DomainMap;
-	}
+	cs_domain = dialog.csDomain();
+	transform.template_scale_x = transform.template_scale_y = dialog.unitScaleFactor();
+	updateTransformationMatrices();
 	
 	return true;
 }

--- a/src/gdal/ogr_template.cpp
+++ b/src/gdal/ogr_template.cpp
@@ -285,7 +285,7 @@ try
 		projected_crs_spec = explicit_georef->getProjectedCRSSpec();
 	}
 	
-	TemplatePositioningDialog dialog(dialog_parent);
+	TemplatePositioningDialog dialog(getTemplateFilename(), dialog_parent);
 	if (dialog.exec() == QDialog::Rejected)
 		return false;
 	

--- a/src/gdal/ogr_template.h
+++ b/src/gdal/ogr_template.h
@@ -81,12 +81,16 @@ public:
 	 * Loads the geospatial vector data into the template_map.
 	 * 
 	 * If is_georereferenced is true, the template_map will be configured to use
-	 * the georeferencing of the map given in the constructor, and OgrFileImportFormat
-	 * will let OGR do coordinate transformations as needed.
+	 * the explicit_georef if defined, or the georeferencing of the map given in
+	 * the constructor otherwise.
+	 * OgrFileImport will let OGR do coordinate transformations as needed and
+	 * possible. Data which is not georeferenced will be dropped.
 	 * 
 	 * If is_georeferenced is false and an explicit_georef is defined, the
-	 * template_map will be configured to use this particular georeferencing
-	 * to produce a projection of the original data.
+	 * template_map will be configured to use this particular georeferencing.
+	 * OgrFileImport will let OGR do coordinate transformations as needed and
+	 * possible. Data which is not georeferenced will be assumed to have map
+	 * coordinates. This is for legacy template track compatibility.
 	 * 
 	 * Otherwise, the data will be handled as raw ground or paper units,
 	 * depending on cs_domain.
@@ -116,6 +120,7 @@ private:
 	std::unique_ptr<Georeferencing> map_configuration_georef;
 	QString track_crs_spec;           // (limited) TemplateTrack compatibility
 	QString projected_crs_spec;       // (limited) TemplateTrack compatibility
+	QString data_crs_spec;
 	CoordinateSystem::Domain cs_domain { CoordinateSystem::DomainGround };  //  transient
 	bool template_track_compatibility { false };  //  transient
 	bool explicit_georef_pending      { false };  //  transient

--- a/src/gdal/ogr_template.h
+++ b/src/gdal/ogr_template.h
@@ -26,6 +26,7 @@
 #include <QObject>
 #include <QString>
 
+#include "core/coordinate_system.h"
 #include "templates/template_map.h"
 
 class QByteArray;
@@ -87,8 +88,8 @@ public:
 	 * template_map will be configured to use this particular georeferencing
 	 * to produce a projection of the original data.
 	 * 
-	 * Otherwise, the data will be handled as raw map or paper data, depending on
-	 * use_real_coords.
+	 * Otherwise, the data will be handled as raw ground or paper units,
+	 * depending on cs_domain.
 	 */
 	bool loadTemplateFileImpl() override;
 	
@@ -115,9 +116,9 @@ private:
 	std::unique_ptr<Georeferencing> map_configuration_georef;
 	QString track_crs_spec;           // (limited) TemplateTrack compatibility
 	QString projected_crs_spec;       // (limited) TemplateTrack compatibility
+	CoordinateSystem::Domain cs_domain { CoordinateSystem::DomainGround };  //  transient
 	bool template_track_compatibility { false };  //  transient
 	bool explicit_georef_pending      { false };  //  transient
-	bool use_real_coords              { true };   //  transient
 	bool center_in_view               { false };  //  transient
 };
 

--- a/src/templates/template_positioning_dialog.cpp
+++ b/src/templates/template_positioning_dialog.cpp
@@ -28,6 +28,7 @@
 #include <QFormLayout>
 #include <QRadioButton>
 #include <QSpacerItem>
+#include <QVBoxLayout>
 
 #include "gui/util_gui.h"
 #include "templates/template_image_open_dialog.h"
@@ -52,24 +53,32 @@ TemplatePositioningDialog::TemplatePositioningDialog(const QString& display_name
 	coord_system_box->addItem(tr("Map"));
 	coord_system_box->setCurrentIndex(0);
 	
+	layout->addItem(Util::SpacerItem::create(this));
+	
 	unit_scale_edit = Util::SpinBox::create(6, 0, 99999.999999, tr("m", "meters"));
 	unit_scale_edit->setValue(1);
 	unit_scale_edit->setEnabled(false);
 	layout->addRow(tr("One coordinate unit equals:"), unit_scale_edit);
 	
-	original_pos_radio = new QRadioButton(tr("Position track at given coordinates"));
+	layout->addItem(Util::SpacerItem::create(this));
+	
+	original_pos_radio = new QRadioButton(tr("Position data at given coordinates"));
 	original_pos_radio->setChecked(true);
 	layout->addRow(original_pos_radio);
 	
-	view_center_radio = new QRadioButton(tr("Position track at view center"));
+	view_center_radio = new QRadioButton(tr("Position data at view center"));
 	layout->addRow(view_center_radio);
 	
 	layout->addItem(Util::SpacerItem::create(this));
 	
-	auto button_box = new QDialogButtonBox(QDialogButtonBox::Cancel | QDialogButtonBox::Ok);
-	layout->addWidget(button_box);
+	auto* vbox_layout = new QVBoxLayout();
+	vbox_layout->addLayout(layout);
+	vbox_layout->addStretch(1);
 	
-	setLayout(layout);
+	auto* button_box = new QDialogButtonBox(QDialogButtonBox::Cancel | QDialogButtonBox::Ok);
+	vbox_layout->addWidget(button_box);
+	
+	setLayout(vbox_layout);
 	
 	connect(button_box, &QDialogButtonBox::accepted, this, &QDialog::accept);
 	connect(button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);

--- a/src/templates/template_positioning_dialog.cpp
+++ b/src/templates/template_positioning_dialog.cpp
@@ -124,6 +124,10 @@ void TemplatePositioningDialog::updateWidgets()
 {
 	switch (csDomain())
 	{
+	case CoordinateSystem::DomainGeospatial:
+		Q_UNREACHABLE();
+		Q_FALLTHROUGH();
+		
 	case CoordinateSystem::DomainGround:  // Real
 		unit_scale_edit->setMinimum(0.0001);
 		unit_scale_edit->setDecimals(3);

--- a/src/templates/template_positioning_dialog.cpp
+++ b/src/templates/template_positioning_dialog.cpp
@@ -24,16 +24,19 @@
 #include <Qt>
 #include <QtGlobal>
 #include <QChar>
-#include <QComboBox>
 #include <QDialogButtonBox>
 #include <QDoubleSpinBox>
 #include <QFormLayout>
+#include <QLabel>
+#include <QLatin1String>
+#include <QPushButton>
 #include <QRadioButton>
 #include <QSpacerItem>
-#include <QVariant>
 #include <QVBoxLayout>
 
+#include "core/georeferencing.h"
 #include "gui/util_gui.h"
+#include "gui/widgets/crs_selector.h"
 #include "templates/template_image_open_dialog.h"
 #include "util/backports.h"  // IWYU pragma: keep
 
@@ -46,7 +49,7 @@ class MapCoordF;
 // not inline
 TemplatePositioningDialog::~TemplatePositioningDialog() = default;
 
-TemplatePositioningDialog::TemplatePositioningDialog(const QString& display_name, QWidget* parent)
+TemplatePositioningDialog::TemplatePositioningDialog(const QString& display_name, const Georeferencing& data_georef, QWidget* parent)
 : QDialog(parent, Qt::WindowSystemMenuHint | Qt::WindowTitleHint)
 {
 	setWindowModality(Qt::WindowModal);
@@ -54,18 +57,25 @@ TemplatePositioningDialog::TemplatePositioningDialog(const QString& display_name
 	
 	auto* layout = new QFormLayout();
 	
-	coord_system_box = new QComboBox();
+	coord_system_box = new CRSSelector(data_georef);
 	layout->addRow(tr("Coordinate system"), coord_system_box);
-	coord_system_box->addItem(tr("Ground"), CoordinateSystem::DomainGround);
-	coord_system_box->addItem(tr("Map"), CoordinateSystem::DomainMap);
-	coord_system_box->setCurrentIndex(0);
-	
-	layout->addItem(Util::SpacerItem::create(this));
 	
 	unit_scale_edit = Util::SpinBox::create(4, 0, 1000.0);
 	unit_scale_edit->setValue(1);
 	unit_scale_edit->setEnabled(false);
 	layout->addRow(tr("One coordinate unit equals:"), unit_scale_edit);
+	
+	status_label = new QLabel();
+	layout->addRow(tr("Status:"), status_label);
+	
+	layout->addItem(Util::SpacerItem::create(this));
+	coord_system_box->setDialogLayout(layout);
+	
+	if (data_georef.getState() == Georeferencing::Geospatial)
+		coord_system_box->addCustomItem(tr("From the data"), CoordinateSystem::DomainGeospatial);
+	coord_system_box->addCustomItem(tr("Ground"), CoordinateSystem::DomainGround);
+	coord_system_box->addCustomItem(tr("Paper"), CoordinateSystem::DomainMap);
+	coord_system_box->setCurrentIndex(0);
 	
 	layout->addItem(Util::SpacerItem::create(this));
 	
@@ -82,12 +92,12 @@ TemplatePositioningDialog::TemplatePositioningDialog(const QString& display_name
 	vbox_layout->addLayout(layout);
 	vbox_layout->addStretch(1);
 	
-	auto* button_box = new QDialogButtonBox(QDialogButtonBox::Cancel | QDialogButtonBox::Ok);
+	button_box = new QDialogButtonBox(QDialogButtonBox::Cancel | QDialogButtonBox::Ok);
 	vbox_layout->addWidget(button_box);
 	
 	setLayout(vbox_layout);
 	
-	connect(coord_system_box, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &TemplatePositioningDialog::updateWidgets);
+	connect(coord_system_box, &CRSSelector::crsChanged, this, &TemplatePositioningDialog::updateWidgets);
 	updateWidgets();
 	
 	connect(button_box, &QDialogButtonBox::accepted, this, &QDialog::accept);
@@ -96,15 +106,14 @@ TemplatePositioningDialog::TemplatePositioningDialog(const QString& display_name
 
 CoordinateSystem::Domain TemplatePositioningDialog::csDomain() const
 {
-	auto const domain = coord_system_box->currentData().toInt();
+	auto const domain = coord_system_box->currentCustomItem();
 	switch (domain)
 	{
 	case CoordinateSystem::DomainMap:
 	case CoordinateSystem::DomainGround:
 		return static_cast<CoordinateSystem::Domain>(domain);
 	default:
-		qDebug("Unexpected domain: %d", domain);
-		return CoordinateSystem::DomainMap;
+		return CoordinateSystem::DomainGeospatial;
 	}
 }
 
@@ -119,14 +128,31 @@ bool TemplatePositioningDialog::centerOnView() const
 }
 
 
+QString TemplatePositioningDialog::currentCRSSpec() const
+{
+	switch (coord_system_box->currentCustomItem())
+	{
+	case CoordinateSystem::DomainMap:
+	case CoordinateSystem::DomainGround:
+	case CoordinateSystem::DomainGeospatial:
+		return {};
+	default:
+		return coord_system_box->currentCRSSpec();
+	}
+}
+
+
 // slot
 void TemplatePositioningDialog::updateWidgets()
 {
+	auto georeferenced = false;
 	switch (csDomain())
 	{
 	case CoordinateSystem::DomainGeospatial:
-		Q_UNREACHABLE();
-		Q_FALLTHROUGH();
+		georeferenced = true;
+		unit_scale_edit->setSuffix({});
+		original_pos_radio->setChecked(true);
+		break;
 		
 	case CoordinateSystem::DomainGround:  // Real
 		unit_scale_edit->setMinimum(0.0001);
@@ -140,8 +166,29 @@ void TemplatePositioningDialog::updateWidgets()
 		unit_scale_edit->setSuffix(QChar::Space + Util::InputProperties<MapCoordF>::unit());
 		break;
 		
+	default:
+		Q_UNREACHABLE();
 	}
+	
 	unit_scale_edit->setValue(1);
+	unit_scale_edit->setEnabled(!georeferenced);
+	view_center_radio->setEnabled(!georeferenced);
+	view_center_radio->setChecked(!georeferenced);
+	
+	auto valid = true;
+	auto error_text = QString{};
+	if (georeferenced)
+	{
+		Georeferencing georef;
+		auto spec =  coord_system_box->currentCRSSpec();
+		valid = spec.isEmpty() || georef.setProjectedCRS({}, spec);
+		error_text = georef.getErrorText();
+	}
+	if (valid)
+		status_label->setText(tr("valid"));
+	else
+		status_label->setText(QLatin1String("<b style=\"color:red\">") + error_text + QLatin1String("</b>"));
+	button_box->button(QDialogButtonBox::Ok)->setEnabled(valid);
 }
 
 

--- a/src/templates/template_positioning_dialog.cpp
+++ b/src/templates/template_positioning_dialog.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012 Thomas Schöps
- *    Copyright 2013, 2017 Kai Pastor
+ *    Copyright 2013-2020 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -25,7 +25,6 @@
 #include <QComboBox>
 #include <QDialogButtonBox>
 #include <QDoubleSpinBox>
-#include <QFlags>
 #include <QFormLayout>
 #include <QRadioButton>
 #include <QSpacerItem>
@@ -35,13 +34,16 @@
 
 namespace OpenOrienteering {
 
+// not inline
+TemplatePositioningDialog::~TemplatePositioningDialog() = default;
+
 TemplatePositioningDialog::TemplatePositioningDialog(QWidget* parent)
 : QDialog(parent, Qt::WindowSystemMenuHint | Qt::WindowTitleHint)
 {
 	setWindowModality(Qt::WindowModal);
 	setWindowTitle(tr("Track scaling and positioning"));
 	
-	QFormLayout* layout = new QFormLayout();
+	auto* layout = new QFormLayout();
 	
 	coord_system_box = new QComboBox();
 	layout->addRow(tr("Coordinate system"), coord_system_box);

--- a/src/templates/template_positioning_dialog.cpp
+++ b/src/templates/template_positioning_dialog.cpp
@@ -30,6 +30,7 @@
 #include <QSpacerItem>
 
 #include "gui/util_gui.h"
+#include "templates/template_image_open_dialog.h"
 
 
 namespace OpenOrienteering {
@@ -37,11 +38,11 @@ namespace OpenOrienteering {
 // not inline
 TemplatePositioningDialog::~TemplatePositioningDialog() = default;
 
-TemplatePositioningDialog::TemplatePositioningDialog(QWidget* parent)
+TemplatePositioningDialog::TemplatePositioningDialog(const QString& display_name, QWidget* parent)
 : QDialog(parent, Qt::WindowSystemMenuHint | Qt::WindowTitleHint)
 {
 	setWindowModality(Qt::WindowModal);
-	setWindowTitle(tr("Track scaling and positioning"));
+	setWindowTitle(TemplateImageOpenDialog::tr("Opening %1").arg(display_name));
 	
 	auto* layout = new QFormLayout();
 	

--- a/src/templates/template_positioning_dialog.h
+++ b/src/templates/template_positioning_dialog.h
@@ -42,7 +42,7 @@ class TemplatePositioningDialog : public QDialog
 Q_OBJECT
 public:
 	~TemplatePositioningDialog() override;
-	explicit TemplatePositioningDialog(QWidget* parent = nullptr);
+	explicit TemplatePositioningDialog(const QString& display_name, QWidget* parent = nullptr);
 	TemplatePositioningDialog(const TemplatePositioningDialog&) = delete;
 	TemplatePositioningDialog(TemplatePositioningDialog&&) = delete;
 	TemplatePositioningDialog& operator=(const TemplatePositioningDialog&) = delete;

--- a/src/templates/template_positioning_dialog.h
+++ b/src/templates/template_positioning_dialog.h
@@ -28,12 +28,16 @@
 
 #include "core/coordinate_system.h"
 
-class QComboBox;
+class QDialogButtonBox;
 class QDoubleSpinBox;
+class QLabel;
 class QRadioButton;
 class QWidget;
 
 namespace OpenOrienteering {
+
+class CRSSelector;
+class Georeferencing;
 
 
 /**
@@ -46,7 +50,7 @@ class TemplatePositioningDialog : public QDialog
 Q_OBJECT
 public:
 	~TemplatePositioningDialog() override;
-	explicit TemplatePositioningDialog(const QString& display_name, QWidget* parent = nullptr);
+	explicit TemplatePositioningDialog(const QString& display_name, const Georeferencing& data_georef, QWidget* parent = nullptr);
 	TemplatePositioningDialog(const TemplatePositioningDialog&) = delete;
 	TemplatePositioningDialog(TemplatePositioningDialog&&) = delete;
 	TemplatePositioningDialog& operator=(const TemplatePositioningDialog&) = delete;
@@ -59,14 +63,19 @@ public:
 	/** Returns whether non-georeferenced data shall be centered in the current view. */
 	bool centerOnView() const;
 	
+	/** Returns the current CRS spec for georeferenced data. */
+	QString currentCRSSpec() const;
+	
 protected:
 	void updateWidgets();
 	
 private:
-	QComboBox* coord_system_box;
+	CRSSelector* coord_system_box;
+	QLabel* status_label;
 	QDoubleSpinBox* unit_scale_edit;
 	QRadioButton* original_pos_radio;
 	QRadioButton* view_center_radio;
+	QDialogButtonBox* button_box;
 };
 
 

--- a/src/templates/template_positioning_dialog.h
+++ b/src/templates/template_positioning_dialog.h
@@ -35,7 +35,9 @@ namespace OpenOrienteering {
 
 
 /**
- * Dialog allowing for positioning of a template.
+ * Dialog for initial setup of vector templates (coordinate system, position).
+ * 
+ * \see TemplateImageOpenDialog, SelectCRSDialog
  */
 class TemplatePositioningDialog : public QDialog
 {

--- a/src/templates/template_positioning_dialog.h
+++ b/src/templates/template_positioning_dialog.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012 Thomas Schöps
- *    Copyright 2013, 2017 Kai Pastor
+ *    Copyright 2013-2020 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -22,9 +22,9 @@
 #ifndef OPENORIENTEERING_TEMPLATE_POSITIIONING_DIALOG_H
 #define OPENORIENTEERING_TEMPLATE_POSITIIONING_DIALOG_H
 
-#include <QtGlobal>
 #include <QDialog>
 #include <QObject>
+#include <QString>
 
 class QComboBox;
 class QDoubleSpinBox;
@@ -41,7 +41,12 @@ class TemplatePositioningDialog : public QDialog
 {
 Q_OBJECT
 public:
-	TemplatePositioningDialog(QWidget* parent = nullptr);
+	~TemplatePositioningDialog() override;
+	explicit TemplatePositioningDialog(QWidget* parent = nullptr);
+	TemplatePositioningDialog(const TemplatePositioningDialog&) = delete;
+	TemplatePositioningDialog(TemplatePositioningDialog&&) = delete;
+	TemplatePositioningDialog& operator=(const TemplatePositioningDialog&) = delete;
+	TemplatePositioningDialog& operator=(TemplatePositioningDialog&&) = delete;
 	
 	bool useRealCoords() const;
 	double getUnitScale() const;
@@ -52,8 +57,6 @@ private:
 	QDoubleSpinBox* unit_scale_edit;
 	QRadioButton* original_pos_radio;
 	QRadioButton* view_center_radio;
-	
-	Q_DISABLE_COPY(TemplatePositioningDialog)
 };
 
 

--- a/src/templates/template_positioning_dialog.h
+++ b/src/templates/template_positioning_dialog.h
@@ -26,6 +26,8 @@
 #include <QObject>
 #include <QString>
 
+#include "core/coordinate_system.h"
+
 class QComboBox;
 class QDoubleSpinBox;
 class QRadioButton;
@@ -50,9 +52,15 @@ public:
 	TemplatePositioningDialog& operator=(const TemplatePositioningDialog&) = delete;
 	TemplatePositioningDialog& operator=(TemplatePositioningDialog&&) = delete;
 	
-	bool useRealCoords() const;
-	double getUnitScale() const;
+	/** Returns the selected domain of the coordinate system. */
+	CoordinateSystem::Domain csDomain() const;
+	/** Returns the length of one data unit in terms of one base unit. */
+	double unitScaleFactor() const;
+	/** Returns whether non-georeferenced data shall be centered in the current view. */
 	bool centerOnView() const;
+	
+protected:
+	void updateWidgets();
 	
 private:
 	QComboBox* coord_system_box;


### PR DESCRIPTION
Apart from the `OgrTemplate` change, this PR includes a second change worth mentioning: A global `CoordinateSystem::Domain` enum, replacing local enums in `OgrFileImport` and `TemplatePositioningDialog`.

Before merging this, I want to study if I can merge `TemplatePositioningDialog` and `SelectCRSDialog`.