### PR TITLE
LineSymbolSettings: Fix enabling/disabling in line symbol editor

### DIFF
--- a/src/gui/symbols/line_symbol_settings.cpp
+++ b/src/gui/symbols/line_symbol_settings.cpp
@@ -254,7 +254,6 @@ LineSymbolSettings::LineSymbolSettings(LineSymbol* symbol, SymbolSettingDialog* 
 	mid_symbol_widget_list = {
 	    mid_symbol_placement_label, mid_symbol_placement_combo,
 	    mid_symbol_per_spot_label, mid_symbol_per_spot_edit,
-	    mid_symbol_distance_label, mid_symbol_distance_edit,
 	    show_at_least_one_symbol_check,
 	};
 	

--- a/src/gui/symbols/line_symbol_settings.cpp
+++ b/src/gui/symbols/line_symbol_settings.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2018 Kai Pastor
+ *    Copyright 2012-2019, 2024 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -40,9 +40,9 @@
 #include <QVariant>
 #include <QWidget>
 
-#include "core/symbols/symbol.h"
 #include "core/symbols/line_symbol.h"
 #include "core/symbols/point_symbol.h"
+#include "core/symbols/symbol.h"
 #include "gui/util_gui.h"
 #include "gui/symbols/point_symbol_editor_widget.h"
 #include "gui/symbols/symbol_setting_dialog.h"
@@ -69,7 +69,9 @@ SymbolPropertiesWidget* LineSymbol::createPropertiesWidget(SymbolSettingDialog* 
 // ### LineSymbolSettings ###
 
 LineSymbolSettings::LineSymbolSettings(LineSymbol* symbol, SymbolSettingDialog* dialog)
-: SymbolPropertiesWidget(symbol, dialog), symbol(symbol), dialog(dialog)
+: SymbolPropertiesWidget(symbol, dialog)
+, symbol(symbol)
+, dialog(dialog)
 {
 	auto map = dialog->getPreviewMap();
 	
@@ -252,6 +254,7 @@ LineSymbolSettings::LineSymbolSettings(LineSymbol* symbol, SymbolSettingDialog* 
 	mid_symbol_widget_list = {
 	    mid_symbol_placement_label, mid_symbol_placement_combo,
 	    mid_symbol_per_spot_label, mid_symbol_per_spot_edit,
+	    mid_symbol_distance_label, mid_symbol_distance_edit,
 	    show_at_least_one_symbol_check,
 	};
 	
@@ -717,8 +720,9 @@ void LineSymbolSettings::updateStates()
 	{
 		mid_symbol_widget->setEnabled(!symbol->mid_symbol->isEmpty());
 	}
-	mid_symbol_distance_label->setEnabled(mid_symbol_distance_label->isEnabled() && symbol->mid_symbols_per_spot > 1);
-	mid_symbol_distance_edit->setEnabled(mid_symbol_distance_edit->isEnabled() && symbol->mid_symbols_per_spot > 1);
+	const bool mid_symbol_distance_enabled = !symbol->mid_symbol->isEmpty() && symbol->mid_symbols_per_spot > 1;
+	mid_symbol_distance_label->setEnabled(mid_symbol_distance_enabled);
+	mid_symbol_distance_edit->setEnabled(mid_symbol_distance_enabled);
 	
 	const bool border_active = symbol_active && symbol->have_border_lines;
 	for (auto border_widget : border_widget_list)


### PR DESCRIPTION
The 'mid symbol distance' field and label were not correctly disabled and enabled.
Enabling them by increasing 'Mid symbols per spot' was not possible unless reentering the symbols setting dialog. If they were enabled, removing the mid symbol would not disable them.
Adding both to `mid_symbol_widget_list` solves the issue.

Alternatively it would have been possible to replace in `mid_symbol_distance_edit->setEnabled(mid_symbol_distance_edit->isEnabled() &&` ...
by
`mid_symbol_distance_edit->setEnabled(!symbol->mid_symbol->isEmpty() &&` ...