### PR TITLE
Licensing: Find GDAL license on Arch Linux

### DIFF
--- a/doc/licensing/arch-licensing.cmake
+++ b/doc/licensing/arch-licensing.cmake
@@ -1,5 +1,5 @@
 #
-#    Copyright 2017 Kai Pastor
+#    Copyright 2017-2022 Kai Pastor
 #    
 #    This file is part of OpenOrienteering.
 # 
@@ -24,4 +24,5 @@ include("linux-distribution.cmake")
 set(system_copyright_dir "/usr/share/licenses")
 set(copyright_pattern
   "${system_copyright_dir}/@package@/LICENSE"
+  "${system_copyright_dir}/@package@/LICENSE.TXT" # gdal
 )


### PR DESCRIPTION
This change enables cmake to find the GDAL's LICENSE.TXT.