### PR TITLE
OcdFileImport: Fix import of Rectangle symbols and objects

### DIFF
--- a/src/fileformats/ocd_file_import.cpp
+++ b/src/fileformats/ocd_file_import.cpp
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2013-2021 Kai Pastor
+ *    Copyright 2013-2022 Kai Pastor
  *
  *    Some parts taken from file_format_oc*d8{.h,_p.h,cpp} which are
  *    Copyright 2012 Pete Curtis
@@ -1749,7 +1749,8 @@ LineSymbol* OcdFileImport::importRectangleSymbol(const S& ocd_symbol)
 		
 		rect.inner_line = inner_line;
 		rect.text = text;
-		rect.number_from_bottom = ocd_symbol.grid_flags & 2;
+		rect.numbering_on = ocd_symbol.grid_flags & 2;
+		rect.number_from_bottom = ocd_symbol.grid_flags & 4;
 		rect.cell_width = 0.001 * convertLength(ocd_symbol.cell_width);
 		rect.cell_height = 0.001 * convertLength(ocd_symbol.cell_height);
 		rect.unnumbered_cells = ocd_symbol.unnumbered_cells;
@@ -2104,7 +2105,7 @@ Object* OcdFileImport::importRectangleObject(const Ocd::OcdPoint32* ocd_points, 
 		}
 		
 		// Create grid text
-		if (height >= rect.cell_height / 2)
+		if (rect.numbering_on && height >= rect.cell_height / 2)
 		{
 			for (int y = 0; y < num_cells_y; ++y) 
 			{
@@ -2114,9 +2115,9 @@ Object* OcdFileImport::importRectangleObject(const Ocd::OcdPoint32* ocd_points, 
 					QString cell_text;
 					
 					if (rect.number_from_bottom)
-						cell_num = y * num_cells_x + x + 1;
-					else
 						cell_num = (num_cells_y - 1 - y) * num_cells_x + x + 1;
+					else
+						cell_num = y * num_cells_x + x + 1;
 					
 					if (cell_num > num_cells_x * num_cells_y - rect.unnumbered_cells)
 						cell_text = rect.unnumbered_text;

--- a/src/fileformats/ocd_file_import.h
+++ b/src/fileformats/ocd_file_import.h
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2013-2018 Kai Pastor
+ *    Copyright 2013-2022 Kai Pastor
  *
  *    Some parts taken from file_format_oc*d8{.h,_p.h,cpp} which are
  *    Copyright 2012 Pete Curtis
@@ -76,6 +76,7 @@ protected:
 		// Only valid if has_grid is true
 		LineSymbol* inner_line;
 		TextSymbol* text;
+		bool numbering_on;
 		bool number_from_bottom;
 		double cell_width;
 		double cell_height;


### PR DESCRIPTION
The 'GridFlags' field consists of 3 bits: 1=Grid On, 2=Numbering On, 4=Numbered from the bottom
The symbol import previously only considered Grid On and mapped 'Numbered from the bottom' to Bit 1 instead.
When importing Rectangle objects the 'Numbered from the bottom' property was applied just the other way around.