### PR TITLE
Improve error reporting on saving/loading

### DIFF
--- a/src/fileformats/file_format.cpp
+++ b/src/fileformats/file_format.cpp
@@ -24,11 +24,13 @@
 #include <iterator>
 
 #include <Qt>
+#include <QCoreApplication>
 #include <QFileInfo>
 #include <QLatin1Char>
 #include <QLatin1String>
 
-#include "file_import_export.h"
+#include "mapper_config.h"
+#include "fileformats/file_import_export.h"
 
 
 namespace OpenOrienteering {
@@ -42,6 +44,21 @@ FileFormatException::~FileFormatException() noexcept = default;
 const char* FileFormatException::what() const noexcept
 {
 	return msg_c.constData();
+}
+
+
+// static
+FileFormatException FileFormatException::internalError(const char* function_info)
+{
+	return FileFormatException {
+		QCoreApplication::translate("OpenOrienteering::Util",
+		                            "Internal error detected!"
+		                            " Please report this issue."
+		                            "\nVersion: %1"
+		                            "\nLocation: %2")
+		        .arg(QString::fromUtf8(APP_VERSION),
+		             QString::fromUtf8(function_info))
+	};
 }
 
 

--- a/src/fileformats/file_format.h
+++ b/src/fileformats/file_format.h
@@ -70,10 +70,35 @@ public:
 	 */
 	const char* what() const noexcept override;
 	
+	
+	/**
+	 * Returns an exception object representing an internal error
+	 * in the given function.
+	 * 
+	 * This is a helper function used by the FILEFORMAT_ASSERT macro.
+	 */
+	static FileFormatException internalError(const char* function_info);
+	
+	
 private:
 	QString const msg;
 	QByteArray const msg_c;
 };
