### PR TITLE
OCD: Fix handling of OcdGrid::Germany (8xxx) zones

### DIFF
--- a/src/fileformats/ocd_georef_fields.cpp
+++ b/src/fileformats/ocd_georef_fields.cpp
@@ -236,10 +236,6 @@ constexpr struct
     { OcdGrid::France, 16, 3948 }, // RGF93 / CC48
     { OcdGrid::France, 17, 3949 }, // RGF93 / CC49
     { OcdGrid::France, 18, 3950 }, // RGF93 / CC50
-    { OcdGrid::Germany, 2, 31466 }, // DHDN, Gauss-Krüger Zone 2
-    { OcdGrid::Germany, 3, 31467 }, // DHDN, Gauss-Krüger Zone 3
-    { OcdGrid::Germany, 4, 31468 }, // DHDN, Gauss-Krüger Zone 4
-    { OcdGrid::Germany, 5, 31469 }, // DHDN, Gauss-Krüger Zone 5
     { OcdGrid::Germany, 6, 25831 }, // ETRS89 / UTM zone 31N
     { OcdGrid::Germany, 7, 25832 }, // ETRS89 / UTM zone 32N
     { OcdGrid::Germany, 8, 25833 }, // ETRS89 / UTM zone 33N
@@ -696,7 +692,7 @@ std::pair<const MapperCrs, const int> fromOcd(const int combined_ocd_grid_zone)
 		// DHDN, Gauss-Krüger, Zone 2-5
 		if (ocd_zone_id >= 2 && ocd_zone_id <= 5)
 			return { MapperCrs::GaussKrueger, ocd_zone_id };
-		break;
+		Q_FALLTHROUGH();
 
 	default:
 		for (const auto& record : grid_zone_epsg_codes)

--- a/test/georef_ocd_mapping_t.cpp
+++ b/test/georef_ocd_mapping_t.cpp
@@ -132,6 +132,10 @@ void commonTestData()
 	        << OcdGeorefFields { 5.22000000, 15000, 367205, 5807281, 2033, 1 }
 	        << GeorefCoreData { 15000, 3.67, 5.22, { 367205, 5807281 }, QStringLiteral("UTM"), { QStringLiteral("33") } }
 	        << 0U;
+	QTest::newRow("Kaiserdom St. Bartholomaeus - Germany, ETRS89/UTM zone 32N")
+	        << OcdGeorefFields { 3.26000000, 15000, 477509, 5550982, 8007, 1 }
+	        << GeorefCoreData { 15000, 3.02, 3.26, { 477509, 5550982 }, QStringLiteral("EPSG"), { QStringLiteral("25832") } }
+	        << 0U;
 	QTest::newRow("Nasca airport - Peru, WGS 84/UTM zone 18S")
 	        << OcdGeorefFields { -2.70000000, 15000, 504606, 8358028, -2018, 1 }
 	        << GeorefCoreData { 15000, -2.71, -2.70, { 504606, 8358028 }, QStringLiteral("UTM"), { QStringLiteral("18 S") } }


### PR DESCRIPTION
From the beginning, the intent was to translate zone is'd 8002 through
8005 directly into Mapper's native MapperCrs::GaussKrueger zone and look
up the other ones in the generic zone-EPSG code table.

Closes GH-1912