### PR TITLE
Import of graphic, layout and image objects

### DIFF
--- a/src/fileformats/file_import_export.h
+++ b/src/fileformats/file_import_export.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Pete Curtis
- *    Copyright 2018 Kai Pastor
+ *    Copyright 2018, 2023 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -111,6 +111,13 @@ public:
 	 * The provided message should be translated.
 	 */
 	void addWarning(const QString& str) { warnings_.emplace_back(str); }
+	
+	/**
+	 * Adds a string to the current list of warnings if not yet in the list.
+	 * 
+	 * The provided message should be translated.
+	 */
+	void addWarningOnce(const QString& str) { if (std::find(warnings_.begin(), warnings_.end(), str) == warnings_.end()) warnings_.emplace_back(str); }
 	
 	/**
 	 * Returns the current list of warnings collected by this object.

--- a/src/fileformats/ocd_file_import.cpp
+++ b/src/fileformats/ocd_file_import.cpp
@@ -1066,34 +1066,22 @@ void OcdFileImport::importDisplayPar(const OcdFile< F >& file)
 
 void OcdFileImport::importDisplayPar(const QString& param_string)
 {
-	const QChar* unicode = param_string.unicode();
+	OcdParameterStreamReader parameters(param_string);
 	
-	int i = param_string.indexOf(QLatin1Char('\t'), 0);
-	; // skip first word for this entry type
-	while (i >= 0)
+	while (parameters.readNext())
 	{
-		int next_i = param_string.indexOf(QLatin1Char('\t'), i+1);
-		int len = (next_i > 0 ? next_i : param_string.length()) - i - 2;
-		const QString param_value = QString::fromRawData(unicode+i+2, len); // no copying!
-		switch (param_string[i+1].toLatin1())
+		QStringRef param_value = parameters.value();
+		switch (parameters.key())
 		{
-		case '\t':
-			// empty item
-			break;
 		case 'j':
-			{
-				graphic_objects_hidden = param_value.toInt() == 2;
-				break;
-			}
+			graphic_objects_hidden = param_value.toInt() == 2;
+			break;
 		case 'l':
-			{
-				layout_objects_hidden = param_value.toInt() == 2;
-				break;
-			}
+			layout_objects_hidden = param_value.toInt() == 2;
+			break;
 		default:
 			; // nothing
 		}
-		i = next_i;
 	}
 }
 

--- a/src/fileformats/ocd_file_import.cpp
+++ b/src/fileformats/ocd_file_import.cpp
@@ -111,6 +111,7 @@ OcdFileImport::OcdFileImport(const QString& path, Map* map, MapView* view)
  , custom_8bit_encoding { codecFromSettings() }
  , graphic_objects_hidden(false)
  , layout_objects_hidden(false)
+ , image_objects_displaymode(0)
 {
 	if (!custom_8bit_encoding)
 	{
@@ -1076,10 +1077,13 @@ void OcdFileImport::importDisplayPar(const QString& param_string)
 		switch (parameters.key())
 		{
 		case 'j':
-			graphic_objects_hidden = param_value.toInt() == 2;
+			graphic_objects_hidden = param_value.toInt() == Ocd::SymbolHidden;
+			break;
+		case 'k':
+			image_objects_displaymode = param_value.toInt();
 			break;
 		case 'l':
-			layout_objects_hidden = param_value.toInt() == 2;
+			layout_objects_hidden = param_value.toInt() == Ocd::SymbolHidden;
 			break;
 		default:
 			; // nothing
@@ -1879,87 +1883,47 @@ void OcdFileImport::setupPointSymbolPattern(PointSymbol* symbol, std::size_t dat
 	}
 }
 
-
-Symbol* OcdFileImport::getGraphicObjectSymbol(const Ocd::ObjectV8& ocd_object)
-{
-	Q_UNUSED(ocd_object);
-	return nullptr;
-}
-
-
-template< class O >
-Symbol* OcdFileImport::getGraphicObjectSymbol(const O& ocd_object)
-{
-	Symbol* symbol = nullptr;
-	auto symbol_setup_common = [this](Symbol& symbol) {
-		symbol.setName(QLatin1String("helper symbol for graphic objects"));
-		symbol.setNumberComponent(0, 999);
-		symbol.setNumberComponent(1, -1);
-		symbol.setNumberComponent(2, -1);
-		symbol.setHidden(graphic_objects_hidden);
-	};
-	
-	switch (ocd_object.type)
-	{
-	case Ocd::ObjectTypeLine:
-		{
-			auto* line_symbol = new OcdImportedLineSymbol();
-			symbol_setup_common(*line_symbol);
-			line_symbol->color = convertColor(ocd_object.color);
-			line_symbol->line_width = convertLength(ocd_object.line_width);
-			symbol = line_symbol;
-		}
-		break;
-	case Ocd::ObjectTypeArea:
-		{
-			auto* area_symbol = new OcdImportedAreaSymbol();
-			symbol_setup_common(*area_symbol);
-			area_symbol->color = convertColor(ocd_object.color);
-			symbol = area_symbol;
-		}
-		break;
-	default:
-		addWarning(tr("Encountered an unsupported type of graphic object (%1). Skipping.").arg(ocd_object.type));
-		break;
-	}
-	
-	if (symbol)
-	{
-		int num_symbols = map->getNumSymbols();
-		for (int i = 0; i < num_symbols; ++i)
-		{
-			if (symbol->equals(map->getSymbol(i)))
-			{
-				delete symbol;
-				return map->getSymbol(i);
-			}
-		}
-		map->addSymbol(symbol, map->getNumSymbols());
-	}
-	return symbol;
-}
-
-Symbol* OcdFileImport::getLayoutObjectSymbol(const Ocd::ObjectV8& ocd_object)
+Symbol* OcdFileImport::getSpecialObjectSymbol(const Ocd::ObjectV8& ocd_object)
 {
 	Q_UNUSED(ocd_object);
 	return nullptr;
 }
 
 template< class O >
-Symbol* OcdFileImport::getLayoutObjectSymbol(const O& ocd_object)
+Symbol* OcdFileImport::getSpecialObjectSymbol(const O& ocd_object)
 {
+	using LineStyle = Ocd::LineSymbolCommonV8;
+	
 	Symbol* symbol = nullptr;
 	auto h_alignment = TextObject::AlignHCenter;
+	float opacity = 1.0f;
 	
-	auto symbol_setup_common = [this](Symbol& symbol) {
-		symbol.setName(QLatin1String("helper symbol for layout objects"));
-		symbol.setNumberComponent(0, 998);
+	auto symbol_setup_common = [this](Symbol& symbol, const O& ocd_object) {
+		if (ocd_object.symbol == Ocd::LayoutObject)
+		{
+			symbol.setName(QLatin1String("Auxiliary symbol for layout objects"));
+			symbol.setNumberComponent(0, 998);
+			symbol.setHidden(layout_objects_hidden);
+		}
+		else if (ocd_object.symbol == Ocd::ImageObject)
+		{
+			symbol.setName(QLatin1String("Auxiliary symbol for image objects"));
+			symbol.setNumberComponent(0, 997);
+			symbol.setProtected(bool(image_objects_displaymode & Ocd::SymbolProtected));
+			symbol.setHidden(bool(image_objects_displaymode & Ocd::SymbolHidden));
+		}
+		else
+		{
+			symbol.setName(QLatin1String("Auxiliary symbol for graphic objects"));
+			symbol.setNumberComponent(0, 999);
+			symbol.setHidden(graphic_objects_hidden);
+		}
 		symbol.setNumberComponent(1, -1);
 		symbol.setNumberComponent(2, -1);
-		symbol.setHidden(layout_objects_hidden);
+		
 	};
 	
-	auto get_map_color = [this](const quint32 color) {
+	auto get_map_color = [this](const quint32 color, const float opacity) {
 		MapColorCmyk cmyk;
 		cmyk.c = quint8(color) / 255.f;
 		cmyk.m = quint8(color >> 8) / 255.f;
@@ -1972,8 +1936,9 @@ Symbol* OcdFileImport::getLayoutObjectSymbol(const O& ocd_object)
 			if (map_cymk == cmyk)	// actually a fuzzy comparision
 				return const_cast<MapColor*>(map->getColor(i));
 		}
-		auto new_color = new MapColor(tr("Imported layout object"), num_colors);
+		auto new_color = new MapColor(tr("Imported layout or image object"), num_colors);
 		new_color->setCmyk(cmyk);
+		new_color->setOpacity(opacity);
 		map->addColor(new_color, num_colors);
 		return new_color;
 	};
@@ -1983,25 +1948,57 @@ Symbol* OcdFileImport::getLayoutObjectSymbol(const O& ocd_object)
 	case Ocd::ObjectTypeLine:
 		{
 			auto* line_symbol = new OcdImportedLineSymbol();
-			symbol_setup_common(*line_symbol);
-			line_symbol->color = get_map_color(quint32(ocd_object.color));
+			symbol_setup_common(*line_symbol, ocd_object);
+			line_symbol->color = ocd_object.symbol == Ocd::GraphicObject ? convertColor(ocd_object.color) : get_map_color(quint32(ocd_object.color), opacity);
 			line_symbol->line_width = convertLength(ocd_object.line_width);
+			// Cap and join styles
+			switch (ocd_object.diam_flags)
+			{
+			case LineStyle::BevelJoin_FlatCap:
+				line_symbol->join_style = LineSymbol::BevelJoin;
+				line_symbol->cap_style = LineSymbol::FlatCap;
+				break;
+			case LineStyle::RoundJoin_RoundCap:
+				line_symbol->join_style = LineSymbol::RoundJoin;
+				line_symbol->cap_style = LineSymbol::RoundCap;
+				break;
+			case LineStyle::BevelJoin_PointedCap:
+				line_symbol->join_style = LineSymbol::BevelJoin;
+				line_symbol->cap_style = LineSymbol::PointedCap;
+				break;
+			case LineStyle::RoundJoin_PointedCap:
+				line_symbol->join_style = LineSymbol::RoundJoin;
+				line_symbol->cap_style = LineSymbol::PointedCap;
+				break;
+			case LineStyle::MiterJoin_FlatCap:
+				line_symbol->join_style = LineSymbol::MiterJoin;
+				line_symbol->cap_style = LineSymbol::FlatCap;
+				break;
+			case LineStyle::MiterJoin_PointedCap:
+				line_symbol->join_style = LineSymbol::MiterJoin;
+				line_symbol->cap_style = LineSymbol::PointedCap;
+				break;
+			default:
+				addSymbolWarning( line_symbol,
+								  tr("Unsupported line style '%1'.").
+								  arg(ocd_object.diam_flags) );
+			}
 			symbol = line_symbol;
 		}
 		break;
 	case Ocd::ObjectTypeArea:
 		{
 			auto* area_symbol = new OcdImportedAreaSymbol();
-			symbol_setup_common(*area_symbol);
-			area_symbol->color = get_map_color(quint32(ocd_object.color));
+			symbol_setup_common(*area_symbol, ocd_object);
+			area_symbol->color = ocd_object.symbol == Ocd::GraphicObject ? convertColor(ocd_object.color) : get_map_color(quint32(ocd_object.color), opacity);
 			symbol = area_symbol;
 		}
 		break;
-	case Ocd::ObjectTypeUnformattedText:
+	case Ocd::ObjectTypeUnformattedText:	// only for layout objects
 		{
 			auto* text_symbol = new OcdImportedTextSymbol();
-			symbol_setup_common(*text_symbol);
-			text_symbol->color = get_map_color(quint32(ocd_object.color));
+			symbol_setup_common(*text_symbol, ocd_object);
+			text_symbol->kerning = false;
 			
 			auto data = QString(reinterpret_cast<const QChar *>(ocd_object.coords + ocd_object.num_items + ocd_object.num_text));
 			OcdParameterStreamReader parameters(data);
@@ -2051,23 +2048,33 @@ Symbol* OcdFileImport::getLayoutObjectSymbol(const O& ocd_object)
 					if (ok)
 						text_symbol->font_size = qRound(1000.0 * f_value / 72.0 * 25.4);
 					break;
-				case 'o':	// probably opacity value
+				case 'o':
+					f_value = param_value.toFloat(&ok);
+					if (ok && f_value >= 0.f && f_value <= 100.f)
+						opacity = 0.01f * f_value;
 					break;
 				default:
 					; // nothing
 				}
 			}
+			text_symbol->color = get_map_color(quint32(ocd_object.color), opacity);
 			text_symbol->updateQFont();
 			symbol = text_symbol;
 		}
 		break;
 	default:
-		addWarning(tr("Encountered an unsupported type of layout object (%1). Skipping.").arg(ocd_object.type));
+		addWarning(tr("Encountered an unsupported type of graphical object (%1). Skipping.").arg(ocd_object.type));
 		break;
 	}
 	
 	if (symbol)
 	{
+		if (ocd_object.symbol == Ocd::LayoutObject)
+			addWarningOnce(tr("Importing layout objects using auxiliary symbols. Export as layout objects is not possible."));
+		else if (ocd_object.symbol == Ocd::ImageObject)
+			addWarningOnce(tr("Importing image objects using auxiliary symbols. Export as image objects is not possible."));
+		else
+			addWarningOnce(tr("Importing graphic objects using auxiliary symbols. Export as graphic objects is not possible."));
 		int num_symbols = map->getNumSymbols();
 		for (int i = 0; i < num_symbols; ++i)
 		{
@@ -2093,11 +2100,10 @@ Object* OcdFileImport::importObject(const O& ocd_object, MapPart* part)
 	Symbol* symbol = nullptr;
 	switch (ocd_object.symbol)
 	{
-	case -2: // graphic object
-		symbol = getGraphicObjectSymbol(ocd_object);
-		break;
-	case -4: // layout object
-		symbol = getLayoutObjectSymbol(ocd_object);
+	case Ocd::GraphicObject:
+	case Ocd::ImageObject:
+	case Ocd::LayoutObject:
+		symbol = getSpecialObjectSymbol(ocd_object);
 		break;
 	default:
 		if (ocd_object.symbol >= 0)
@@ -2110,15 +2116,15 @@ Object* OcdFileImport::importObject(const O& ocd_object, MapPart* part)
 	{
 		switch (ocd_object.type)
 		{
-		case 1:
+		case Ocd::ObjectTypePoint:
 			symbol = map->getUndefinedPoint();
 			break;
-		case 2:
-		case 3:
+		case Ocd::ObjectTypeLine:
+		case Ocd::ObjectTypeArea:
 			symbol = map->getUndefinedLine();
 			break;
-		case 4:
-		case 5:
+		case Ocd::ObjectTypeUnformattedText:
+		case Ocd::ObjectTypeFormattedText:
 			symbol = map->getUndefinedText();
 			break;
 		default:

--- a/src/fileformats/ocd_file_import.cpp
+++ b/src/fileformats/ocd_file_import.cpp
@@ -108,6 +108,7 @@ OcdFileImport::OcdFileImport(const QString& path, Map* map, MapView* view)
  : Importer { path, map, view }
  , custom_8bit_encoding { codecFromSettings() }
  , graphic_objects_hidden(false)
+ , layout_objects_hidden(false)
 {
 	if (!custom_8bit_encoding)
 	{
@@ -325,12 +326,12 @@ void OcdFileImport::importImplementation()
 	{
 		importExtras(file);
 		importDisplayPar(file);
-		importObjects(file);
-		importTemplates(file);
 		if (view)
 		{
 			importView(file);
 		}
+		importObjects(file);
+		importTemplates(file);
 	}
 	
 	// No deep copy during import
@@ -1039,6 +1040,9 @@ void OcdFileImport::importView(const QString& param_string)
 		case 'k':
 			map->setBaselineViewEnabled(param_value.toInt() != 0);
 			break;
+		case 'l':
+			layout_objects_hidden = param_value.toInt() == 1;
+			break;
 		default:
 			; // nothing
 		}
@@ -1079,6 +1083,11 @@ void OcdFileImport::importDisplayPar(const QString& param_string)
 		case 'j':
 			{
 				graphic_objects_hidden = param_value.toInt() == 2;
+				break;
+			}
+		case 'l':
+			{
+				layout_objects_hidden = param_value.toInt() == 2;
 				break;
 			}
 		default:
@@ -1952,6 +1961,108 @@ Symbol* OcdFileImport::getGraphicObjectSymbol(const O& ocd_object)
 	return symbol;
 }
 
+Symbol* OcdFileImport::getLayoutObjectSymbol(const Ocd::ObjectV8& ocd_object)
+{
+	Q_UNUSED(ocd_object);
+	return nullptr;
+}
+
+template< class O >
+Symbol* OcdFileImport::getLayoutObjectSymbol(const O& ocd_object)
+{
+	Symbol* symbol = nullptr;
+	auto symbol_setup_common = [this](Symbol& symbol) {
+		symbol.setName(QLatin1String("helper symbol for layout objects"));
+		symbol.setNumberComponent(0, 998);
+		symbol.setNumberComponent(1, -1);
+		symbol.setNumberComponent(2, -1);
+		symbol.setHidden(layout_objects_hidden);
+	};
+	
+	auto get_cached_symbol = [this](const quint64 key) {
+		return layout_symbol_index.contains(key) ? 
+					layout_symbol_index[key] : nullptr;
+	};
+
+	auto store_cached_symbol = [this](const quint64 key, Symbol* symbol) {
+		map->addSymbol(symbol, map->getNumSymbols());
+		layout_symbol_index[key] = symbol;
+	};
+	
+	auto get_map_color = [this](const quint32 color) {
+		MapColorCmyk cmyk;
+		cmyk.c = quint8(color) / 255.f;
+		cmyk.m = quint8(color >> 8) / 255.f;
+		cmyk.y = quint8(color >> 16) / 255.f;
+		cmyk.k = quint8(color >> 24) / 255.f;
+		int num_colors = map->getNumColors();
+		for (int i = 0; i < num_colors; ++i)
+		{
+			auto map_cymk = map->getColor(i)->getCmyk();
+			if (map_cymk == cmyk)	// actually a fuzzy comparision
+				return const_cast<MapColor*>(map->getColor(i));
+		}
+		auto new_color = new MapColor(tr("Imported layout object"), num_colors);
+		new_color->setCmyk(cmyk);
+		map->addColor(new_color, num_colors);
+		return new_color;
+	};
+	
+	switch (ocd_object.type)
+	{
+	case Ocd::ObjectTypeLine:
+		{
+			const auto g_key = quint64(ocd_object.color) 
+							 | quint64(ocd_object.line_width) << 32
+							 | quint64(Ocd::ObjectTypeLine) << 56;
+			symbol = get_cached_symbol(g_key);
+			if (!symbol)
+			{
+				auto* line_symbol = new OcdImportedLineSymbol();
+				symbol_setup_common(*line_symbol);
+				line_symbol->color = get_map_color(quint32(ocd_object.color));
+				line_symbol->line_width = convertLength(ocd_object.line_width);
+				symbol = line_symbol;
+				store_cached_symbol(g_key, symbol);
+			}
+		}
+		break;
+	case Ocd::ObjectTypeArea:
+		{
+			const auto g_key = quint64(ocd_object.color)
+							 | quint64(Ocd::ObjectTypeArea) << 56;
+			symbol = get_cached_symbol(g_key);
+			if (!symbol)
+			{
+				auto* area_symbol = new OcdImportedAreaSymbol();
+				symbol_setup_common(*area_symbol);
+				area_symbol->color = get_map_color(quint32(ocd_object.color));
+				symbol = area_symbol;
+				store_cached_symbol(g_key, symbol);
+			}
+		}
+		break;
+	case Ocd::ObjectTypeUnformattedText:
+		{
+			const auto g_key = quint64(ocd_object.color)
+							 | quint64(Ocd::ObjectTypeUnformattedText) << 56;
+			symbol = get_cached_symbol(g_key);
+			if (!symbol)
+			{
+				auto* text_symbol = new OcdImportedTextSymbol();
+				symbol_setup_common(*text_symbol);
+				text_symbol->color = get_map_color(quint32(ocd_object.color));
+				symbol = text_symbol;
+				store_cached_symbol(g_key, symbol);
+			}
+		}
+		break;
+	default:
+		addWarning(tr("Encountered an unsupported type of layout object (%1). Skipping.").arg(ocd_object.type));
+		break;
+	}
+	return symbol;
+}
 
 template< class O >
 Object* OcdFileImport::importObject(const O& ocd_object, MapPart* part)
@@ -1961,6 +2072,9 @@ Object* OcdFileImport::importObject(const O& ocd_object, MapPart* part)
 	{
 	case -2: // graphic object
 		symbol = getGraphicObjectSymbol(ocd_object);
+		break;
+	case -4: // layout object
+		symbol = getLayoutObjectSymbol(ocd_object);
 		break;
 	default:
 		if (ocd_object.symbol >= 0)

--- a/src/fileformats/ocd_file_import.cpp
+++ b/src/fileformats/ocd_file_import.cpp
@@ -107,6 +107,7 @@ OcdFileImport::OcdImportedPathObject::~OcdImportedPathObject() = default;
 OcdFileImport::OcdFileImport(const QString& path, Map* map, MapView* view)
  : Importer { path, map, view }
  , custom_8bit_encoding { codecFromSettings() }
+ , graphic_objects_hidden(false)
 {
 	if (!custom_8bit_encoding)
 	{
@@ -323,6 +324,7 @@ void OcdFileImport::importImplementation()
 	if (!loadSymbolsOnly())
 	{
 		importExtras(file);
+		importDisplayPar(file);
 		importObjects(file);
 		importTemplates(file);
 		if (view)
@@ -1052,6 +1054,39 @@ void OcdFileImport::importView(const QString& param_string)
 	}
 }
 
+template< class F >
+void OcdFileImport::importDisplayPar(const OcdFile< F >& file)
+{
+	handleStrings(file, { { 1024, &OcdFileImport::importDisplayPar } });
+}
+
+void OcdFileImport::importDisplayPar(const QString& param_string)
+{
+	const QChar* unicode = param_string.unicode();
+	
+	int i = param_string.indexOf(QLatin1Char('\t'), 0);
+	; // skip first word for this entry type
+	while (i >= 0)
+	{
+		int next_i = param_string.indexOf(QLatin1Char('\t'), i+1);
+		int len = (next_i > 0 ? next_i : param_string.length()) - i - 2;
+		const QString param_value = QString::fromRawData(unicode+i+2, len); // no copying!
+		switch (param_string[i+1].toLatin1())
+		{
+		case '\t':
+			// empty item
+			break;
+		case 'j':
+			{
+				graphic_objects_hidden = param_value.toInt() == 2;
+				break;
+			}
+		default:
+			; // nothing
+		}
+		i = next_i;
+	}
+}
 
 template< class OcdBaseSymbol >
 void OcdFileImport::setupBaseSymbol(Symbol* symbol, const OcdBaseSymbol& ocd_base_symbol)
@@ -1857,11 +1892,12 @@ template< class O >
 Symbol* OcdFileImport::getGraphicObjectSymbol(const O& ocd_object)
 {
 	Symbol* symbol = nullptr;
-	auto symbol_setup_common = [](Symbol& symbol) {
+	auto symbol_setup_common = [this](Symbol& symbol) {
 		symbol.setName(QLatin1String("helper symbol for graphic objects"));
 		symbol.setNumberComponent(0, 999);
 		symbol.setNumberComponent(1, -1);
-		symbol.setNumberComponent(2, -1);				
+		symbol.setNumberComponent(2, -1);
+		symbol.setHidden(graphic_objects_hidden);
 	};
 	
 	auto get_cached_symbol = [this](const quint64 key) {

--- a/src/fileformats/ocd_file_import.cpp
+++ b/src/fileformats/ocd_file_import.cpp
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2013-2022 Kai Pastor
+ *    Copyright 2013-2023 Kai Pastor
  *
  *    Some parts taken from file_format_oc*d8{.h,_p.h,cpp} which are
  *    Copyright 2012 Pete Curtis
@@ -1897,55 +1897,43 @@ Symbol* OcdFileImport::getGraphicObjectSymbol(const O& ocd_object)
 		symbol.setHidden(graphic_objects_hidden);
 	};
 	
-	auto get_cached_symbol = [this](const quint64 key) {
-		return graphic_symbol_index.contains(key) ?
-		            graphic_symbol_index[key] : nullptr;
-	};
-
-	auto store_cached_symbol = [this](const quint64 key, Symbol* symbol) {
-		map->addSymbol(symbol, map->getNumSymbols());
-		graphic_symbol_index[key] = symbol;
-	};
-	
 	switch (ocd_object.type)
 	{
 	case Ocd::ObjectTypeLine:
 		{
-			const auto g_key = quint64(ocd_object.color) 
-			                   | quint64(ocd_object.line_width) << 32
-			                   | quint64(Ocd::ObjectTypeLine) << 56;
-			symbol = get_cached_symbol(g_key);
-			if (!symbol)
-			{
-				auto* line_symbol = new OcdImportedLineSymbol();
-				symbol_setup_common(*line_symbol);
-				line_symbol->color = convertColor(ocd_object.color);
-				line_symbol->line_width = convertLength(ocd_object.line_width);
-				symbol = line_symbol;
-				store_cached_symbol(g_key, symbol);
-			}
+			auto* line_symbol = new OcdImportedLineSymbol();
+			symbol_setup_common(*line_symbol);
+			line_symbol->color = convertColor(ocd_object.color);
+			line_symbol->line_width = convertLength(ocd_object.line_width);
+			symbol = line_symbol;
 		}
 		break;
 	case Ocd::ObjectTypeArea:
 		{
-			const auto g_key = quint64(ocd_object.color)
-			                   | quint64(Ocd::ObjectTypeArea) << 56;
-			symbol = get_cached_symbol(g_key);
-			if (!symbol)
-			{
-				auto* area_symbol = new OcdImportedAreaSymbol();
-				symbol_setup_common(*area_symbol);
-				area_symbol->color = convertColor(ocd_object.color);		
-				symbol = area_symbol;
-				store_cached_symbol(g_key, symbol);
-			}
+			auto* area_symbol = new OcdImportedAreaSymbol();
+			symbol_setup_common(*area_symbol);
+			area_symbol->color = convertColor(ocd_object.color);
+			symbol = area_symbol;
 		}
 		break;
 	default:
-	         addWarning(tr("Encountered an unsupported type of graphic object (%1). Skipping.").arg(ocd_object.type));
-	         break;
+		addWarning(tr("Encountered an unsupported type of graphic object (%1). Skipping.").arg(ocd_object.type));
+		break;
 	}
-
+	
+	if (symbol)
+	{
+		int num_symbols = map->getNumSymbols();
+		for (int i = 0; i < num_symbols; ++i)
+		{
+			if (symbol->equals(map->getSymbol(i)))
+			{
+				delete symbol;
+				return map->getSymbol(i);
+			}
+		}
+		map->addSymbol(symbol, map->getNumSymbols());
+	}
 	return symbol;
 }
 
@@ -1965,16 +1953,6 @@ Symbol* OcdFileImport::getLayoutObjectSymbol(const O& ocd_object)
 		symbol.setNumberComponent(1, -1);
 		symbol.setNumberComponent(2, -1);
 		symbol.setHidden(layout_objects_hidden);
-	};
-	
-	auto get_cached_symbol = [this](const quint64 key) {
-		return layout_symbol_index.contains(key) ? 
-					layout_symbol_index[key] : nullptr;
-	};
-
-	auto store_cached_symbol = [this](const quint64 key, Symbol* symbol) {
-		map->addSymbol(symbol, map->getNumSymbols());
-		layout_symbol_index[key] = symbol;
 	};
 	
 	auto get_map_color = [this](const quint32 color) {
@@ -2000,54 +1978,46 @@ Symbol* OcdFileImport::getLayoutObjectSymbol(const O& ocd_object)
 	{
 	case Ocd::ObjectTypeLine:
 		{
-			const auto g_key = quint64(ocd_object.color) 
-							 | quint64(ocd_object.line_width) << 32
-							 | quint64(Ocd::ObjectTypeLine) << 56;
-			symbol = get_cached_symbol(g_key);
-			if (!symbol)
-			{
-				auto* line_symbol = new OcdImportedLineSymbol();
-				symbol_setup_common(*line_symbol);
-				line_symbol->color = get_map_color(quint32(ocd_object.color));
-				line_symbol->line_width = convertLength(ocd_object.line_width);
-				symbol = line_symbol;
-				store_cached_symbol(g_key, symbol);
-			}
+			auto* line_symbol = new OcdImportedLineSymbol();
+			symbol_setup_common(*line_symbol);
+			line_symbol->color = get_map_color(quint32(ocd_object.color));
+			line_symbol->line_width = convertLength(ocd_object.line_width);
+			symbol = line_symbol;
 		}
 		break;
 	case Ocd::ObjectTypeArea:
 		{
-			const auto g_key = quint64(ocd_object.color)
-							 | quint64(Ocd::ObjectTypeArea) << 56;
-			symbol = get_cached_symbol(g_key);
-			if (!symbol)
-			{
-				auto* area_symbol = new OcdImportedAreaSymbol();
-				symbol_setup_common(*area_symbol);
-				area_symbol->color = get_map_color(quint32(ocd_object.color));
-				symbol = area_symbol;
-				store_cached_symbol(g_key, symbol);
-			}
+			auto* area_symbol = new OcdImportedAreaSymbol();
+			symbol_setup_common(*area_symbol);
+			area_symbol->color = get_map_color(quint32(ocd_object.color));
+			symbol = area_symbol;
 		}
 		break;
 	case Ocd::ObjectTypeUnformattedText:
 		{
-			const auto g_key = quint64(ocd_object.color)
-							 | quint64(Ocd::ObjectTypeUnformattedText) << 56;
-			symbol = get_cached_symbol(g_key);
-			if (!symbol)
-			{
-				auto* text_symbol = new OcdImportedTextSymbol();
-				symbol_setup_common(*text_symbol);
-				text_symbol->color = get_map_color(quint32(ocd_object.color));
-				symbol = text_symbol;
-				store_cached_symbol(g_key, symbol);
-			}
+			auto* text_symbol = new OcdImportedTextSymbol();
+			symbol_setup_common(*text_symbol);
+			text_symbol->color = get_map_color(quint32(ocd_object.color));
+			symbol = text_symbol;
 		}
 		break;
 	default:
 		addWarning(tr("Encountered an unsupported type of layout object (%1). Skipping.").arg(ocd_object.type));
 		break;
+	}
+	
+	if (symbol)
+	{
+		int num_symbols = map->getNumSymbols();
+		for (int i = 0; i < num_symbols; ++i)
+		{
+			if (symbol->equals(map->getSymbol(i)))
+			{
+				delete symbol;
+				return map->getSymbol(i);
+			}
+		}
+		map->addSymbol(symbol, map->getNumSymbols());
 	}
 	return symbol;
 }

--- a/src/fileformats/ocd_file_import.cpp
+++ b/src/fileformats/ocd_file_import.cpp
@@ -1845,13 +1845,92 @@ void OcdFileImport::setupPointSymbolPattern(PointSymbol* symbol, std::size_t dat
 	}
 }
 
+
+Symbol* OcdFileImport::getGraphicObjectSymbol(const Ocd::ObjectV8& ocd_object)
+{
+	Q_UNUSED(ocd_object);
+	return nullptr;
+}
+
+
+template< class O >
+Symbol* OcdFileImport::getGraphicObjectSymbol(const O& ocd_object)
+{
+	Symbol* symbol = nullptr;
+	auto symbol_setup_common = [](Symbol& symbol) {
+		symbol.setName(QLatin1String("helper symbol for graphic objects"));
+		symbol.setNumberComponent(0, 999);
+		symbol.setNumberComponent(1, -1);
+		symbol.setNumberComponent(2, -1);				
+	};
+	
+	auto get_cached_symbol = [this](const quint64 key) {
+		return graphic_symbol_index.contains(key) ?
+		            graphic_symbol_index[key] : nullptr;
+	};
+
+	auto store_cached_symbol = [this](const quint64 key, Symbol* symbol) {
+		map->addSymbol(symbol, map->getNumSymbols());
+		graphic_symbol_index[key] = symbol;
+	};
+	
+	switch (ocd_object.type)
+	{
+	case Ocd::ObjectTypeLine:
+		{
+			const auto g_key = quint64(ocd_object.color) 
+			                   | quint64(ocd_object.line_width) << 32
+			                   | quint64(Ocd::ObjectTypeLine) << 56;
+			symbol = get_cached_symbol(g_key);
+			if (!symbol)
+			{
+				auto* line_symbol = new OcdImportedLineSymbol();
+				symbol_setup_common(*line_symbol);
+				line_symbol->color = convertColor(ocd_object.color);
+				line_symbol->line_width = convertLength(ocd_object.line_width);
+				symbol = line_symbol;
+				store_cached_symbol(g_key, symbol);
+			}
+		}
+		break;
+	case Ocd::ObjectTypeArea:
+		{
+			const auto g_key = quint64(ocd_object.color)
+			                   | quint64(Ocd::ObjectTypeArea) << 56;
+			symbol = get_cached_symbol(g_key);
+			if (!symbol)
+			{
+				auto* area_symbol = new OcdImportedAreaSymbol();
+				symbol_setup_common(*area_symbol);
+				area_symbol->color = convertColor(ocd_object.color);		
+				symbol = area_symbol;
+				store_cached_symbol(g_key, symbol);
+			}
+		}
+		break;
+	default:
+	         addWarning(tr("Encountered an unsupported type of graphic object (%1). Skipping.").arg(ocd_object.type));
+	         break;
+	}
+
+	return symbol;
+}
+
+
 template< class O >
 Object* OcdFileImport::importObject(const O& ocd_object, MapPart* part)
 {
 	Symbol* symbol = nullptr;
-	if (ocd_object.symbol >= 0)
+	switch (ocd_object.symbol)
 	{
-		symbol = symbol_index[ocd_object.symbol];
+	case -2: // graphic object
+		symbol = getGraphicObjectSymbol(ocd_object);
+		break;
+	default:
+		if (ocd_object.symbol >= 0)
+		{
+			symbol = symbol_index[ocd_object.symbol];
+		}
 	}
 	
 	if (!symbol)

--- a/src/fileformats/ocd_file_import.cpp
+++ b/src/fileformats/ocd_file_import.cpp
@@ -1,5 +1,7 @@
 /*
  *    Copyright 2013-2023 Kai Pastor
+ *    Copyright 2017-2023 Libor Pecháček
+ *    Copyright 2021-2023 Matthias Kühlewein
  *
  *    Some parts taken from file_format_oc*d8{.h,_p.h,cpp} which are
  *    Copyright 2012 Pete Curtis
@@ -1947,6 +1949,8 @@ template< class O >
 Symbol* OcdFileImport::getLayoutObjectSymbol(const O& ocd_object)
 {
 	Symbol* symbol = nullptr;
+	auto h_alignment = TextObject::AlignHCenter;
+	
 	auto symbol_setup_common = [this](Symbol& symbol) {
 		symbol.setName(QLatin1String("helper symbol for layout objects"));
 		symbol.setNumberComponent(0, 998);
@@ -1998,6 +2002,62 @@ Symbol* OcdFileImport::getLayoutObjectSymbol(const O& ocd_object)
 			auto* text_symbol = new OcdImportedTextSymbol();
 			symbol_setup_common(*text_symbol);
 			text_symbol->color = get_map_color(quint32(ocd_object.color));
+			
+			auto data = QString(reinterpret_cast<const QChar *>(ocd_object.coords + ocd_object.num_items + ocd_object.num_text));
+			OcdParameterStreamReader parameters(data);
+			
+			text_symbol->font_family = parameters.value().toString();
+			
+			while (parameters.readNext())
+			{
+				float f_value;
+				int i_value;
+				bool ok;
+				QStringRef param_value = parameters.value();
+				switch (parameters.key())
+				{
+				case 'a':
+					i_value = param_value.toInt(&ok);
+					if (ok)
+					{
+						switch (i_value)
+						{
+						case Ocd::HAlignLeft:
+							h_alignment = TextObject::AlignLeft;
+							break;
+						case Ocd::HAlignRight:
+							h_alignment = TextObject::AlignRight;
+							break;
+						case Ocd::HAlignJustified:
+							// not yet implemented
+							// issue no warning here
+						default:
+							; // default value is set above
+						}
+					}
+					break;
+				case 'b':
+					i_value = param_value.toInt(&ok);
+					if (ok)
+						text_symbol->bold = i_value != 0;
+					break;
+				case 'i':
+					i_value = param_value.toInt(&ok);
+					if (ok)
+						text_symbol->italic = i_value != 0;
+					break;
+				case 's':
+					f_value = param_value.toFloat(&ok);
+					if (ok)
+						text_symbol->font_size = qRound(1000.0 * f_value / 72.0 * 25.4);
+					break;
+				case 'o':	// probably opacity value
+					break;
+				default:
+					; // nothing
+				}
+			}
+			text_symbol->updateQFont();
 			symbol = text_symbol;
 		}
 		break;
@@ -2014,10 +2074,15 @@ Symbol* OcdFileImport::getLayoutObjectSymbol(const O& ocd_object)
 			if (symbol->equals(map->getSymbol(i)))
 			{
 				delete symbol;
-				return map->getSymbol(i);
+				symbol = map->getSymbol(i);
+				if (ocd_object.type == Ocd::ObjectTypeUnformattedText)
+					text_halign_map[symbol] = h_alignment;
+				return symbol;
 			}
 		}
 		map->addSymbol(symbol, map->getNumSymbols());
+		if (ocd_object.type == Ocd::ObjectTypeUnformattedText)
+			text_halign_map[symbol] = h_alignment;
 	}
 	return symbol;
 }

--- a/src/fileformats/ocd_file_import.cpp
+++ b/src/fileformats/ocd_file_import.cpp
@@ -329,6 +329,7 @@ void OcdFileImport::importImplementation()
 	{
 		importExtras(file);
 		importDisplayPar(file);
+		importLayoutObjects(file);
 		if (view)
 		{
 			importView(file);
@@ -853,8 +854,10 @@ void OcdFileImport::importObjects(const OcdFile< F >& file)
 	MapPart* part = map->getCurrentPart();
 	FILEFORMAT_ASSERT(part);
 	
+	object_index = 0;
 	for (auto ocd_object : file.objects())
 	{
+		++object_index;
 		if ( ocd_object.entry->symbol
 		     && ocd_object.entry->status != Ocd::ObjectDeleted
 		     && ocd_object.entry->status != Ocd::ObjectDeletedForUndo )
@@ -1088,6 +1091,58 @@ void OcdFileImport::importDisplayPar(const QString& param_string)
 		default:
 			; // nothing
 		}
+	}
+}
+
+template< class F >
+void OcdFileImport::importLayoutObjects(const OcdFile< F >& file)
+{
+	handleStrings(file, { { 27, &OcdFileImport::importLayoutObjects } });
+}
+
+void OcdFileImport::importLayoutObjects(const QString& param_string)
+{
+	OcdParameterStreamReader parameters(param_string);
+	
+	auto path_or_description = parameters.value().toString();
+	int object_number = -1;
+	int type = -1;
+	int visibility = -1;
+	
+	while (parameters.readNext())
+	{
+		int i_value;
+		bool ok;
+		QStringRef param_value = parameters.value();
+		switch (parameters.key())
+		{
+		case 'r':
+			i_value = param_value.toInt(&ok);
+			if (ok)
+				type = i_value;
+			break;
+		case 's':
+			i_value = param_value.toInt(&ok);
+			if (ok)
+				visibility = i_value;
+			break;
+		case 'n':
+			i_value = param_value.toInt(&ok);
+			if (ok)
+				object_number = i_value;
+			break;
+		default:
+			; // nothing
+		}
+	}
+	
+	if (type == 0 && visibility == 0 && object_number > 0)
+	{
+		hidden_layout_objects.insert(object_number);
+	}
+	else if (type == 1)
+	{
+		addWarning(tr("Layout image object (%1) cannot be imported.").arg(path_or_description));
 	}
 }
 
@@ -1903,7 +1958,8 @@ Symbol* OcdFileImport::getSpecialObjectSymbol(const O& ocd_object)
 		{
 			symbol.setName(QLatin1String("Auxiliary symbol for layout objects"));
 			symbol.setNumberComponent(0, 998);
-			symbol.setHidden(layout_objects_hidden);
+			if (layout_objects_hidden || hidden_layout_objects.contains(object_index))
+				symbol.setHidden(true);
 		}
 		else if (ocd_object.symbol == Ocd::ImageObject)
 		{
@@ -2075,6 +2131,7 @@ Symbol* OcdFileImport::getSpecialObjectSymbol(const O& ocd_object)
 			addWarningOnce(tr("Importing image objects using auxiliary symbols. Export as image objects is not possible."));
 		else
 			addWarningOnce(tr("Importing graphic objects using auxiliary symbols. Export as graphic objects is not possible."));
+		
 		int num_symbols = map->getNumSymbols();
 		for (int i = 0; i < num_symbols; ++i)
 		{

--- a/src/fileformats/ocd_file_import.h
+++ b/src/fileformats/ocd_file_import.h
@@ -237,6 +237,10 @@ protected:
 	
 	void importView(const QString& param_string);
 	
+	template< class F >
+	void importDisplayPar(const OcdFile< F >& file);
+	
+	void importDisplayPar(const QString& param_string);
 	
 	// Symbol import
 	
@@ -368,6 +372,9 @@ protected:
 	
 	/// The actual format version of the imported file
 	int ocd_version;
+	
+	/// The visibility of graphics objects (true if hidden)
+	bool graphic_objects_hidden;
 };
 
 

--- a/src/fileformats/ocd_file_import.h
+++ b/src/fileformats/ocd_file_import.h
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2013-2022 Kai Pastor
+ *    Copyright 2013-2023 Kai Pastor
  *
  *    Some parts taken from file_format_oc*d8{.h,_p.h,cpp} which are
  *    Copyright 2012 Pete Curtis
@@ -362,12 +362,6 @@ protected:
 	
 	/// maps OCD symbol number to oo-mapper symbol object
 	QHash<unsigned int, Symbol *> symbol_index;
-	
-	/// maps OCD graphic object properties to oo-mapper synthetic symbol object
-	QHash<quint64, Symbol *> graphic_symbol_index;
-	
-	/// maps OCD layout object properties to oo-mapper synthetic symbol object
-	QHash<quint64, Symbol *> layout_symbol_index;
 	
 	/// maps OO Mapper text symbol pointer to OCD defined horizontal alignment (stored in objects instead of symbols in OO Mapper)
 	QHash<Symbol*, TextObject::HorizontalAlignment> text_halign_map;

--- a/src/fileformats/ocd_file_import.h
+++ b/src/fileformats/ocd_file_import.h
@@ -31,6 +31,7 @@
 #include <QByteArray>
 #include <QCoreApplication>
 #include <QHash>
+#include <QSet>
 #include <QLocale>
 #include <QString>
 
@@ -242,6 +243,11 @@ protected:
 	
 	void importDisplayPar(const QString& param_string);
 	
+	template< class F >
+	void importLayoutObjects(const OcdFile< F >& file);
+	
+	void importLayoutObjects(const QString& param_string);
+	
 	// Symbol import
 	
 	template< class S >
@@ -376,8 +382,14 @@ protected:
 	/// The visibility of layout objects (true if hidden)
 	bool layout_objects_hidden;
 	
+	/// stores the object numbers of hidden layout objects
+	QSet<int> hidden_layout_objects;
+	
 	/// The protection and visibility state of image objects (bitfield: 1 = protected, 2 = hidden)
 	int image_objects_displaymode;
+	
+	/// counting objects during import
+	int object_index;
 };
 
 

--- a/src/fileformats/ocd_file_import.h
+++ b/src/fileformats/ocd_file_import.h
@@ -309,15 +309,10 @@ protected:
 	template< class O >
 	Object* importObject(const O& ocd_object, MapPart* part);
 	
-	Symbol* getGraphicObjectSymbol(const Ocd::ObjectV8& ocd_object);
-
-	template< class O >
-	Symbol* getGraphicObjectSymbol(const O& ocd_object);
-	
-	Symbol* getLayoutObjectSymbol(const Ocd::ObjectV8& ocd_object);
+	Symbol* getSpecialObjectSymbol(const Ocd::ObjectV8& ocd_object);
 	
 	template< class O >
-	Symbol* getLayoutObjectSymbol(const O& ocd_object);
+	Symbol* getSpecialObjectSymbol(const O& ocd_object);
 	
 	QString getObjectText(const Ocd::ObjectV8& ocd_object) const;
 	
@@ -380,6 +375,9 @@ protected:
 	
 	/// The visibility of layout objects (true if hidden)
 	bool layout_objects_hidden;
+	
+	/// The protection and visibility state of image objects (bitfield: 1 = protected, 2 = hidden)
+	int image_objects_displaymode;
 };
 
 

--- a/src/fileformats/ocd_file_import.h
+++ b/src/fileformats/ocd_file_import.h
@@ -314,6 +314,11 @@ protected:
 	template< class O >
 	Symbol* getGraphicObjectSymbol(const O& ocd_object);
 	
+	Symbol* getLayoutObjectSymbol(const Ocd::ObjectV8& ocd_object);
+	
+	template< class O >
+	Symbol* getLayoutObjectSymbol(const O& ocd_object);
+	
 	QString getObjectText(const Ocd::ObjectV8& ocd_object) const;
 	
 	template< class O >
@@ -361,6 +366,9 @@ protected:
 	/// maps OCD graphic object properties to oo-mapper synthetic symbol object
 	QHash<quint64, Symbol *> graphic_symbol_index;
 	
+	/// maps OCD layout object properties to oo-mapper synthetic symbol object
+	QHash<quint64, Symbol *> layout_symbol_index;
+	
 	/// maps OO Mapper text symbol pointer to OCD defined horizontal alignment (stored in objects instead of symbols in OO Mapper)
 	QHash<Symbol*, TextObject::HorizontalAlignment> text_halign_map;
 	
@@ -375,6 +383,9 @@ protected:
 	
 	/// The visibility of graphics objects (true if hidden)
 	bool graphic_objects_hidden;
+	
+	/// The visibility of layout objects (true if hidden)
+	bool layout_objects_hidden;
 };
 
 

--- a/src/fileformats/ocd_file_import.h
+++ b/src/fileformats/ocd_file_import.h
@@ -305,6 +305,11 @@ protected:
 	template< class O >
 	Object* importObject(const O& ocd_object, MapPart* part);
 	
+	Symbol* getGraphicObjectSymbol(const Ocd::ObjectV8& ocd_object);
+
+	template< class O >
+	Symbol* getGraphicObjectSymbol(const O& ocd_object);
+	
 	QString getObjectText(const Ocd::ObjectV8& ocd_object) const;
 	
 	template< class O >
@@ -348,6 +353,9 @@ protected:
 	
 	/// maps OCD symbol number to oo-mapper symbol object
 	QHash<unsigned int, Symbol *> symbol_index;
+	
+	/// maps OCD graphic object properties to oo-mapper synthetic symbol object
+	QHash<quint64, Symbol *> graphic_symbol_index;
 	
 	/// maps OO Mapper text symbol pointer to OCD defined horizontal alignment (stored in objects instead of symbols in OO Mapper)
 	QHash<Symbol*, TextObject::HorizontalAlignment> text_halign_map;

--- a/src/fileformats/ocd_types.h
+++ b/src/fileformats/ocd_types.h
@@ -281,6 +281,20 @@ namespace Ocd
 	};
 	
 	/**
+	 * Object type values.
+	 */
+	enum ObjectType
+	{
+		ObjectTypePoint = 1,
+		ObjectTypeLine = 2,
+		ObjectTypeArea = 3,
+		ObjectTypeUnformattedText = 4,
+		ObjectTypeFormattedText = 5,
+		ObjectTypeLineText = 6,
+		ObjectTypeRectangle = 7,
+	};
+
+	/**
 	 * Status values for objects.
 	 */
 	enum ObjectStatus

--- a/src/fileformats/ocd_types.h
+++ b/src/fileformats/ocd_types.h
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2013, 2015-2019 Kai Pastor
+ *    Copyright 2013, 2015-2023 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -278,6 +278,16 @@ namespace Ocd
 		SymbolNormal    = 0,
 		SymbolProtected = 1,
 		SymbolHidden    = 2
+	};
+	
+	/**
+	 * Object type values for objects without symbols
+	 */
+	enum SpecialObjectType
+	{
+		GraphicObject = -2,
+		ImageObject = -3,
+		LayoutObject = -4
 	};
 	
 	/**


### PR DESCRIPTION
Graphic, layout and image objects are stored in .ocd without dedicated symbols.
While graphic objects re-use existing symbol colors, image and layout objects store the object color inside the object.
Mapper imports these special objects by defining auxiliary symbols and colors.
Layout image objects, i.e.,objects that reference externally stored images cannot yet be imported, however, a warning is now issued instead of silently discarding them.

Closes #959
Closes #1231