### PR TITLE
Auxiliary symbol properties

### DIFF
--- a/src/core/objects/text_object.h
+++ b/src/core/objects/text_object.h
@@ -31,6 +31,7 @@
 #include <QPointF>
 #include <QRectF>
 #include <QTransform>
+#include <QMetaType>
 
 #include "core/map_coord.h"
 #include "core/objects/object.h"
@@ -393,5 +394,8 @@ const TextObjectLineInfo*TextObject::getLineInfo(int i) const
 
 
 }  // namespace OpenOrienteering
+
+Q_DECLARE_METATYPE(OpenOrienteering::TextObject::HorizontalAlignment)
+Q_DECLARE_METATYPE(OpenOrienteering::TextObject::VerticalAlignment)
 
 #endif

--- a/src/core/symbols/symbol.cpp
+++ b/src/core/symbols/symbol.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2020 Kai Pastor
+ *    Copyright 2012-2023 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -88,6 +88,7 @@ Symbol::Symbol(const Symbol& proto)
 , is_hidden { proto.is_hidden }
 , is_protected { proto.is_protected }
 , is_rotatable { proto.is_rotatable }
+, auxiliary_properties ( proto.auxiliary_properties )
 {
 	// nothing else
 }

--- a/src/core/symbols/symbol.h
+++ b/src/core/symbols/symbol.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2020 Kai Pastor
+ *    Copyright 2012-2023 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -32,6 +32,7 @@
 #include <QtGlobal>
 #include <QFlags>
 #include <QHash>
+#include <QVariant>
 #include <QImage>
 #include <QMetaType>
 #include <QRgb>
@@ -499,6 +500,26 @@ public:
 	 */
 	virtual bool hasRotatableFillPattern() const;
 	
