### PR TITLE
OCDImportExport: import and export of Hatch areas and Baseline view state

### DIFF
--- a/src/fileformats/ocd_file_export.cpp
+++ b/src/fileformats/ocd_file_export.cpp
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 Kai Pastor
+ *    Copyright 2016-2021 Kai Pastor
  *
  *    Some parts taken from file_format_oc*d8{.h,_p.h,cpp} which are
  *    Copyright 2012 Pete Curtis
@@ -549,6 +549,7 @@ QString stringForViewPar(const MapView& view, const MapCoord& area_offset, quint
 	else
 	{
 		const auto center = view.center() - area_offset;
+		const auto hatched = view.getMap()->isAreaHatchingEnabled() ? 1 : 0;
 		out << qSetRealNumberPrecision(6)
 		    << "\tx" << center.x()
 		    << "\ty" << -center.y()
@@ -558,8 +559,13 @@ QString stringForViewPar(const MapView& view, const MapCoord& area_offset, quint
 		    << "\tt50"
 		    << "\tb50"
 		    << "\tc50"
-		    << "\th0"
+		    << "\th" << hatched
 		    << "\td0";
+	}
+	if (version > 10)
+	{
+		const auto keyline = view.getMap()->isBaselineViewEnabled() ? 1 : 0;
+		out << "\tk" << keyline;
 	}
 	return string_1030;
 }

--- a/src/fileformats/ocd_file_export.cpp
+++ b/src/fileformats/ocd_file_export.cpp
@@ -549,7 +549,7 @@ QString stringForViewPar(const MapView& view, const MapCoord& area_offset, quint
 	else
 	{
 		const auto center = view.center() - area_offset;
-		const auto hatched = view.getMap()->isAreaHatchingEnabled() ? 1 : 0;
+		const auto hatched = view.getMap()->isAreaHatchingEnabled() ? '1' : '0';
 		out << qSetRealNumberPrecision(6)
 		    << "\tx" << center.x()
 		    << "\ty" << -center.y()
@@ -564,7 +564,7 @@ QString stringForViewPar(const MapView& view, const MapCoord& area_offset, quint
 	}
 	if (version > 10)
 	{
-		const auto keyline = view.getMap()->isBaselineViewEnabled() ? 1 : 0;
+		const auto keyline = view.getMap()->isBaselineViewEnabled() ? '1' : '0';
 		out << "\tk" << keyline;
 	}
 	return string_1030;

--- a/src/fileformats/ocd_file_import.cpp
+++ b/src/fileformats/ocd_file_import.cpp
@@ -1043,7 +1043,6 @@ void OcdFileImport::importView(const QString& param_string)
 	
 	bool zoom_ok = false;
 	double zoom=1.0, offset_x=0.0, offset_y=0.0;
-	int hatched = 0, keyline =0;
 	
 	int i = param_string.indexOf(QLatin1Char('\t'), 0);
 	; // skip first word for this entry type
@@ -1058,30 +1057,20 @@ void OcdFileImport::importView(const QString& param_string)
 			// empty item
 			break;
 		case 'x':
-			{
-				offset_x = param_value.toDouble();
-				break;
-			}
+			offset_x = param_value.toDouble();
+			break;
 		case 'y':
-			{
-				offset_y = param_value.toDouble();
-				break;
-			}
+			offset_y = param_value.toDouble();
+			break;
 		case 'z':
-			{
-				zoom = param_value.toDouble(&zoom_ok);
-				break;
-			}
+			zoom = param_value.toDouble(&zoom_ok);
+			break;
 		case 'h':
-			{
-				hatched = param_value.toInt();	// returns 0 for failure which is the default anyway
-				break;
-			}
+			map->setAreaHatchingEnabled(param_value.toInt() != 0);
+			break;
 		case 'k':
-			{
-				keyline = param_value.toInt();	// returns 0 for failure which is the default anyway
-				break;
-			}
+			map->setBaselineViewEnabled(param_value.toInt() != 0);
+			break;
 		default:
 			; // nothing
 		}
@@ -1094,11 +1083,6 @@ void OcdFileImport::importView(const QString& param_string)
 		if (zoom_ok)
 		{
 			view->setZoom(zoom);
-		}
-		if (map)
-		{
-			map->setAreaHatchingEnabled(hatched != 0);
-			map->setBaselineViewEnabled(keyline != 0);
 		}
 	}
 }

--- a/src/fileformats/ocd_file_import.cpp
+++ b/src/fileformats/ocd_file_import.cpp
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2013-2020 Kai Pastor
+ *    Copyright 2013-2021 Kai Pastor
  *
  *    Some parts taken from file_format_oc*d8{.h,_p.h,cpp} which are
  *    Copyright 2012 Pete Curtis
@@ -1043,6 +1043,7 @@ void OcdFileImport::importView(const QString& param_string)
 	
 	bool zoom_ok = false;
 	double zoom=1.0, offset_x=0.0, offset_y=0.0;
+	int hatched = 0, keyline =0;
 	
 	int i = param_string.indexOf(QLatin1Char('\t'), 0);
 	; // skip first word for this entry type
@@ -1071,6 +1072,16 @@ void OcdFileImport::importView(const QString& param_string)
 				zoom = param_value.toDouble(&zoom_ok);
 				break;
 			}
+		case 'h':
+			{
+				hatched = param_value.toInt();	// returns 0 for failure which is the default anyway
+				break;
+			}
+		case 'k':
+			{
+				keyline = param_value.toInt();	// returns 0 for failure which is the default anyway
+				break;
+			}
 		default:
 			; // nothing
 		}
@@ -1083,6 +1094,11 @@ void OcdFileImport::importView(const QString& param_string)
 		if (zoom_ok)
 		{
 			view->setZoom(zoom);
+		}
+		if (map)
+		{
+			map->setAreaHatchingEnabled(hatched != 0);
+			map->setBaselineViewEnabled(keyline != 0);
 		}
 	}
 }


### PR DESCRIPTION
Mapper currently saves the View settings of Hatch areas and Baseline view to .omap.
With this change Mapper exports and imports the View settings to .ocd (Baseline view is denoted as Keyline mode and is present for OCAD 11 and newer, however not for all editions and not in the OCAD viewer).