### PR TITLE
PaintOnTemplateFeature: Fix setupTemplate()

### DIFF
--- a/src/templates/paint_on_template_feature.cpp
+++ b/src/templates/paint_on_template_feature.cpp
@@ -351,6 +351,7 @@ Template* PaintOnTemplateFeature::setupTemplate() const
 		template_image->setTemplateScaleY(1.0/pixel_per_mm);
 		template_image->setTemplateShear(0);
 		template_image->setTemplateRotation(0);
+		template_image->setTemplateState(Template::Unloaded);
 		template_image->loadTemplateFile();
 		
 		if (template_image->getTemplateState() != Template::Loaded)


### PR DESCRIPTION
Indicate that template configuration is finished before loading the
template file, so that that function takes care of setting the state
to Loaded on success.
Complements aee1057f.
Fixes GH-1830 (Cannot add scribble template).