### PR TITLE
Preserve GPX track accuracy by accepting any authority

### DIFF
--- a/src/core/georeferencing.cpp
+++ b/src/core/georeferencing.cpp
@@ -383,7 +383,14 @@ ProjTransform::ProjTransform(const QString& crs_spec)
 	// Cf. https://github.com/OSGeo/PROJ/pull/1573
 	crs_spec_utf8.replace("+datum=potsdam", "+ellps=bessel +nadgrids=@BETA2007.gsb");
 #endif
+#if defined(ACCEPT_USE_OF_DEPRECATED_PROJ_API_H) || (PROJ_VERSION_MAJOR) < 8
 	pj = proj_create_crs_to_crs(PJ_DEFAULT_CTX, geographic_crs_spec_utf8, crs_spec_utf8, nullptr);
+#else
+	static auto const geographic_crs = crs(Georeferencing::geographic_crs_spec);
+	auto const projected_crs = crs(crs_spec);
+	static const char* const options[] = {"AUTHORITY=any", nullptr};
+	pj = proj_create_crs_to_crs_from_pj(PJ_DEFAULT_CTX, geographic_crs.pj, projected_crs.pj, nullptr, options);
+#endif
 	if (pj)
 		operator=({proj_normalize_for_visualization(PJ_DEFAULT_CTX, pj)});
 }

--- a/test/template_t.cpp
+++ b/test/template_t.cpp
@@ -51,8 +51,6 @@
 
 #ifdef ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
 #  include <proj_api.h>
-#else
-#  include <proj.h>
 #endif
 
 #include "test_config.h"
@@ -446,7 +444,7 @@ private slots:
 		QVERIFY(map.getTemplate(template_index)->loadTemplateFile());
 		QCOMPARE(temp->getTemplateState(), Template::Loaded);
 
-#if (!defined(ACCEPT_USE_OF_DEPRECATED_PROJ_API_H) && (PROJ_VERSION_MAJOR)*100+(PROJ_VERSION_MINOR) < 802) || PJ_VERSION >= 600 
+#if !defined(ACCEPT_USE_OF_DEPRECATED_PROJ_API_H) || PJ_VERSION >= 600
 		QEXPECT_FAIL("TemplateTrack from v0.8.4", "Unsupported WGS 84 -> NAD 83 transformation", Continue);
 #else
 		QEXPECT_FAIL("TemplateTrack NAD83", "Unsupported WGS 84 -> NAD 83 transformation", Continue);
@@ -569,7 +567,7 @@ private slots:
 			ogr_template_center = center(temp);
 		}
 		
-#if (!defined(ACCEPT_USE_OF_DEPRECATED_PROJ_API_H) && (PROJ_VERSION_MAJOR)*100+(PROJ_VERSION_MINOR) < 802) || PJ_VERSION >= 600
+#if !defined(ACCEPT_USE_OF_DEPRECATED_PROJ_API_H) || PJ_VERSION >= 600
 		QEXPECT_FAIL("TemplateTrack NAD83", "Unsupported WGS 84 -> NAD 83 transformation", Continue);
 		QEXPECT_FAIL("OgrTemplate NAD83", "Unsupported WGS 84 -> NAD 83 transformation", Continue);
 #endif


### PR DESCRIPTION
This is a possible alternative solution to #2008, rather than revising the expected template test failures as in #2009.

By setting up the PROJ transformation with an added option to permit _any_ authority, the tracks that relate to NAD83-based maps are placed more accurately than when processed via GDAL. With this change, those test tracks are positioned the same as they are by the Mapper executables in the 0.9.5 release.