### PR TITLE
OcdFileExport: Factor out prepareTextSymbolExport()

### DIFF
--- a/src/fileformats/ocd_file_export.h
+++ b/src/fileformats/ocd_file_export.h
@@ -121,6 +121,8 @@ class OcdFileExport : public Exporter
 	
 	using StringAppender = void (qint32, const QString&);
 	
+	struct TextFormatMapping;
+	
 public:
 	/// \todo Add proper API
 	static quint16 default_version;
@@ -214,6 +216,8 @@ protected:
 	
 	template< class OcdTextSymbol >
 	QByteArray exportTextSymbol(const TextSymbol* text_symbol, quint32 symbol_number, int alignment);
+	
+	std::vector<TextFormatMapping>::iterator prepareTextSymbolExport(const TextSymbol* text_symbol);
 	
 	template< class OcdTextSymbol >
 	void setupTextSymbolExtra(const TextSymbol* text_symbol, OcdTextSymbol& ocd_text_symbol);


### PR DESCRIPTION
A significant part of text symbol export for OCD is preparatory stuff,
independent of actual OCD format. This commit adds a separate member
function, helping to minimize the code size of the template function.