### PR TITLE
OcdParameterStreamReader: Documentation, more state

### DIFF
--- a/src/fileformats/ocd_parameter_stream_reader.cpp
+++ b/src/fileformats/ocd_parameter_stream_reader.cpp
@@ -20,6 +20,8 @@
 
 #include "ocd_parameter_stream_reader.h"
 
+#include <cmath>
+
 #include <QtGlobal>
 #include <QChar>
 #include <QLatin1Char>
@@ -58,7 +60,7 @@ bool OcdParameterStreamReader::readNext()
 
 QStringRef OcdParameterStreamReader::value() const
 {
-	return param_string.midRef(pos, next - pos);
+	return param_string.midRef(pos, std::max(-1, next - pos));
 }
 
 

--- a/src/fileformats/ocd_parameter_stream_reader.cpp
+++ b/src/fileformats/ocd_parameter_stream_reader.cpp
@@ -1,5 +1,6 @@
 /*
  *    Copyright 2022 Matthias Kühlewein
+ *    Copyright 2022 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -19,6 +20,7 @@
 
 #include "ocd_parameter_stream_reader.h"
 
+#include <QtGlobal>
 #include <QChar>
 #include <QLatin1Char>
 
@@ -28,50 +30,35 @@ namespace OpenOrienteering {
 OcdParameterStreamReader::OcdParameterStreamReader(const QString& param_string) noexcept
  : param_string(param_string)
  , pos(0)
+ , next(param_string.indexOf(QLatin1Char('\t')))
+ , current_key(noKey())
 {}
 
 bool OcdParameterStreamReader::readNext()
 {
 	while (!atEnd())
 	{
-		pos = param_string.indexOf(QLatin1Char('\t'), pos);
-		if (pos < 0 || pos + 1 >= param_string.length())	// accept \t at end only if there is space for at least the key
+		pos = next + 1;
+		next = param_string.indexOf(QLatin1Char('\t'), pos);
+		if (pos < param_string.length())
 		{
-			pos = param_string.length();
-			return false;
+			current_key = param_string.at(pos).toLatin1();
+			if (Q_LIKELY(current_key != '\t'))
+			{
+				++pos;
+				return true;
+			}
 		}
-		++pos;
-		if (param_string.at(pos).toLatin1() != '\t')	// is the next key \t ? if yes then skip over
-			return true;
 	}
+	
+	current_key = noKey();
+	pos = param_string.length();
 	return false;
-}
-
-char OcdParameterStreamReader::key() const
-{
-	if (!pos || atEnd())
-		return noKey();
-
-	return param_string.at(pos).toLatin1();
 }
 
 QStringRef OcdParameterStreamReader::value() const
 {
-	QStringRef ref;
-	
-	if (!atEnd())
-	{
-		int start = pos ? pos + 1 : pos;
-		if (start < param_string.length())
-		{
-			int end = param_string.indexOf(QLatin1Char('\t'), start);
-			if (end < 0)
-				end = param_string.length();
-			if (end > start)
-				ref = param_string.midRef(start, end - start);
-		}
-	}
-	return ref;
+	return param_string.midRef(pos, next - pos);
 }
 
 

--- a/src/fileformats/ocd_parameter_stream_reader.h
+++ b/src/fileformats/ocd_parameter_stream_reader.h
@@ -1,5 +1,6 @@
 /*
  *    Copyright 2022 Matthias Kühlewein
+ *    Copyright 2022 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -48,7 +49,7 @@ public:
 	/**
 	 * Returns the current key.
 	 */
-	char key() const;
+	char key() const { return current_key; }
 	
 	/**
 	 * Returns the current value.
@@ -58,7 +59,7 @@ public:
 	/**
 	 * Returns true if there is no more data.
 	 */
