### PR TITLE
ObjectQueryParser: Object query fixes

### DIFF
--- a/src/core/objects/object_query.cpp
+++ b/src/core/objects/object_query.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2016 Mitchell Krome
- *    Copyright 2017-2020 Kai Pastor
+ *    Copyright 2017-2022 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -858,7 +858,7 @@ void ObjectQueryParser::getToken()
 		++pos;
 	}
 	else if ((current == QLatin1Char('!') || current == QLatin1Char('~'))
-	         && pos < input.length()
+	         && pos+1 < input.length()
 	         && input.at(pos+1) == QLatin1Char('='))
 	{
 		token = TokenTextOperator;
@@ -880,7 +880,7 @@ void ObjectQueryParser::getToken()
 				break;
 			}
 			else if ((current == QLatin1Char('!') || current == QLatin1Char('~'))
-			         && pos < input.length()
+			         && pos+1 < input.length()
 			         && input.at(pos+1) == QLatin1Char('='))
 			{
 				break;

--- a/src/core/objects/object_query.cpp
+++ b/src/core/objects/object_query.cpp
@@ -80,7 +80,6 @@ QString fromEscaped(QString string)
 		if (c == QLatin1Char('\\'))
 		{
 			string.remove(i, 1);
-			++i;
 		}
 	}
 	return string;

--- a/src/core/objects/object_query.cpp
+++ b/src/core/objects/object_query.cpp
@@ -833,8 +833,7 @@ void ObjectQueryParser::getToken()
 			}
 			else if (current == QLatin1Char('\\'))
 			{
-				if (pos < input.length())
-					++pos;
+				++pos;
 			}
 		}
 	}

--- a/test/object_query_t.cpp
+++ b/test/object_query_t.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2016 Mitchell Krome
- *    Copyright 2017-2020 Kai Pastor
+ *    Copyright 2017-2022 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -488,6 +488,11 @@ void ObjectQueryTest::testParser()
 	QCOMPARE(p.parse(QStringLiteral("NOT (NOT \"1\") AND \"3\"")), q);
 	QCOMPARE(p.parse(QStringLiteral("(NOT NOT \"1\") AND \"3\"")), q);
 	QCOMPARE(p.parse(QStringLiteral("(NOT (NOT \"1\")) AND \"3\"")), q);
+	
+	q = ObjectQuery(QStringLiteral("A"), ObjectQuery::OperatorIs, QStringLiteral("\"1\""));	// "1"
+	QCOMPARE(p.parse(QStringLiteral("A = \"\\\"1\\\"\"")), q);	// A = "\"1\""
+	q = ObjectQuery(QStringLiteral("A"), ObjectQuery::OperatorIs, QStringLiteral("\"\\1\""));	// "\1"
+	QCOMPARE(p.parse(QStringLiteral("A = \"\\\"\\\\1\\\"\"")), q);	// A = "\"\\1\""
 	
 	Map m;
 	auto* symbol_1 = new PointSymbol();


### PR DESCRIPTION
There are two bugs in object_query.cpp:
- for special object queries an out_of_range access occurs which leads to a crash in the Debug version.
- the fromEscaped() functions fails for sequences of escaped characters (to verify the correct behaviour a test was added to ObjectQueryTest).

The last change is the removal of an unnecessary if condition.