### PR TITLE
GdalSettingsPage: Delete 'Value' cell

### DIFF
--- a/src/gdal/gdal_settings_page.cpp
+++ b/src/gdal/gdal_settings_page.cpp
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 Kai Pastor
+ *    Copyright 2016-2022 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -217,7 +217,7 @@ void GdalSettingsPage::cellChange(int row, int column)
 			if (row == last_row)
 			{
 				parameters->item(row, 0)->setText({ });
-				parameters->item(row, 0)->setText({ });
+				parameters->item(row, 1)->setText({ });
 			}
 			else
 			{


### PR DESCRIPTION
When a duplicated 'Parameter' is entered the behaviour depends whether
the row is the last row or not.
If it's not the last row, then the complete row is removed, i.e. also
the 'Value' content is deleted.
If it's the last row then just the cell contents shall be deleted.
However, due to a copy-and-paste error only the 'Parameter' cell
content was deleted (twice).