### PR TITLE
CI: Workaround superbuild Android sdk_host quirk

### DIFF
--- a/ci/setup-common.yml
+++ b/ci/setup-common.yml
@@ -1,6 +1,6 @@
 # This file is part of OpenOrienteering.
 
-# Copyright 2019 Kai Pastor
+# Copyright 2019-2021 Kai Pastor
 #
 # Redistribution and use is allowed according to the terms of the BSD license:
 #
@@ -51,6 +51,8 @@ steps:
     if [ -z "${APP_ID_SUFFIX}" -a -n "${VERSION_DISPLAY}" ] ; then
       echo "##vso[task.setVariable variable=APP_ID_SUFFIX].${BUILD_SOURCEBRANCHNAME}"
     fi
+    # Fix Superbuild sdk_host quirk
+    echo "##vso[task.setVariable variable=ANDROID_NDK_ROOT]"
     env | sort
   displayName: 'Update environment'
 


### PR DESCRIPTION
Azure Pipelines started setting ANDROID_NDK_ROOT which breaks the
initialization of 'sdk_host' in Superbuild's Android toolchain setup.