### PR TITLE
CoVe: Address GCC warning about std::binary_function

### DIFF
--- a/3rd-party/cove/libvectorizer/Polygons.cpp
+++ b/3rd-party/cove/libvectorizer/Polygons.cpp
@@ -826,7 +826,8 @@ bool Polygons::joinPolygons(path_t*& plist,
 
 	compdists(pointlist, ops, min, max, true, progressObserver, 50, 12);
 
-	sort(ops.begin(), ops.end(), greater_weight());
+	sort(ops.begin(), ops.end(), 
+	     [](const JOINOP& x, const JOINOP& y) { return x.weight > y.weight; });
 
 	nops = ops.size();
 	cntr = 0;

--- a/3rd-party/cove/libvectorizer/Polygons.h
+++ b/3rd-party/cove/libvectorizer/Polygons.h
@@ -143,15 +143,6 @@ private:
 
 	typedef std::vector<JOINENDPOINT> JOINENDPOINTLIST;
 
-	struct greater_weight
-		: public std::binary_function<const JOINOP&, const JOINOP&, bool>
-	{
-		bool operator()(const JOINOP& x, const JOINOP& y)
-		{
-			return x.weight > y.weight;
-		}
-	};
-
 	// implementation dependent value...
 	static const int NPOINTS_MAX;
 


### PR DESCRIPTION
Address a tiny warning from a new GCC.