### PR TITLE
Revert "OcdFileImport: Honor area hatch/structure north orientation"

### DIFF
--- a/src/fileformats/ocd_file_import.cpp
+++ b/src/fileformats/ocd_file_import.cpp
@@ -1559,7 +1559,6 @@ Symbol* OcdFileImport::importAreaSymbol(const Ocd::AreaSymbolV8& ocd_symbol)
 	setupBaseSymbol(symbol, ocd_symbol.base);
 	setupAreaSymbolCommon(
 	            symbol,
-	            ocd_symbol.base.flags & Ocd::SymbolRotatable,
 	            ocd_symbol.fill_on,
 	            ocd_symbol.common,
 	            ocd_symbol.data_size,
@@ -1575,7 +1574,6 @@ Symbol* OcdFileImport::importAreaSymbol(const S& ocd_symbol)
 	setupBaseSymbol(symbol, ocd_symbol.base);
 	setupAreaSymbolCommon(
 	            symbol,
-	            ocd_symbol.base.flags & Ocd::SymbolRotatable,
 	            ocd_symbol.common.fill_on_V9,
 	            ocd_symbol.common,
 	            ocd_symbol.data_size,
@@ -1603,7 +1601,7 @@ Symbol* OcdFileImport::importAreaSymbol(const S& ocd_symbol)
 	return combined;
 }
 
-void OcdFileImport::setupAreaSymbolCommon(OcdImportedAreaSymbol* symbol, bool rotatable, bool fill_on, const Ocd::AreaSymbolCommonV8& ocd_symbol, std::size_t data_size, const Ocd::PointSymbolElementV8* elements)
+void OcdFileImport::setupAreaSymbolCommon(OcdImportedAreaSymbol* symbol, bool fill_on, const Ocd::AreaSymbolCommonV8& ocd_symbol, std::size_t data_size, const Ocd::PointSymbolElementV8* elements)
 {
 	// Basic area symbol fields: minimum_area, color
 	symbol->minimum_area = 0;
@@ -1617,7 +1615,7 @@ void OcdFileImport::setupAreaSymbolCommon(OcdImportedAreaSymbol* symbol, bool ro
 		AreaSymbol::FillPattern pattern;
 		pattern.type = AreaSymbol::FillPattern::LinePattern;
 		pattern.angle = convertAngle(ocd_symbol.hatch_angle_1);
-		pattern.setRotatable(rotatable);
+		pattern.setRotatable(true);
 		pattern.line_spacing = convertLength(ocd_symbol.hatch_dist);
 		pattern.line_offset = 0;
 		pattern.line_width = convertLength(ocd_symbol.hatch_line_width);
@@ -1642,7 +1640,7 @@ void OcdFileImport::setupAreaSymbolCommon(OcdImportedAreaSymbol* symbol, bool ro
 		AreaSymbol::FillPattern pattern;
 		pattern.type = AreaSymbol::FillPattern::PointPattern;
 		pattern.angle = convertAngle(ocd_symbol.structure_angle);
-		pattern.setRotatable(rotatable);
+		pattern.setRotatable(true);
 		pattern.point_distance = convertLength(ocd_symbol.structure_width);
 		pattern.line_spacing = convertLength(ocd_symbol.structure_height);
 		pattern.line_offset = 0;

--- a/src/fileformats/ocd_file_import.h
+++ b/src/fileformats/ocd_file_import.h
@@ -264,7 +264,6 @@ protected:
 	
 	void setupAreaSymbolCommon(
 	        OcdImportedAreaSymbol* symbol,
-	        bool rotatable,
 	        bool fill_on,
 	        const Ocd::AreaSymbolCommonV8& ocd_symbol,
 	        std::size_t data_size,

--- a/test/file_format_t.cpp
+++ b/test/file_format_t.cpp
@@ -63,7 +63,6 @@
 #include "core/map_printer.h"
 #include "core/objects/object.h"
 #include "core/objects/text_object.h"
-#include "core/symbols/area_symbol.h"
 #include "core/symbols/symbol.h"
 #include "core/symbols/line_symbol.h"
 #include "fileformats/file_format.h"
@@ -314,15 +313,6 @@ namespace
 	}
 	
 	
-	void fuzzyCompareSymbol(const AreaSymbol& actual, const AreaSymbol& expected)
-	{
-		auto pattern_rotable = false;
-		for (auto i = 0; i < expected.getNumFillPatterns(); ++i)
-			pattern_rotable |= expected.getFillPattern(i).rotatable();
-		for (auto i = 0; i < actual.getNumFillPatterns(); ++i)
-			COMPARE_SYMBOL_PROPERTY(actual.getFillPattern(i).rotatable(), pattern_rotable, expected);
-	}
-	
 	void fuzzyCompareSymbol(const Symbol& actual, const Symbol& expected, const QByteArray& /*format_id*/)
 	{
 		COMPARE_SYMBOL_PROPERTY(actual.isHidden(), expected.isHidden(), expected);
@@ -333,19 +323,6 @@ namespace
 #ifdef EXPORT_PRESERVES_DOMINANT_COLOR
 		COMPARE_SYMBOL_PROPERTY(actual.guessDominantColor()->getName(), expected.guessDominantColor()->getName(), expected);
 #endif
-		if (actual.getType() != expected.getType())
-			return;  // The following tests assume the same type.
-		
-		switch (actual.getType())
-		{
-		case Symbol::Area:
-			fuzzyCompareSymbol(static_cast<AreaSymbol const&>(actual), static_cast<AreaSymbol const&>(expected));
-			break;
-			
-		default:
-			;  /// \todo Extend fuzzy testing
-		}
-		
 	}
 	
 	void fuzzyMatchSymbol(const Map& map, const QByteArray& format_id, const Symbol* expected)


### PR DESCRIPTION
This reverts commit 918dd9b0df1cc752dd65e83c0c259585e946e557 as explained in issue #1926.