### PR TITLE
OgrFileImport: Improve DXF import of text objects

### DIFF
--- a/src/gdal/ogr_file_format_p.h
+++ b/src/gdal/ogr_file_format_p.h
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 Kai Pastor
+ *    Copyright 2016-2023 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -355,6 +355,8 @@ private:
 	AreaSymbol* default_area_symbol;
 	QHash<QByteArray, MapColor*> colors;
 	MapColor* default_pen_color;
+	
+	QVariantHash object_properties;
 	
 	MapCoordConstructor to_map_coord;
 	


### PR DESCRIPTION
Text object properties like the text itsef, alignment and rotation were previously imported by putting them into a string and transporting the string via the description property of the related text symbol. Besides being an awkward design the approach suffers from multiple deficiencies: the auxiliary string was not removed from the description field, the rotation angle was rounded (e.g., -17.2 became 20) and the way of constructing and parsing the string was unnecessary complex.

This commit uses a static QVariantHash object to transport the object properties. As only a single object is imported at a time it's not required to pass a reference to this QVariantHash object to the functions that return the related symbol and retrieve the object properties.