### PR TITLE
OpenStreetMap lookup of reference point to show marker

### DIFF
--- a/src/gui/georeferencing_dialog.cpp
+++ b/src/gui/georeferencing_dialog.cpp
@@ -393,8 +393,8 @@ void GeoreferencingDialog::projectionChanged()
 	setValueIfChanged(lat_edit, latitude);
 	setValueIfChanged(lon_edit, longitude);
 	QString osm_link =
-	  QString::fromLatin1("http://www.openstreetmap.org/?lat=%1&lon=%2&zoom=18&layers=M").
-	  arg(latitude).arg(longitude);
+      QString::fromLatin1("http://www.openstreetmap.org/?mlat=%1&mlon=%2&zoom=18&layers=M").
+      arg(latitude,0,'g',10).arg(longitude,0,'g',10);
 	QString worldofo_link =
 	  QString::fromLatin1("http://maps.worldofo.com/?zoom=15&lat=%1&lng=%2").
 	  arg(latitude).arg(longitude);

--- a/src/gui/georeferencing_dialog.cpp
+++ b/src/gui/georeferencing_dialog.cpp
@@ -393,8 +393,8 @@ void GeoreferencingDialog::projectionChanged()
 	setValueIfChanged(lat_edit, latitude);
 	setValueIfChanged(lon_edit, longitude);
 	QString osm_link =
-      QString::fromLatin1("http://www.openstreetmap.org/?mlat=%1&mlon=%2&zoom=18&layers=M").
-      arg(latitude,0,'g',10).arg(longitude,0,'g',10);
+	  QString::fromLatin1("https://www.openstreetmap.org/?mlat=%1&mlon=%2&zoom=18&layers=M").
+	  arg(latitude, 0, 'g', 10).arg(longitude, 0, 'g', 10);
 	QString worldofo_link =
 	  QString::fromLatin1("http://maps.worldofo.com/?zoom=15&lat=%1&lng=%2").
 	  arg(latitude).arg(longitude);


### PR DESCRIPTION
Map Georeferencing now shows a marker at the reference point in OpenStreetMap lookup of the position.
In addition the lookup operates with an improved precision.