+	/**
+	 * Sets an auxiliary property of this symbol.
+	 */
+	void setAuxiliaryProperty(QString key, QVariant value) { auxiliary_properties.insert(key, value); }
+	
+	/**
+	 * Returns an auxiliary property of this symbol.
+	 */
+	QVariant getAuxiliaryProperty(QString key) const { return auxiliary_properties.value(key); }
+	
+	/**
+	 * Returns an auxiliary property of this symbol or a default value.
+	 */
+	QVariant getAuxiliaryProperty(QString key, QVariant default_value) const { return auxiliary_properties.value(key, default_value); }
+	
+	/**
+	 * Returns a reference to the auxiliary property member.
+	 */
+	const QVariantHash& getAuxiliaryPropertyHash() const { return auxiliary_properties; }
+	
 protected:
 	/**
 	 * Sets the rotatability state of the symbol.
@@ -621,6 +642,7 @@ private:
 	bool is_hidden;           /// \see isHidden()
 	bool is_protected;        /// \see isProtected()
 	bool is_rotatable = false;
+	QVariantHash auxiliary_properties;	/// Auxiliary properties for import of objects (e.g., .ocd, .dxf files). Auxiliary properties are not saved in a map file.
 };
 
 

--- a/src/fileformats/ocd_file_import.cpp
+++ b/src/fileformats/ocd_file_import.cpp
@@ -1915,7 +1915,7 @@ Object* OcdFileImport::importObject(const O& ocd_object, MapPart* part)
 		auto t = new TextObject(symbol);
 		t->setText(getObjectText(ocd_object));
 		t->setRotation(convertAngle(ocd_object.angle));
-		t->setHorizontalAlignment(text_halign_map.value(symbol));
+		t->setHorizontalAlignment((symbol->getAuxiliaryProperty(QLatin1String("HAlign")).value<TextObject::HorizontalAlignment>()));
 		// Vertical alignment is set in fillTextPathCoords().
 		
 		// Text objects need special path translation
@@ -2232,7 +2232,7 @@ bool OcdFileImport::fillTextPathCoords(TextObject *object, TextSymbol *symbol, q
 		// anchor point
 		MapCoord coord = convertOcdPoint(ocd_points[0]);
 		object->setAnchorPosition(coord.nativeX(), coord.nativeY());
-		object->setVerticalAlignment(text_valign_map.value(symbol));
+		object->setVerticalAlignment((symbol->getAuxiliaryProperty(QLatin1String("VAlign")).value<TextObject::VerticalAlignment>()));
 	}
 	
 	return true;
@@ -2258,32 +2258,32 @@ void OcdFileImport::setBasicAttributes(OcdFileImport::OcdImportedTextSymbol* sym
 	switch (attributes.alignment & Ocd::HAlignMask)
 	{
 	case Ocd::HAlignLeft:
-		text_halign_map[symbol] = TextObject::AlignLeft;
+		symbol->setAuxiliaryProperty(QLatin1String("HAlign"), QVariant(TextObject::AlignLeft));
 		break;
 	case Ocd::HAlignRight:
-		text_halign_map[symbol] = TextObject::AlignRight;
+		symbol->setAuxiliaryProperty(QLatin1String("HAlign"), QVariant(TextObject::AlignRight));
 		break;
 	case Ocd::HAlignJustified:
 		/// \todo Implement justified alignment
 		addSymbolWarning(symbol, tr("Justified alignment is not supported."));
 		Q_FALLTHROUGH();
 	default:
-		text_halign_map[symbol] = TextObject::AlignHCenter;
+		symbol->setAuxiliaryProperty(QLatin1String("HAlign"), QVariant(TextObject::AlignHCenter));
 	}
 	
 	switch (attributes.alignment & Ocd::VAlignMask)
 	{
 	case Ocd::VAlignTop:
-		text_valign_map[symbol] = TextObject::AlignTop;
+		symbol->setAuxiliaryProperty(QLatin1String("VAlign"), QVariant(TextObject::AlignTop));
 		break;
 	case Ocd::VAlignMiddle:
-		text_valign_map[symbol] = TextObject::AlignVCenter;
+		symbol->setAuxiliaryProperty(QLatin1String("VAlign"), QVariant(TextObject::AlignVCenter));
 		break;
 	default:
 		addSymbolWarning(symbol, tr("Vertical alignment '%1' is not supported.").arg(attributes.alignment & Ocd::VAlignMask));
 		Q_FALLTHROUGH();
 	case Ocd::VAlignBottom:
-		text_valign_map[symbol] = TextObject::AlignBaseline;
+		symbol->setAuxiliaryProperty(QLatin1String("VAlign"), QVariant(TextObject::AlignBaseline));
 	}
 	
 	if (attributes.char_spacing != 0)

--- a/src/fileformats/ocd_file_import.h
+++ b/src/fileformats/ocd_file_import.h
@@ -349,12 +349,6 @@ protected:
 	/// maps OCD symbol number to oo-mapper symbol object
 	QHash<unsigned int, Symbol *> symbol_index;
 	
-	/// maps OO Mapper text symbol pointer to OCD defined horizontal alignment (stored in objects instead of symbols in OO Mapper)
-	QHash<Symbol*, TextObject::HorizontalAlignment> text_halign_map;
-	
-	/// maps OO Mapper text symbol pointer to OCD defined vertical alignment (stored in objects instead of symbols in OO Mapper)
-	QHash<Symbol*, TextObject::VerticalAlignment> text_valign_map;
-	
 	/// maps OCD symbol number to rectangle information struct
 	QHash<int, RectangleInfo> rectangle_info;
 	

--- a/src/gdal/ogr_file_format.cpp
+++ b/src/gdal/ogr_file_format.cpp
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2016-2020 Kai Pastor
+ *    Copyright 2016-2023 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -1175,15 +1175,9 @@ Object* OgrFileImport::importPointGeometry(OGRFeatureH feature, OGRGeometryH geo
 		return object;
 	}
 	
-	if (symbol->getType() == Symbol::Text)
+	if (symbol->getType() == Symbol::Text && !symbol->getAuxiliaryPropertyHash().isEmpty())
 	{
-		const auto& description = symbol->getDescription();
-		auto length = description.length();
-		auto split = description.indexOf(QLatin1Char(' '));
-		FILEFORMAT_ASSERT(split > 0);
-		FILEFORMAT_ASSERT(split < length);
-		
-		auto label = description.right(length - split - 1);
+		auto label = symbol->getAuxiliaryProperty(QLatin1String("label")).toString();
 		if (label.startsWith(QLatin1Char{'{'}) && label.endsWith(QLatin1Char{'}'}))
 		{
 			label.remove(0, 1);
@@ -1204,13 +1198,13 @@ Object* OgrFileImport::importPointGeometry(OGRFeatureH feature, OGRGeometryH geo
 			object->setText(label);
 			
 			bool ok;
-			auto anchor = QStringRef(&description, 1, 2).toInt(&ok);
+			auto anchor = symbol->getAuxiliaryProperty(QLatin1String("anchor"), 1).toInt(&ok);
 			if (ok)
 			{
 				applyLabelAnchor(anchor, object);
 			}
-				
-			auto angle = QStringRef(&description, 3, split-3).toDouble(&ok);
+			
+			auto angle = symbol->getAuxiliaryProperty(QLatin1String("angle"), 0.0).toDouble(&ok);
 			if (ok)
 			{
 				object->setRotation(qDegreesToRadians(angle));
@@ -1676,21 +1670,15 @@ TextSymbol* OgrFileImport::getSymbolForLabel(OGRStyleToolH tool, const QByteArra
 		map->addSymbol(copy.release(), map->getNumSymbols());
 	}
 	
+	text_symbol->setAuxiliaryProperty(QLatin1String("label"), QVariant(QString::fromUtf8(label_string)));
+	
 	auto anchor = qBound(1, OGR_ST_GetParamNum(tool, OGRSTLabelAnchor, &is_null), 12);
-	if (is_null)
-		anchor = 1;
+	if (!is_null)
+		text_symbol->setAuxiliaryProperty(QLatin1String("anchor"), QVariant(anchor));
 	
 	auto angle = OGR_ST_GetParamDbl(tool, OGRSTLabelAngle, &is_null);
-	if (is_null)
-		angle = 0.0;
-	
-	QString description;
-	description.reserve(int(qstrlen(label_string) + 100));
-	description.append(QString::number(100 + anchor));
-	description.append(QString::number(angle, 'g', 1));
-	description.append(QLatin1Char(' '));
-	description.append(QString::fromUtf8(label_string));
-	text_symbol->setDescription(description);
+	if (!is_null)
+		text_symbol->setAuxiliaryProperty(QLatin1String("angle"), QVariant(angle));
 	
 	return text_symbol;
 }


### PR DESCRIPTION
Mapper sometimes needs to handle symbol properties that are not part of Mapper's own set of symbol properties and that need to be applied when importing objects.
Example: horizontal and vertical text alignment is a symbol property in OACD but an object property in Mapper.
Mapper uses auxiliary data structures to temporary store those symbol properties for later applying them on object import.
This change adds a QVariantHash element to the Symbol base class that allows a flexible and type safe storage of auxiliary symbol properties.
These auxiliary symbol properties are neither saved to a map file nor loaded from it.

The second commit applies the auxiliary symbol properties to the DXF import where text object properties like the text itself, alignment and rotation were previously imported by putting them into a string and transporting the string via the description property of the related text symbol.
Besides being an awkward design the approach suffers from multiple deficiencies: the auxiliary string was not removed from the description field, the rotation angle was rounded (e.g., -17.2 became 20) and the way of constructing and parsing the string was unnecessary complex.
Note that this commit replaces #2135.
    
The third commit applies the auxiliary symbol properties to the import of OCAD maps.
Auxiliary symbol properties are replacing the text_halign_map and text_valign_map hashes that were used to store OCAD's symbol properties for horizontal and vertical text alignment for being applied later to text object import.

This PR is a POC to demonstrate a possible way of preserving symbol/object related properties until object creation.

Auxiliary symbol properties could be considered with respect to #2082 and #1639.