### PR TITLE
Handle undefined symbols in .ocd export

### DIFF
--- a/test/data/undefined-objects.omap
+++ b/test/data/undefined-objects.omap
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns="http://openorienteering.org/apps/mapper/xml/v2" version="9">
+<notes></notes>
+<georeferencing scale="10000"><projected_crs id="Local"/></georeferencing>
+<colors count="0">
+</colors>
+<barrier version="6" required="0.6.0">
+<symbols count="0">
+</symbols>
+<parts count="1" current="0">
+<part name="default part"><objects count="5">
+<object type="0" symbol="-2"><coords count="1">4792 1790;</coords></object>
+<object type="1" symbol="-3"><coords count="2">3222 1770;-2778 1770;</coords><pattern rotation="0"><coord x="0" y="0"/></pattern></object>
+<object type="4" symbol="-4" h_align="1" v_align="0"><coords count="1">1212 0;</coords><text>B</text></object>
+<object type="4" symbol="-4" h_align="2" v_align="0"><coords count="1">6137 72;</coords><text>C</text></object>
+<object type="4" symbol="-4" h_align="0" v_align="0"><coords count="1">-3667 0;</coords><text>A</text></object>
+</objects></part>
+</parts>
+<templates count="0" first_front_template="0">
+<defaults use_meters_per_pixel="true" meters_per_pixel="0" dpi="0" scale="0"/>
+</templates>
+<view>
+<grid color="#80646464" display="0" alignment="0" additional_rotation="0" unit="1" h_spacing="500" v_spacing="500" h_offset="0" v_offset="0" snapping_enabled="true"/>
+<map_view zoom="7.44274" position_x="3266" position_y="334"><map opacity="1" visible="true"/><templates count="0"/></map_view>
+</view>
+</barrier>
+</map>

--- a/test/file_format_t.cpp
+++ b/test/file_format_t.cpp
@@ -504,6 +504,7 @@ namespace
 	  "data:/examples/forest sample.omap",
 	  "data:/examples/overprinting.omap",
 	  "testdata:templates/world-file.xmap",
+	  "data:undefined-objects.omap",
 	};
 	
 	auto const xml_test_files = {


### PR DESCRIPTION
A real fix to the .ocd export issue reported by users. Feel free to edit/reimplement it to your liking.