### PR TITLE
OcdFileExport: Export OCD template opacity

### DIFF
--- a/src/fileformats/ocd_file_export.cpp
+++ b/src/fileformats/ocd_file_export.cpp
@@ -2778,6 +2778,7 @@ QString OcdFileExport::stringForTemplate(const Template& temp, const MapCoord& a
 			addWarning(::OpenOrienteering::OcdFileExport::tr("Cannot save custom positioning of template '%1'.")
 			           .arg(temp.getTemplateFilename()));
 		}
+		out << "\td" << d;
 	}
 	else if (ocd_version >= 11)
 	{


### PR DESCRIPTION
A small nit spotted while working with .ocd export. This is "obviously correct", in my opinion, and I'll merge the change as soon as CI tests finish.