### PR TITLE
OcdFileExport: Fix map notes export to .ocd version 8

### DIFF
--- a/src/fileformats/ocd_file_export.cpp
+++ b/src/fileformats/ocd_file_export.cpp
@@ -810,11 +810,11 @@ void OcdFileExport::exportSetup(OcdFile<Ocd::FormatV8>& file)
 		if (!notes.isEmpty())
 		{
 			auto size = notes.size() + 1;
-			if (size > 32768)
+			if (size > 32767)
 			{
 				/// \todo addWarning(...)
-				size = 32768;
-				notes.truncate(23767);
+				size = 32767;
+				notes.truncate(32766);
 			}
 			file.header()->info_pos = quint32(file.byteArray().size());
 			file.header()->info_size = quint32(size);


### PR DESCRIPTION
If the size of the map notes exceeded 32768 the map notes were truncated when saving as OCAD 8.
However, instead of truncating to 32767 (the terminating 0 will be appended) it was truncated to 23767.
When testing the fix with OCAD12 it turned out that it was necessary to truncate to 32766, otherwise OCAD12 would not open the map.