### PR TITLE
AreaSymbol::FillPattern: Don't compare the name

### DIFF
--- a/src/core/symbols/area_symbol.cpp
+++ b/src/core/symbols/area_symbol.cpp
@@ -165,9 +165,6 @@ bool AreaSymbol::FillPattern::equals(const AreaSymbol::FillPattern& other, Qt::C
 			return false;
 	}
 	
-	if (name.compare(other.name, case_sensitivity) != 0)
-		return false;
-	
 	return true;
 }
 


### PR DESCRIPTION
The name property is transient, only used by the symbol editor UI.
It is not exported or imported. For proper merging of imported
symbols, fill pattern comparison must ignore the name.
Fixes GH-1828 (duplicate symbol after edit, copy, paste).