### PR TITLE
TagsWidget: Rely on QTableWidget::removeRow()

### DIFF
--- a/src/gui/widgets/tags_widget.cpp
+++ b/src/gui/widgets/tags_widget.cpp
@@ -206,13 +206,6 @@ void TagsWidget::cellChange(int row, int column)
 				// Jump to previous row
 				tags_table->setCurrentCell(row - 1, 1);
 			}
-			else
-			{
-				// Reset current row
-				tags_table->item(row, 1)->setText({});
-				auto value_item = tags_table->item(row, 1);
-				value_item->setFlags(value_item->flags() & ~Qt::ItemIsEnabled);
-			}
 		}
 		else if (!key.isEmpty())
 		{


### PR DESCRIPTION
... when removing the first row. Fixes a quirk with the value of the
new first row being invisible or lost.