### PR TITLE
Export georeferencing to OCD more accurately

### DIFF
--- a/src/fileformats/ocd_file_export.cpp
+++ b/src/fileformats/ocd_file_export.cpp
@@ -958,6 +958,7 @@ void OcdFileExport::exportGeoreferencing()
 	    << qSetRealNumberPrecision(4)
 	    << "\tg" << grid_spacing_map
 	    << "\tr" << fields.r
+	    << qSetRealNumberPrecision(9)
 	    << "\tx" << fields.x
 	    << "\ty" << fields.y
 	    << qSetRealNumberPrecision(8)

--- a/src/fileformats/ocd_file_import.cpp
+++ b/src/fileformats/ocd_file_import.cpp
@@ -394,10 +394,18 @@ void OcdFileImport::importGeoreferencing(const QString& param_string)
 			}
 			break;
 		case 'x':
-			tryParamConvert(fields.x, param_value);
+			{
+				auto real_offset_x = param_value.toDouble(&ok);
+				if (ok)
+					fields.x = real_offset_x;
+			}
 			break;
 		case 'y':
-			tryParamConvert(fields.y, param_value);
+			{
+				auto real_offset_y = param_value.toDouble(&ok);
+				if (ok)
+					fields.y = real_offset_y;
+			}
 			break;
 		case 'i':
 			tryParamConvert(fields.i, param_value);

--- a/src/fileformats/ocd_georef_fields.cpp
+++ b/src/fileformats/ocd_georef_fields.cpp
@@ -839,8 +839,8 @@ bool operator==(const OcdGeorefFields& lhs, const OcdGeorefFields& rhs)
 {
 	return lhs.i == rhs.i
 	        && ((qIsNaN(lhs.m) && qIsNaN(rhs.m)) || qAbs(lhs.m - rhs.m) < 5e-9) // 8-digit precision or both NaN's
-	        && lhs.x == rhs.x
-	        && lhs.y == rhs.y
+	        && ((qIsNaN(lhs.x) && qIsNaN(rhs.x)) || qAbs(lhs.x - rhs.x) < 5e-9) // 8-digit precision or both NaN's
+	        && ((qIsNaN(lhs.y) && qIsNaN(rhs.y)) || qAbs(lhs.y - rhs.y) < 5e-9) // 8-digit precision or both NaN's
 	        && ((qIsNaN(lhs.a) && qIsNaN(rhs.a)) || qAbs(lhs.a - rhs.a) < 5e-9) // 8-digit precision or both NaN's
 	        && lhs.r == rhs.r;
 }
@@ -873,8 +873,8 @@ OcdGeorefFields OcdGeorefFields::fromGeoref(const Georeferencing& georef,
 	retval.a = georef.getGrivation();
 	retval.m = georef.getScaleDenominator() * georef.getCombinedScaleFactor();
 	const QPointF offset(georef.toProjectedCoords(MapCoord{}));
-	retval.x = qRound(offset.x()); // OCD easting and northing is integer
-	retval.y = qRound(offset.y());
+	retval.x = offset.x();
+	retval.y = offset.y();
 
 	// attempt translation from Mapper CRS reference into OCD one
 	auto crs_id_string = georef.getProjectedCRSId();

--- a/src/fileformats/ocd_georef_fields.h
+++ b/src/fileformats/ocd_georef_fields.h
@@ -40,10 +40,10 @@ class Georeferencing;
 struct OcdGeorefFields
 {
 	double a { 0 },     ///< Real world angle
-	       m { 15000 }; ///< Map scale, relative to grid
-	int x { 0 },        ///< Real world offset easting
-	    y { 0 },        ///< Real world offset northing
-	    i { 1000 },     ///< Grid and zone
+	       m { 15000 }, ///< Map scale, relative to grid
+	       x { 0 },     ///< Real world offset easting
+	       y { 0 };     ///< Real world offset northing
+	int i { 1000 },     ///< Grid and zone
 	    r { 0 };        ///< Real world coord (0 = paper, 1 = real world)
 
 	/**

--- a/test/georef_ocd_mapping_t.cpp
+++ b/test/georef_ocd_mapping_t.cpp
@@ -93,8 +93,8 @@ char* toString(const OcdGeorefFields &f) // NOLINT : declared parameter name is 
 {
 	auto ret = QString(QStringLiteral("m:%1; x:%2; y:%3; a:%4; i:%5; r:%6"))
 	           .arg(f.m, 0, 'f', 3)
-	           .arg(f.x)
-	           .arg(f.y)
+	           .arg(f.x, 0, 'f', 2)
+	           .arg(f.y, 0, 'f', 2)
 	           .arg(f.a, 0, 'f', 8)
 	           .arg(f.i)
 	           .arg(f.r);


### PR DESCRIPTION
This change addresses the case described in #2080, in which a map was exported to an OCAD file format, and then when imported its map objects were offset from their original geolocations.

First, it changes handling of the georeferencing scale and offsets from integers to floating point. Actually, Mapper was already reading those values as floating point during import. All that was necessary was (1) eliminate some intermediate conversions to integer, and (2) use floating point formatting for output, with appropriate precision.

I tested that a current version of OCAD accepts floating point values in the input. It does sometimes round them to integers, which can affect the geolocations of map objects.

Second, this change addresses that OCAD's _map scale_ is calculated relative to the projected _grid_, which differs from Mapper's map scale that is relative to the ellipsoid shape of the earth. For example, start with the OSM data provided in #2080. At that location, the grid scale factor for UTM is 0.9996. If Mapper creates a map from that OSM data with a scale of 1:10,000 and a UTM coordinate system, then the map scale from the OCAD point of view is 1:9,996.

This change is not high priority, because the offsets that it fixes are on the order of 1 meter in the example that I checked. It's a pretty straightforward fix, but there's some risk of being less compatible with OCAD. On the whole I believe it is worthwhile, and is a good way to address #2080.