### PR TITLE
Map: Fix unsafe reference to unique_ptr

### DIFF
--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -1985,7 +1985,7 @@ void Map::loadTemplateFilesAsync(MapView& view, std::function<void(const QString
 		if (temp->getTemplateState() == Template::Unloaded
 		    && view.getTemplateVisibility(temp.get()).visible)
 		{
-			QTimer::singleShot(10, temp.get(), ([this, &view, &temp, log = std::move(listener)]() {
+			QTimer::singleShot(10, temp.get(), ([this, &view, temp = temp.get(), log = std::move(listener)]() {
 				log(qApp->translate("OpenOrienteering::MainWindow", "Opening %1")
 				         .arg(temp->getTemplateFilename()));
 				if (temp->getTemplateState() != Template::Loaded)


### PR DESCRIPTION
The scheduled template loading event is bound to the lifetime of the
template object, but the lambda captures a reference to the unique_ptr
owning the template. The lifetime of the unique_ptr can end before the
lifetime of the pointed-to object when ownership is transferred to
another unique_ptr. Here, this is triggered when the the template
container reallocates memory due to insertion.
We can safely capture a raw pointer to the template instead.
Fixes GH-1893 (crash on early location display toggle).