### PR TITLE
Improve georef handling for template maps

### DIFF
--- a/src/templates/template_map.cpp
+++ b/src/templates/template_map.cpp
@@ -187,6 +187,10 @@ bool TemplateMap::loadTemplateFileImpl()
 			updateTransformationMatrices();
 			block_georeferencing = false;
 		}
+		else
+		{
+			block_georeferencing = false;
+		}
 	}
 	else if (importer)
 	{

--- a/src/templates/template_map.cpp
+++ b/src/templates/template_map.cpp
@@ -205,7 +205,8 @@ bool TemplateMap::postLoadSetup(QWidget* /* dialog_parent */, bool& out_center_i
 	auto const is_unconfigured = [](auto const& georef) {
 		return georef.getState() != Georeferencing::Geospatial && georef.toProjectedCoords(MapCoordF{}) == QPointF{};
 	};
-	out_center_in_view = is_unconfigured(templateMap()->getGeoreferencing());
+	out_center_in_view = is_unconfigured(templateMap()->getGeoreferencing())
+	                     || is_unconfigured(map->getGeoreferencing());
 	return true;
 }
 

--- a/src/templates/template_map.h
+++ b/src/templates/template_map.h
@@ -159,7 +159,7 @@ private:
 	 * be cleared. Note that this initialization matches the behaviour before
 	 * introducing support for georeferenced maps.
 	 */
-	bool block_georeferencing = true;
+	bool block_georeferencing = false;
 	
 	static QStringList locked_maps;
 };


### PR DESCRIPTION
- Center added templates also when the map has no geospatial reference.
   Faciltates using the Course Design symbol set on legacy maps.
- Enable toggling of georeferenced state.
  Allows to reset the template position.
- Trigger the map georeferencing dialog when adding a TemplateMap to a map has no valid geospatial reference.
  Again, this is useful for the Course Design symbol set, but also for fresh starts in regular mapping.