-	bool atEnd() const { return pos >= param_string.length(); }
+	bool atEnd() const { return next == -1; }
 	
 	/**
 	 * The value returned by `key()` for the first value, or at the end of input.
@@ -67,7 +68,9 @@ public:
 	
 private:
 	QString param_string;
-	int pos;
+	int pos;  ///< The begin of the current value substring, or param_string.length().
+	int next; ///< The position after the end of the current value substring, or -1 if reaching the end of input.
+	char current_key;
 };
 
 }  // namespace Openorienteering

--- a/src/fileformats/ocd_parameter_stream_reader.h
+++ b/src/fileformats/ocd_parameter_stream_reader.h
@@ -34,8 +34,7 @@ class OcdParameterStreamReader
 {
 public:
 	/**
-	 * Constructs a new reader object. The given string object must exist as long
-	 * as the reader is used.
+	 * Constructs a new reader object.
 	 */
 	explicit OcdParameterStreamReader(const QString& param_string) noexcept;
 	
@@ -67,7 +66,7 @@ public:
 	static constexpr char noKey() { return 0; }
 	
 private:
-	const QString& param_string;
+	QString param_string;
 	int pos;
 };
 

--- a/src/fileformats/ocd_parameter_stream_reader.h
+++ b/src/fileformats/ocd_parameter_stream_reader.h
@@ -27,17 +27,43 @@ namespace OpenOrienteering {
 
 
 /**
- * A class for processing OCD parameter string,
+ * A class for processing OCD parameter strings,
  * loosely modeled after QXmlStreamReader.
  */
 class OcdParameterStreamReader
 {
 public:
+	/**
+	 * Constructs a new reader object. The given string object must exist as long
+	 * as the reader is used.
+	 */
 	explicit OcdParameterStreamReader(const QString& param_string) noexcept;
+	
+	/**
+	 * Reads the input until the next key-value pair.
+	 * 
+	 * @return True if another key-value pair was reached. False for end of input.
+	 */
 	bool readNext();
+	
+	/**
+	 * Returns the current key.
+	 */
 	char key() const;
+	
+	/**
+	 * Returns the current value.
+	 */
 	QStringRef value() const;
+	
+	/**
+	 * Returns true if there is no more data.
+	 */
 	bool atEnd() const { return pos >= param_string.length(); }
+	
+	/**
+	 * The value returned by `key()` for the first value, or at the end of input.
+	 */
 	static constexpr char noKey() { return 0; }
 	
 private:

--- a/test/ocd_parameter_stream_reader_t.cpp
+++ b/test/ocd_parameter_stream_reader_t.cpp
@@ -1,21 +1,22 @@
 /*
-*    Copyright 2022 Matthias Kühlewein
-*
-*    This file is part of OpenOrienteering.
-*
-*    OpenOrienteering is free software: you can redistribute it and/or modify
-*    it under the terms of the GNU General Public License as published by
-*    the Free Software Foundation, either version 3 of the License, or
-*    (at your option) any later version.
-*
-*    OpenOrienteering is distributed in the hope that it will be useful,
-*    but WITHOUT ANY WARRANTY; without even the implied warranty of
-*    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-*    GNU General Public License for more details.
-*
-*    You should have received a copy of the GNU General Public License
-*    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
-*/
+ *    Copyright 2022 Matthias Kühlewein
+ *    Copyright 2022 Kai Pastor
+ *
+ *    This file is part of OpenOrienteering.
+ *
+ *    OpenOrienteering is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OpenOrienteering is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include <QtGlobal>
 #include <QtTest>
@@ -116,6 +117,7 @@ private slots:
 		QTest::addColumn<QString>("result_pattern");
 		
 		QTest::newRow("Empty string") << "" << "";
+		QTest::newRow("Only tabs")    << "\t\t" << "";
 		QTest::newRow("Leading tabs") << "\t\t\ta73" << "a";
 		QTest::newRow("Trailing tab") << "\ta73\t" << "a";
 		QTest::newRow("Multiple separating tabs") << "\ta73\t\t\tb73" << "ab";


### PR DESCRIPTION
@dl3sdo A few more changes which I couldn't finish before this afternoon. Would have been much harder without the unit test. 

Apart from documentation, this change ensures that `param_string.indexOf(QLatin1Char('\t') ...)` is called only once per tab character. All complexity is in `readNext()`.