### PR TITLE
GeoreferencingDialog: Hide 'Show reference point in' for local CRS

### DIFF
--- a/src/gui/georeferencing_dialog.cpp
+++ b/src/gui/georeferencing_dialog.cpp
@@ -188,7 +188,7 @@ GeoreferencingDialog::GeoreferencingDialog(
 	geographic_ref_layout->addWidget(geographic_datum_label, 0);
 	
 	show_refpoint_label = new QLabel(tr("Show reference point in:"));
-	link_label = new QLabel();
+	link_label = new QLabel(QLatin1String("-"));
 	link_label->setOpenExternalLinks(true);
 	
 	keep_projected_radio = new QRadioButton(tr("Projected coordinates"));

--- a/src/gui/georeferencing_dialog.cpp
+++ b/src/gui/georeferencing_dialog.cpp
@@ -49,6 +49,7 @@
 #include <QSignalBlocker>
 #include <QSize>
 #include <QSpacerItem>
+#include <QString>
 #include <QStringList>
 #include <QStringRef>
 #include <QTimer>
@@ -607,7 +608,8 @@ void GeoreferencingDialog::updateWidgets()
 	status_field->setVisible(geographic_coords_enabled);
 	lat_edit->setEnabled(geographic_coords_enabled);
 	lon_edit->setEnabled(geographic_coords_enabled);
-	link_label->setEnabled(geographic_coords_enabled);
+	link_label->setVisible(geographic_coords_enabled);
+	show_refpoint_label->setVisible(geographic_coords_enabled);
 	//keep_geographic_radio->setEnabled(geographic_coords_enabled);
 	
 	updateDeclinationButton();

--- a/src/gui/georeferencing_dialog.cpp
+++ b/src/gui/georeferencing_dialog.cpp
@@ -394,17 +394,7 @@ void GeoreferencingDialog::projectionChanged()
 	QString osm_link =
 	  QString::fromLatin1("https://www.openstreetmap.org/?mlat=%1&mlon=%2&zoom=18&layers=M").
 	  arg(latitude, 0, 'f', 6).arg(longitude, 0, 'f', 6);
-#ifdef MAPPER_WITH_WORLDOFO_LINK
-	QString worldofo_link =
-	  QString::fromLatin1("http://maps.worldofo.com/?zoom=15&lat=%1&lng=%2").
-	  arg(latitude).arg(longitude);
-	link_label->setText(
-	  tr("<a href=\"%1\">OpenStreetMap</a> | <a href=\"%2\">World of O Maps</a>").
-	  arg(osm_link, worldofo_link)
-	);
-#else
 	link_label->setText(tr("<a href=\"%1\">OpenStreetMap</a>").arg(osm_link));
-#endif
 	
 	QString error = georef->getErrorText();
 	if (error.length() == 0)

--- a/src/gui/georeferencing_dialog.cpp
+++ b/src/gui/georeferencing_dialog.cpp
@@ -391,10 +391,18 @@ void GeoreferencingDialog::projectionChanged()
 	double longitude = latlon.longitude();
 	setValueIfChanged(lat_edit, latitude);
 	setValueIfChanged(lon_edit, longitude);
-	QString osm_link =
-	  QString::fromLatin1("https://www.openstreetmap.org/?mlat=%1&mlon=%2&zoom=18&layers=M").
-	  arg(latitude, 0, 'f', 6).arg(longitude, 0, 'f', 6);
-	link_label->setText(tr("<a href=\"%1\">OpenStreetMap</a>").arg(osm_link));
+	
+	if (georef->getState() == Georeferencing::Geospatial)
+	{
+		QString osm_link =
+		  QString::fromLatin1("https://www.openstreetmap.org/?mlat=%1&mlon=%2&zoom=18&layers=M").
+		  arg(latitude, 0, 'f', 6).arg(longitude, 0, 'f', 6);
+		link_label->setText(tr("<a href=\"%1\">OpenStreetMap</a>").arg(osm_link));
+	}
+	else
+	{
+		link_label->setText(QLatin1String("-"));
+	}
 	
 	QString error = georef->getErrorText();
 	if (error.length() == 0)
@@ -598,8 +606,7 @@ void GeoreferencingDialog::updateWidgets()
 	status_field->setVisible(geographic_coords_enabled);
 	lat_edit->setEnabled(geographic_coords_enabled);
 	lon_edit->setEnabled(geographic_coords_enabled);
-	link_label->setVisible(geographic_coords_enabled);
-	show_refpoint_label->setVisible(geographic_coords_enabled);
+	show_refpoint_label->setEnabled(geographic_coords_enabled);
 	//keep_geographic_radio->setEnabled(geographic_coords_enabled);
 	
 	updateDeclinationButton();

--- a/src/gui/georeferencing_dialog.cpp
+++ b/src/gui/georeferencing_dialog.cpp
@@ -393,7 +393,7 @@ void GeoreferencingDialog::projectionChanged()
 	setValueIfChanged(lon_edit, longitude);
 	QString osm_link =
 	  QString::fromLatin1("https://www.openstreetmap.org/?mlat=%1&mlon=%2&zoom=18&layers=M").
-	  arg(latitude, 0, 'g', 10).arg(longitude, 0, 'g', 10);
+	  arg(latitude, 0, 'f', 6).arg(longitude, 0, 'f', 6);
 #ifdef MAPPER_WITH_WORLDOFO_LINK
 	QString worldofo_link =
 	  QString::fromLatin1("http://maps.worldofo.com/?zoom=15&lat=%1&lng=%2").

--- a/src/gui/georeferencing_dialog.h
+++ b/src/gui/georeferencing_dialog.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2015 Kai Pastor
+ *    Copyright 2012-2020, 2025 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -27,7 +27,6 @@
 #include <QDialog>
 #include <QObject>
 #include <QScopedPointer>
-#include <QString>
 
 #include "core/map_coord.h"
 #include "tools/tool.h"
@@ -54,7 +53,7 @@ class MapWidget;
 
 
 /**
- * A GeoreferencingDialog allows the user to adjust the georeferencing properties
+ * The GeoreferencingDialog allows the user to adjust the georeferencing properties
  * of a map.
  */
 class GeoreferencingDialog : public QDialog
@@ -63,7 +62,7 @@ Q_OBJECT
 public:
 	/**
 	 * Constructs a new georeferencing dialog for the map handled by the given 
-	 * controller. The optional parameter initial allows to override the current 
+	 * controller. The optional parameter initially allows to override the current 
 	 * properties of the map's georeferencing. The parameter
 	 * allow_no_georeferencing determines if the okay button can
 	 * be clicked while "- none -" is selected.
@@ -353,4 +352,4 @@ private:
 
 }  // namespace OpenOrienteering
 
-#endif
+#endif // OPENORIENTEERING_GEOREFERENCING_DIALOG_H


### PR DESCRIPTION
When switching between local and geospatial CRS links to OpenStreetMap | World of O Maps were shown even if they were not clickable (for local CRS).
This could also happen for a local CRS when using the Pick on Map and then pressing Reset.
Besides that there was an orphan 'Show reference point in:' label for local CRS.
The commit now uses setVisbible() for both, the label and the links, instead of just using setEnabled() on the links.

When setting up the dialog there was a doubled call edit_layout->addRow(show_refpoint_label, link_label); which lead to adding an empty row. This has been fixed by replacing it by adding a SpacerItem instead.

The last change corrects the link to OpenStreetMap.
mlat and mlon coordinates are now created by 'f', 6 instead of 'g', 10 which is the appropriate format for defining the precision after the decimal point.
BTW: 6 digits are equivalent to 11cm (or better).