+
+
+/**
+ * Checks if the condition is true, and raises an exception otherwise.
+ * 
+ * This macro is to be used by importer and exporter implementations instead
+ * of plain assert or Q_ASSERT: In most cases, program consistency is not
+ * affected by internal errors of importers or exporters, and so there is no
+ * reason to abort the program (debug builds) or to let it run into a crash
+ * (release build). However, on hot paths, evaluating the condition must not
+ * be expensive.
+ */
+#define FILEFORMAT_ASSERT(condition) \
+	if (Q_UNLIKELY(!(condition))) throw FileFormatException::internalError(Q_FUNC_INFO);
+
 
 
 /** Describes a file format understood by this application. Each file format has an ID

--- a/src/fileformats/file_import_export.cpp
+++ b/src/fileformats/file_import_export.cpp
@@ -291,7 +291,7 @@ bool Exporter::doExport()
 		}
 		if (!device_->isOpen() && !device_->open(QIODevice::WriteOnly))
 		{
-			addWarning(tr("Cannot save file\n%1:\n%2").arg(path, device_->errorString()));
+			addWarning(device_->errorString());
 			return false;
 		}
 	}
@@ -307,7 +307,7 @@ bool Exporter::doExport()
 		}
 		if (success && managed_file && !managed_file->commit())
 		{
-			addWarning(tr("Cannot save file\n%1:\n%2").arg(path, managed_file->errorString()));
+			addWarning(managed_file->errorString());
 			success = false;
 		}
 #ifdef Q_OS_ANDROID
@@ -322,7 +322,7 @@ bool Exporter::doExport()
 	}
 	catch (std::exception &e)
 	{
-		addWarning(tr("Cannot save file\n%1:\n%2").arg(path, QString::fromLocal8Bit(e.what())));
+		addWarning(QString::fromLocal8Bit(e.what()));
 		success = false;
 	}
 	

--- a/src/fileformats/ocd_file_export.cpp
+++ b/src/fileformats/ocd_file_export.cpp
@@ -273,7 +273,7 @@ std::unique_ptr<PointSymbol> postProcessFillPattern(const FillPatternSequence& p
 	// ... except for the second pattern when the OCD structure is "shifted rows".
 	if (structure_mode == Ocd::StructureShiftedRows)
 	{
-		Q_ASSERT(patterns.size() == 2);
+		FILEFORMAT_ASSERT(patterns.size() == 2);
 		if (first != last)
 			++first;
 	}
@@ -1094,7 +1094,7 @@ void OcdFileExport::exportSymbols(OcdFile<Format>& file)
 			Q_UNREACHABLE();
 		}
 		
-		Q_ASSERT(!ocd_symbol.isEmpty());
+		FILEFORMAT_ASSERT(!ocd_symbol.isEmpty());
 		file.symbols().insert(ocd_symbol);
 	}
 }
@@ -1237,7 +1237,7 @@ QByteArray OcdFileExport::exportPointSymbol(const PointSymbol* point_symbol)
 	data.reserve(header_size + pattern_size);
 	data.append(reinterpret_cast<const char*>(&ocd_symbol), header_size);
 	exportPattern<typename OcdPointSymbol::Element>(point_symbol, data);
-	Q_ASSERT(data.size() == header_size + pattern_size);
+	FILEFORMAT_ASSERT(data.size() == header_size + pattern_size);
 	
 	return data;
 }
@@ -1365,7 +1365,7 @@ QByteArray OcdFileExport::exportAreaSymbol(const AreaSymbol* area_symbol, quint3
 	data.reserve(header_size + pattern_size);
 	data.append(reinterpret_cast<const char*>(&ocd_symbol), header_size);
 	exportPattern<typename OcdAreaSymbol::Element>(pattern_symbol, data);
-	Q_ASSERT(data.size() == header_size + pattern_size);
+	FILEFORMAT_ASSERT(data.size() == header_size + pattern_size);
 	
 	return data;
 }
@@ -1473,7 +1473,7 @@ quint8 OcdFileExport::exportAreaSymbolCommon(const AreaSymbol* area_symbol, OcdA
 	// Post-processing
 	if (!point_patterns.empty())
 	{
-		Q_ASSERT(ocd_area_common.structure_mode != Ocd::StructureNone);
+		FILEFORMAT_ASSERT(ocd_area_common.structure_mode != Ocd::StructureNone);
 		auto point_symbol = postProcessFillPattern(point_patterns, ocd_area_common.structure_mode);
 		pattern_symbol = point_symbol.get();
 		temporary_symbols.push_back(std::move(point_symbol));
@@ -1565,7 +1565,7 @@ QByteArray OcdFileExport::exportLineSymbol(const LineSymbol* line_symbol, quint3
 	exportPattern<typename OcdLineSymbol::Element>(line_symbol->getDashSymbol(), data);
 	exportPattern<typename OcdLineSymbol::Element>(line_symbol->getStartSymbol(), data);
 	exportPattern<typename OcdLineSymbol::Element>(line_symbol->getEndSymbol(), data);
-	Q_ASSERT(data.size() == int(header_size + pattern_size));
+	FILEFORMAT_ASSERT(data.size() == int(header_size + pattern_size));
 	
 	return data;
 }
@@ -1836,7 +1836,7 @@ void OcdFileExport::exportTextSymbol(OcdFile<Format>& file, const TextSymbol* te
 	if (text_format->count == 0)
 		text_format->alignment = TextObject::AlignHCenter;  // default if unused: centered
 	auto ocd_symbol = exportTextSymbol<typename Format::TextSymbol>(text_symbol, text_format->symbol_number, text_format->alignment);
-	Q_ASSERT(!ocd_symbol.isEmpty());
+	FILEFORMAT_ASSERT(!ocd_symbol.isEmpty());
 	file.symbols().insert(ocd_symbol);
 	
 	++text_format;
@@ -1846,7 +1846,7 @@ void OcdFileExport::exportTextSymbol(OcdFile<Format>& file, const TextSymbol* te
 		temporary_symbols.emplace_back(new PointSymbol());
 		symbol_numbers[temporary_symbols.back().get()] = text_format->symbol_number;
 		ocd_symbol = exportTextSymbol<typename Format::TextSymbol>(text_symbol, text_format->symbol_number, text_format->alignment);
-		Q_ASSERT(!ocd_symbol.isEmpty());
+		FILEFORMAT_ASSERT(!ocd_symbol.isEmpty());
 		file.symbols().insert(ocd_symbol);
 		
 		++text_format;
@@ -1856,7 +1856,7 @@ void OcdFileExport::exportTextSymbol(OcdFile<Format>& file, const TextSymbol* te
 			temporary_symbols.emplace_back(new PointSymbol());
 			symbol_numbers[temporary_symbols.back().get()] = text_format->symbol_number;
 			ocd_symbol = exportTextSymbol<typename Format::TextSymbol>(text_symbol, text_format->symbol_number, text_format->alignment);
-			Q_ASSERT(!ocd_symbol.isEmpty());
+			FILEFORMAT_ASSERT(!ocd_symbol.isEmpty());
 			file.symbols().insert(ocd_symbol);
 			
 			++text_format;
@@ -1886,7 +1886,7 @@ QByteArray OcdFileExport::exportTextSymbol(const TextSymbol* text_symbol, quint3
 	QByteArray data;
 	data.reserve(header_size);
 	data.append(reinterpret_cast<const char*>(&ocd_symbol), header_size);
-	Q_ASSERT(data.size() == header_size);
+	FILEFORMAT_ASSERT(data.size() == header_size);
 	
 	return data;
 }
@@ -2165,7 +2165,7 @@ void OcdFileExport::exportGenericCombinedSymbol(OcdFile<Format>& file, const Com
 		}
 		else
 		{
-			Q_ASSERT(!ocd_data.isEmpty());
+			FILEFORMAT_ASSERT(!ocd_data.isEmpty());
 			breakdown_list.push_back({symbol_number, type});
 			if (number_owner)
 			{
@@ -2285,7 +2285,7 @@ void OcdFileExport::exportObjects(OcdFile<Format>& file)
 			{
 			case Object::Point:
 				ocd_object = exportPointObject<typename Format::Object>(static_cast<const PointObject*>(object), entry);
-				Q_ASSERT(!ocd_object.isEmpty());
+				FILEFORMAT_ASSERT(!ocd_object.isEmpty());
 				file.objects().insert(ocd_object, entry);
 				break;
 				
@@ -2295,7 +2295,7 @@ void OcdFileExport::exportObjects(OcdFile<Format>& file)
 				
 			case Object::Text:
 				ocd_object = exportTextObject<typename Format::Object>(static_cast<const TextObject*>(object), entry);
-				Q_ASSERT(!ocd_object.isEmpty());
+				FILEFORMAT_ASSERT(!ocd_object.isEmpty());
 				file.objects().insert(ocd_object, entry);
 				break;
 			}
@@ -2376,7 +2376,7 @@ void OcdFileExport::exportPathObject(OcdFile<Format>& file, const PathObject* pa
 	{
 		ocd_object.symbol = entry.symbol = decltype(entry.symbol)(symbol_numbers[symbol]);
 		auto data = exportObjectCommon(path, ocd_object, entry);
-		Q_ASSERT(!data.isEmpty());
+		FILEFORMAT_ASSERT(!data.isEmpty());
 		
 		auto breakdown_index_entry = breakdown_index.find(quint32(entry.symbol));
 		if (breakdown_index_entry == end(breakdown_index))
@@ -2398,7 +2398,7 @@ void OcdFileExport::exportPathObject(OcdFile<Format>& file, const PathObject* pa
 				if (Q_UNLIKELY(breakdown->type == 99))
 				{
 					auto child_index_entry = breakdown_index.find(breakdown->number);
-					Q_ASSERT(child_index_entry != end(breakdown_index));
+					FILEFORMAT_ASSERT(child_index_entry != end(breakdown_index));
 					backlog.push_back(quint32(child_index_entry->second));
 					continue;
 				}
@@ -2450,7 +2450,7 @@ QByteArray OcdFileExport::exportTextObject(const TextObject* text, typename OcdO
 	auto text_format = std::find_if(begin(text_format_mapping), end(text_format_mapping), [symbol, alignment](const auto& m) {
 		return m.symbol == symbol && m.alignment == alignment;
 	});
-	Q_ASSERT(text_format != end(text_format_mapping));
+	FILEFORMAT_ASSERT(text_format != end(text_format_mapping));
 	
 	OcdObject ocd_object = {};
 	ocd_object.type = text->hasSingleAnchor() ? 4 : 5;
@@ -2514,7 +2514,7 @@ QByteArray OcdFileExport::exportObjectCommon(const Object* object, OcdObject& oc
 			exportCoordinates(coords, object->getSymbol(), data, bottom_left, top_right);
 		}
 	}
-	Q_ASSERT(data.size() == header_size + items_size);
+	FILEFORMAT_ASSERT(data.size() == header_size + items_size);
 	
 	entry.bottom_left_bound = convertPoint(bottom_left);
 	entry.top_right_bound = convertPoint(top_right);
@@ -2901,7 +2901,7 @@ quint16 OcdFileExport::exportTextCoordinatesBox(const TextObject* object, QByteA
 QByteArray OcdFileExport::exportTextData(const TextObject* object, int chunk_size, int max_chunks)
 {
 	auto max_size = chunk_size * max_chunks;
-	Q_ASSERT(max_size > 0);
+	FILEFORMAT_ASSERT(max_size > 0);
 	
 	// Convert text to OCD format:
 	// - If it starts with a newline, add another.
@@ -2927,12 +2927,12 @@ QByteArray OcdFileExport::exportTextData(const TextObject* object, int chunk_siz
 	delete encoder;
 	
 	auto text_size = encoded_text.size();
-	Q_ASSERT(text_size < max_size);
+	FILEFORMAT_ASSERT(text_size < max_size);
 	
 	// Resize to multiple of chunk size, appending trailing zeros.
 	encoded_text.resize(text_size + (max_size - text_size) % chunk_size);
-	Q_ASSERT(encoded_text.size() <= max_size);
-	Q_ASSERT(encoded_text.size() % chunk_size == 0);
+	FILEFORMAT_ASSERT(encoded_text.size() <= max_size);
+	FILEFORMAT_ASSERT(encoded_text.size() % chunk_size == 0);
 	std::fill(encoded_text.begin() + text_size, encoded_text.end(), 0);
 	return encoded_text;
 }

--- a/src/fileformats/ocd_file_import.cpp
+++ b/src/fileformats/ocd_file_import.cpp
@@ -174,7 +174,7 @@ QString OcdFileImport::convertOcdString(const QChar* src, uint maxlen) const
 	}
 	/// \todo Create and use static decoder
 	QTextCodec* utf16 = QTextCodec::codecForName("UTF-16LE");
-	Q_ASSERT(utf16);
+	FILEFORMAT_ASSERT(utf16);
 	auto decoder = std::unique_ptr<QTextDecoder>(utf16->makeDecoder(QTextCodec::ConvertInvalidToNull));
 	return decoder->toUnicode(reinterpret_cast<const char*>(src), 2*int(last - src));
 }
@@ -330,7 +330,7 @@ void OcdFileImport::importImplementation()
 	}
 	
 	// No deep copy during import
-	Q_ASSERT(file.byteArray().constData() == buffer.constData());
+	FILEFORMAT_ASSERT(file.byteArray().constData() == buffer.constData());
 }
 
 
@@ -849,7 +849,7 @@ void OcdFileImport::resolveSubsymbols()
 void OcdFileImport::importObjects(const OcdFile<Ocd::FormatV8>& file)
 {
 	MapPart* part = map->getCurrentPart();
-	Q_ASSERT(part);
+	FILEFORMAT_ASSERT(part);
 	
 	for (auto ocd_object : file.objects())
 	{
@@ -865,7 +865,7 @@ template< class F >
 void OcdFileImport::importObjects(const OcdFile< F >& file)
 {
 	MapPart* part = map->getCurrentPart();
-	Q_ASSERT(part);
+	FILEFORMAT_ASSERT(part);
 	
 	for (auto ocd_object : file.objects())
 	{
@@ -1548,7 +1548,7 @@ void OcdFileImport::mergeLineSymbol(CombinedSymbol* full_line, LineSymbol* main_
 
 Symbol* OcdFileImport::importAreaSymbol(const Ocd::AreaSymbolV8& ocd_symbol)
 {
-	Q_ASSERT(ocd_version <= 8);
+	FILEFORMAT_ASSERT(ocd_version <= 8);
 	auto symbol = new OcdImportedAreaSymbol();
 	setupBaseSymbol(symbol, ocd_symbol.base);
 	setupAreaSymbolCommon(
@@ -1564,7 +1564,7 @@ Symbol* OcdFileImport::importAreaSymbol(const Ocd::AreaSymbolV8& ocd_symbol)
 template< class S >
 Symbol* OcdFileImport::importAreaSymbol(const S& ocd_symbol)
 {
-	Q_ASSERT(ocd_version >= 9);
+	FILEFORMAT_ASSERT(ocd_version >= 9);
 	auto symbol = new OcdImportedAreaSymbol();
 	setupBaseSymbol(symbol, ocd_symbol.base);
 	setupAreaSymbolCommon(
@@ -1757,7 +1757,7 @@ LineSymbol* OcdFileImport::importRectangleSymbol(const S& ocd_symbol)
 
 void OcdFileImport::setupPointSymbolPattern(PointSymbol* symbol, std::size_t data_size, const Ocd::PointSymbolElementV8* elements)
 {
-	Q_ASSERT(symbol);
+	FILEFORMAT_ASSERT(symbol);
 	
 	symbol->setRotatable(true);
 	bool base_symbol_used = false;

--- a/src/fileformats/xml_file_format.cpp
+++ b/src/fileformats/xml_file_format.cpp
@@ -688,7 +688,7 @@ void XMLFileImporter::importMapNotes()
 
 void XMLFileImporter::importGeoreferencing()
 {
-	Q_ASSERT(xml.name() == literal::georeferencing);
+	FILEFORMAT_ASSERT(xml.name() == literal::georeferencing);
 	
 	bool check_for_offset = MapCoord::boundsOffset().check_for_offset;
 	
@@ -993,7 +993,7 @@ void XMLFileImporter::importMapParts()
 
 void XMLFileImporter::importTemplates()
 {
-	Q_ASSERT(xml.name() == literal::templates);
+	FILEFORMAT_ASSERT(xml.name() == literal::templates);
 	
 	XmlElementReader templates_element(xml);
 	int first_front_template = templates_element.attribute<int>(literal::first_front_template);
@@ -1033,7 +1033,7 @@ void XMLFileImporter::importTemplates()
 
 void XMLFileImporter::importView()
 {
-	Q_ASSERT(xml.name() == literal::view);
+	FILEFORMAT_ASSERT(xml.name() == literal::view);
 	
 	XmlElementReader view_element(xml);
 	if (view_element.attribute<bool>(literal::area_hatching_enabled))
@@ -1063,7 +1063,7 @@ void XMLFileImporter::importView()
 
 void XMLFileImporter::importPrint()
 {
-	Q_ASSERT(xml.name() == literal::print);
+	FILEFORMAT_ASSERT(xml.name() == literal::print);
 	
 	try
 	{

--- a/src/gdal/ogr_file_format.cpp
+++ b/src/gdal/ogr_file_format.cpp
@@ -88,7 +88,7 @@ namespace {
 		auto pen_width = OGR_ST_GetParamDbl(tool, OGRSTPenWidth, &is_null);
 		if (!is_null)
 		{
-			Q_ASSERT(OGR_ST_GetUnit(tool) == OGRSTUMM);
+			FILEFORMAT_ASSERT(OGR_ST_GetUnit(tool) == OGRSTUMM);
 	
 			if (pen_width <= 0.01)
 				pen_width = 0.1;
@@ -1032,7 +1032,7 @@ void OgrFileImport::importStyles(OGRDataSourceH data_source)
 
 void OgrFileImport::importLayer(MapPart* map_part, OGRLayerH layer)
 {
-	Q_ASSERT(map_part);
+	FILEFORMAT_ASSERT(map_part);
 	
 	auto feature_definition = OGR_L_GetLayerDefn(layer);
 	
@@ -1162,8 +1162,8 @@ Object* OgrFileImport::importPointGeometry(OGRFeatureH feature, OGRGeometryH geo
 		const auto& description = symbol->getDescription();
 		auto length = description.length();
 		auto split = description.indexOf(QLatin1Char(' '));
-		Q_ASSERT(split > 0);
-		Q_ASSERT(split < length);
+		FILEFORMAT_ASSERT(split > 0);
+		FILEFORMAT_ASSERT(split < length);
 		
 		auto label = description.right(length - split - 1);
 		if (label.startsWith(QLatin1Char{'{'}) && label.endsWith(QLatin1Char{'}'}))
@@ -1379,7 +1379,7 @@ Symbol* OgrFileImport::getSymbol(Symbol::Type type, const char* raw_style_string
 		Q_UNREACHABLE();
 	}
 	
-	Q_ASSERT(symbol);
+	FILEFORMAT_ASSERT(symbol);
 	return symbol;
 }
 
@@ -1621,7 +1621,7 @@ PointSymbol* OgrFileImport::getSymbolForOgrSymbol(OGRStyleToolH tool, const QByt
 
 TextSymbol* OgrFileImport::getSymbolForLabel(OGRStyleToolH tool, const QByteArray& /*style_string*/)
 {
-	Q_ASSERT(OGR_ST_GetType(tool) == OGRSTCLabel);
+	FILEFORMAT_ASSERT(OGR_ST_GetType(tool) == OGRSTCLabel);
 	
 	int is_null;
 	auto label_string = OGR_ST_GetParamStr(tool, OGRSTLabelTextString, &is_null);
@@ -1679,7 +1679,7 @@ TextSymbol* OgrFileImport::getSymbolForLabel(OGRStyleToolH tool, const QByteArra
 
 LineSymbol* OgrFileImport::getSymbolForPen(OGRStyleToolH tool, const QByteArray& style_string)
 {
-	Q_ASSERT(OGR_ST_GetType(tool) == OGRSTCPen);
+	FILEFORMAT_ASSERT(OGR_ST_GetType(tool) == OGRSTCPen);
 	
 	auto raw_tool_key = OGR_ST_GetStyleString(tool);
 	auto tool_key = QByteArray::fromRawData(raw_tool_key, int(qstrlen(raw_tool_key)));
@@ -1711,7 +1711,7 @@ LineSymbol* OgrFileImport::getSymbolForPen(OGRStyleToolH tool, const QByteArray&
 
 AreaSymbol* OgrFileImport::getSymbolForBrush(OGRStyleToolH tool, const QByteArray& style_string)
 {
-	Q_ASSERT(OGR_ST_GetType(tool) == OGRSTCBrush);
+	FILEFORMAT_ASSERT(OGR_ST_GetType(tool) == OGRSTCBrush);
 	
 	auto raw_tool_key = OGR_ST_GetStyleString(tool);
 	auto tool_key = QByteArray::fromRawData(raw_tool_key, int(qstrlen(raw_tool_key)));


### PR DESCRIPTION
Replaces Q_ASSERT in export/import by a macro which throws proper exceptions instead of letting the app run into crashes in release builds.

Fixes a duplicate error message labeling with "Cannot save file ...".
