### PR TITLE
CombinedSymbol: Fix hasRotatableFillPattern()

### DIFF
--- a/src/core/symbols/combined_symbol.cpp
+++ b/src/core/symbols/combined_symbol.cpp
@@ -411,9 +411,8 @@ void CombinedSymbol::setPart(int i, const Symbol* symbol, bool is_private)
 // override
 bool CombinedSymbol::hasRotatableFillPattern() const
 {
-	using std::begin; using std::end;
 	return std::any_of(begin(parts), end(parts), [](auto const* part) {
-		return part->hasRotatableFillPattern();
+		return part && part->hasRotatableFillPattern();
 	});
 }
 


### PR DESCRIPTION
Some patterns may be null. :facepalm: 
Amends 095bb634.
Resolves GH-1835 (Crash with certain objects).