### PR TITLE
MapEditorController: Select pan tool on touch UI startup

### DIFF
--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -820,6 +820,10 @@ void MapEditorController::attach(MainWindow* window)
 		if (mobile_mode)
 		{
 			createSymbolWidget(window);
+
+			// Activate the map view pan tool
+			pan_act->setChecked(true);
+			pan();
 		}
 		else
 		{
@@ -830,11 +834,11 @@ void MapEditorController::attach(MainWindow* window)
 			
 			if (map->getNumColors() == 0)
 				QTimer::singleShot(0, color_dock_widget, &QWidget::show);
+
+			// Activate the edit tool
+			edit_tool_act->setChecked(true);
+			setEditTool();
 		}
-		
-		// Auto-select the edit tool
-		edit_tool_act->setChecked(true);
-		setEditTool();
 		
 		// Set the coordinates display mode
 		coordsDisplayChanged();


### PR DESCRIPTION
The edit mode is selected by default on editor startup. However, in the touch UI, object editing is rarely the first action to be done after opening a map. The user typically pans the map view to the area of interest first and then starts editing.

This code change makes the touch UI start in the view pan mode. The desktop action remains to be editing as the desktop users use mouse middle button for editing.

Discussed in GH-982.