### PR TITLE
OcdFileExport: Fix export of custom tabulator positions

### DIFF
--- a/src/fileformats/ocd_file_export.cpp
+++ b/src/fileformats/ocd_file_export.cpp
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2021 Kai Pastor
+ *    Copyright 2016-2022 Kai Pastor
  *
  *    Some parts taken from file_format_oc*d8{.h,_p.h,cpp} which are
  *    Copyright 2012 Pete Curtis
@@ -1948,9 +1948,19 @@ void OcdFileExport::setupTextSymbolSpecial(const TextSymbol* text_symbol, OcdTex
 	ocd_text_special.line_below_width = decltype(ocd_text_special.line_below_width)(convertSize(qRound(1000 * text_symbol->getLineBelowWidth())));
 	ocd_text_special.line_below_offset = decltype(ocd_text_special.line_below_offset)(convertSize(qRound(1000 * text_symbol->getLineBelowDistance())));
 	
-	ocd_text_special.num_tabs = text_symbol->getNumCustomTabs();
-	auto last_tab = std::min(ocd_text_special.num_tabs, decltype(ocd_text_special.num_tabs)(std::extent<typename std::remove_pointer<decltype(ocd_text_special.tab_pos)>::type>::value));
-	for (auto i = 0u; i < last_tab; ++i)
+	auto const num_tabs = text_symbol->getNumCustomTabs();
+	auto const max_tabs = int(std::extent<typename std::remove_pointer<decltype(ocd_text_special.tab_pos)>::type>::value);
+	if (num_tabs <= max_tabs)
+	{
+		ocd_text_special.num_tabs = num_tabs;
+	}
+	else
+	{
+		ocd_text_special.num_tabs = max_tabs;
+		addWarning(::OpenOrienteering::OcdFileExport::tr("In text symbol %1: exporting only %2 custom tabulator positions")
+		           .arg(text_symbol->getPlainTextName()).arg(max_tabs));
+	}
+	for (auto i = 0u; i < ocd_text_special.num_tabs; ++i)
 		ocd_text_special.tab_pos[i] = convertSize(text_symbol->getCustomTab(i));
 }
 

--- a/src/fileformats/ocd_file_export.cpp
+++ b/src/fileformats/ocd_file_export.cpp
@@ -1961,7 +1961,7 @@ void OcdFileExport::setupTextSymbolSpecial(const TextSymbol* text_symbol, OcdTex
 		           .arg(text_symbol->getPlainTextName()).arg(max_tabs));
 	}
 	for (auto i = 0u; i < ocd_text_special.num_tabs; ++i)
-		ocd_text_special.tab_pos[i] = convertSize(text_symbol->getCustomTab(i));
+		ocd_text_special.tab_pos[i] = convertSize(qint64(text_symbol->getCustomTab(i)));
 }
 
 

--- a/src/fileformats/ocd_types_v8.h
+++ b/src/fileformats/ocd_types_v8.h
@@ -331,7 +331,7 @@ namespace Ocd
 		quint16 indent_first_line;
 		quint16 indent_other_lines;
 		quint16 num_tabs;
-		quint32 tab_pos[32];
+		qint32 tab_pos[32];
 		quint16 line_below_on;
 		quint16 line_below_color;
 		quint16 line_below_width;


### PR DESCRIPTION
When exporting more than 32 custom tabulator positions the num_tabs
field is now limited to the 32 tabs that are actually only exported and
a warning messages is issued (issue was detected by lpechacek).
In addition the export now converts the tabulator position to a 32 bit
value since the convertSize function that was used before converted it
to a 16 bit value instead (which was indeed only relevant for tab
values larger than 327,67mm).