### PR TITLE
Show usage of color before deletion

### DIFF
--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2021 Kai Pastor
+ *    Copyright 2012-2023 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -2172,7 +2172,7 @@ void MapEditorController::createColorWindow()
 	Q_ASSERT(!color_dock_widget);
 	
 	color_dock_widget = new EditorDockWidget(tr("Colors"), color_window_act, this, window);
-	color_dock_widget->setWidget(new ColorListWidget(map, window, color_dock_widget));
+	color_dock_widget->setWidget(new ColorListWidget(map, window, color_dock_widget, this));
 	color_dock_widget->widget()->setEnabled(!editing_in_progress);
 	color_dock_widget->setObjectName(QString::fromLatin1("Color dock widget"));
 	if (!window->restoreDockWidget(color_dock_widget))

--- a/src/gui/widgets/color_list_widget.h
+++ b/src/gui/widgets/color_list_widget.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012, 2013, 2014, 2017 Kai Pastor
+ *    Copyright 2012-2023 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -37,6 +37,7 @@ namespace OpenOrienteering {
 class MainWindow;
 class Map;
 class MapColor;
+class MapEditorController;
 
 
 /**
@@ -49,7 +50,7 @@ class ColorListWidget : public QWidget
 Q_OBJECT
 public:
 	/** Creates a new ColorWidget for a given map and MainWindow. */
-	ColorListWidget(Map* map, MainWindow* window, QWidget* parent = nullptr);
+	ColorListWidget(Map* map, MainWindow* window, QWidget* parent = nullptr, MapEditorController* map_edditor_controller = nullptr);
 	
 	/** Destroys the ColorWidget. */
 	~ColorListWidget() override;
@@ -90,6 +91,7 @@ private:
 	
 	Map* const map;
 	MainWindow* const window;
+	MapEditorController* const map_editor_controller;
 	bool react_to_changes;
 };
 

--- a/src/gui/widgets/symbol_render_widget.cpp
+++ b/src/gui/widgets/symbol_render_widget.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2014-2019 Kai Pastor
+ *    Copyright 2014-2023 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -311,6 +311,26 @@ void SymbolRenderWidget::selectSingleSymbol(int i)
 	}
 	current_symbol_index = i;
 	
+	emitGuarded_selectedSymbolsChanged();
+}
+
+void SymbolRenderWidget::selectMultipleSymbols(std::vector<int> const &symbols)
+{
+	if (selection_locked)
+		return;
+	
+	updateSelectedIcons();
+	selected_symbols.clear();
+	
+	for (const auto symbol : symbols)
+	{
+		if (symbol >= 0)
+		{
+			selected_symbols.insert(symbol);
+			updateSingleIcon(symbol);
+			current_symbol_index = symbol;
+		}
+	}
 	emitGuarded_selectedSymbolsChanged();
 }
 

--- a/src/gui/widgets/symbol_render_widget.h
+++ b/src/gui/widgets/symbol_render_widget.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2014 Kai Pastor
+ *    Copyright 2014, 2023 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -23,6 +23,7 @@
 #define OPENORIENTEERING_SYMBOL_RENDER_WIDGET_H
 
 #include <set>
+#include <vector>
 
 #include <QObject>
 #include <QPoint>
@@ -119,6 +120,14 @@ public:
 	 * Deselects other symbols, if there was a different selection before.
 	 */
 	void selectSingleSymbol(int i);
+	
+	/**
+	 * @brief Selects the list of symbols exclusively.
+	 * 
+	 * Selects the symbols with the given numbers.
+	 * Deselects other symbols, if there was a different selection before.
+	 */
+	void selectMultipleSymbols(std::vector<int> const &symbols);
 	
 	/**
 	 * @brief Returns the recommended size for the widget.

--- a/src/gui/widgets/symbol_widget.cpp
+++ b/src/gui/widgets/symbol_widget.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2014 Kai Pastor
+ *    Copyright 2014, 2023 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -80,6 +80,11 @@ bool SymbolWidget::isSymbolSelected(const Symbol* symbol) const
 void SymbolWidget::selectSingleSymbol(const Symbol* symbol)
 {
     render_widget->selectSingleSymbol(symbol);
+}
+
+void SymbolWidget::selectMultipleSymbols(std::vector<int> const &symbols)
+{
+	render_widget->selectMultipleSymbols(symbols);
 }
 
 void SymbolWidget::contextMenuEvent(QContextMenuEvent* event)

--- a/src/gui/widgets/symbol_widget.h
+++ b/src/gui/widgets/symbol_widget.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2014 Kai Pastor
+ *    Copyright 2014, 2023 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -21,6 +21,8 @@
 
 #ifndef OPENORIENTEERING_SYMBOL_WIDGET_H
 #define OPENORIENTEERING_SYMBOL_WIDGET_H
+
+#include <vector>
 
 #include <QObject>
 #include <QScrollArea>
@@ -89,6 +91,11 @@ public:
 	 * @brief Selects the symbol exclusively, deselecting all other symbols.
 	 */
 	void selectSingleSymbol(const Symbol* symbol);
+	
+	/**
+	 * @brief Selects the list of symbols exclusively, deselecting all other symbols.
+	 */
+	void selectMultipleSymbols(std::vector<int> const &symbols);
 	
 signals:
 	/**


### PR DESCRIPTION
When the user decided to delete a color that was used by at least one symbol, a warning was issued: "The map contains symbols with this color. Deleting it will remove the color from these objects!".
This warning was however ambiguous: it was even issued when the affected symbol(s) were not used by any object. In addition, the mixture of "symbols" and "these objects" sounded awkward.

With the first commit the number of affected symbols is counted and put out in the warning message.
In addition the number of objects actually using these affected symbols is counted as well. If there is at least one object then the warning is extended by stating the number of affected objects. In any case the message text is changed to "...remove the color from these symbols".

The second commit allows to select the symbols that will be affected by removing a given color by extending the warning message box by a new button 'Select affected symbols and abort'.
Pressing on this button then selects all of the affected symbols in the symbol window.

Warning message when symbols but no objects are affected:
![ColorDeletionSymbols](https://user-images.githubusercontent.com/14225666/212994151-8bedb5b5-d5ec-4ab9-8807-d8a6092fa815.JPG)

Warning message when symbols and objects are affected:
![ColorDeletionSymbolsObjects](https://user-images.githubusercontent.com/14225666/212994209-7a7027f9-4818-4d1d-b97e-231c77edc918.JPG)
After pressing on the 'Select affected symbols and abort' button:
![SelectedSymbols](https://user-images.githubusercontent.com/14225666/212994223-cd22ebb0-8417-4b90-b728-50b66b8488c0.JPG)