### PR TITLE
Consider dash symbols in combined symbols

### DIFF
--- a/src/core/symbols/combined_symbol.cpp
+++ b/src/core/symbols/combined_symbol.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2020 Kai Pastor
+ *    Copyright 2012-2020, 2024 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -413,6 +413,15 @@ bool CombinedSymbol::hasRotatableFillPattern() const
 {
 	return std::any_of(begin(parts), end(parts), [](auto const* part) {
 		return part && part->hasRotatableFillPattern();
+	});
+}
+
+
+// override
+bool CombinedSymbol::containsDashSymbol() const
+{
+	return std::any_of(begin(parts), end(parts), [](auto const* part) {
+		return part && part->containsDashSymbol();
 	});
 }
 

--- a/src/core/symbols/combined_symbol.h
+++ b/src/core/symbols/combined_symbol.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2020 Kai Pastor
+ *    Copyright 2012-2020, 2024 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -97,12 +97,12 @@ public:
     qreal calculateLargestLineExtent() const override;
 	
 	/**
-	 * Determines the border hints for this line symbol.
+	 * Determines the border hints for this combined symbol.
 	 */
 	const BorderHints* borderHints() const override;
 	
 	
-	// Getters / Setter
+	// Getters / Setters
 	inline int getNumParts() const {return (int)parts.size();}
 	inline void setNumParts(int num) {parts.resize(num, nullptr); private_parts.resize(num, false);}
 	
@@ -115,6 +115,8 @@ public:
 	bool hasRotatableFillPattern() const override;
 	
 	SymbolPropertiesWidget* createPropertiesWidget(SymbolSettingDialog* dialog) override;
+	
+	bool containsDashSymbol() const override;
 	
 protected:
 	void saveImpl(QXmlStreamWriter& xml, const Map& map) const override;
@@ -131,4 +133,4 @@ protected:
 
 }  // namespace OpenOrienteering
 
-#endif
+#endif // OPENORIENTEERING_COMBINED_SYMBOL_H

--- a/src/core/symbols/line_symbol.cpp
+++ b/src/core/symbols/line_symbol.cpp
@@ -1768,6 +1768,12 @@ const Symbol::BorderHints* LineSymbol::borderHints() const
 }
 
 
+// virtual
+bool LineSymbol::containsDashSymbol() const {
+	return dash_symbol != nullptr;
+}
+
+
 
 void LineSymbol::setStartSymbol(PointSymbol* symbol)
 {

--- a/src/core/symbols/line_symbol.h
+++ b/src/core/symbols/line_symbol.h
@@ -200,6 +200,9 @@ public:
 	const BorderHints* borderHints() const override;
 	
 	
+	bool containsDashSymbol() const override;
+	
+	
 	/**
 	 * Returns the limit for miter joins in units of the line width.
 	 * See the Qt docs for QPainter::setMiterJoin().
@@ -282,8 +285,6 @@ public:
 	inline const LineSymbolBorder& getRightBorder() const {return right_border;}
 	
 	SymbolPropertiesWidget* createPropertiesWidget(SymbolSettingDialog* dialog) override;
-	
-	bool containsDashSymbol() const override { return dash_symbol != nullptr; }
 	
 protected:
 	void saveImpl(QXmlStreamWriter& xml, const Map& map) const override;

--- a/src/core/symbols/line_symbol.h
+++ b/src/core/symbols/line_symbol.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2020 Kai Pastor
+ *    Copyright 2012-2020, 2024 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -185,7 +185,7 @@ public:
 	
 	
 	/**
-	 * Returns the dimension which shall considered when scaling the icon.
+	 * Returns the dimension which shall be considered when scaling the icon.
 	 */
 	qreal dimensionForIcon() const override;
 	
@@ -282,6 +282,8 @@ public:
 	inline const LineSymbolBorder& getRightBorder() const {return right_border;}
 	
 	SymbolPropertiesWidget* createPropertiesWidget(SymbolSettingDialog* dialog) override;
+	
+	bool containsDashSymbol() const override { return dash_symbol != nullptr; }
 	
 protected:
 	void saveImpl(QXmlStreamWriter& xml, const Map& map) const override;
@@ -481,4 +483,4 @@ protected:
 
 }  // namespace OpenOrienteering
 
-#endif
+#endif // OPENORIENTEERING_LINE_SYMBOL_H

--- a/src/core/symbols/symbol.cpp
+++ b/src/core/symbols/symbol.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2020, 2024 Kai Pastor
+ *    Copyright 2012-2020, 2022, 2024 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -984,6 +984,13 @@ bool Symbol::lessByColor::operator() (const Symbol* s1, const Symbol* s2) const
 	const auto rgb1 = std::find(first, last, rgb_c1);
 	const auto rgb2 = std::find(first, last, rgb_c2);
 	return std::distance(first, rgb1) < std::distance(first, rgb2);
+}
+
+
+// virtual function, derived classes LineSymbol and CombinedSymbol override default behaviour below.
+bool Symbol::containsDashSymbol() const
+{
+	return false;
 }
 
 

--- a/src/core/symbols/symbol.h
+++ b/src/core/symbols/symbol.h
@@ -501,9 +501,14 @@ public:
 	bool isRotatable() const { return is_rotatable; }
 	
 	/**
-	 * Returns if the objects has fill patterns which can be rotated in arbitrary directions.
+	 * Returns if objects with this symbol have fill patterns which can be rotated in arbitrary directions.
 	 */
 	virtual bool hasRotatableFillPattern() const;
+	
+	/**
+	 * Returns if this symbol contains a dash symbol.
+	 */
+	virtual bool containsDashSymbol() const;
 	
 protected:
 	/**

--- a/src/tools/draw_path_tool.cpp
+++ b/src/tools/draw_path_tool.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012-2014 Thomas Schöps
- *    Copyright 2013-2020 Kai Pastor
+ *    Copyright 2013-2020, 2024 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -30,8 +30,8 @@
 #include <QColor>
 #include <QCursor>
 #include <QFlags>
-#include <QLatin1String>
 #include <QKeyEvent>
+#include <QLatin1String>
 #include <QLineF>
 #include <QLocale>
 #include <QMouseEvent>
@@ -51,10 +51,9 @@
 #include "core/path_coord.h"
 #include "core/virtual_coord_vector.h"
 #include "core/virtual_path.h"
-#include "core/symbols/line_symbol.h"
-#include "core/symbols/symbol.h"
 #include "core/objects/object.h"
 #include "core/renderables/renderable.h"
+#include "core/symbols/symbol.h"
 #include "gui/modifier_key.h"
 #include "gui/map/map_editor.h"
 #include "gui/map/map_widget.h"
@@ -1119,19 +1118,13 @@ void DrawPathTool::updateDashPointDrawing()
 	if (is_helper_tool)
 		return;
 	
-	Symbol* symbol = editor->activeSymbol();
-	if (symbol && symbol->getType() == Symbol::Line)
+	// Auto-activate dash points depending on if the selected symbol has a dash symbol.
+	if (editor->activeSymbol()->containsDashSymbol())
 	{
-		// Auto-activate dash points depending on if the selected symbol has a dash symbol.
-		// TODO: instead of just looking if it is a line symbol with dash points,
-		// could also check for combined symbols containing lines with dash points
-		draw_dash_points = (symbol->asLine()->getDashSymbol());
-		
+		draw_dash_points = true;
 		updateStatusText();
 	}
-	else if (symbol &&
-		(symbol->getType() == Symbol::Area ||
-		 symbol->getType() == Symbol::Combined))
+	else
 	{
 		draw_dash_points = false;
 	}

--- a/src/tools/draw_path_tool.cpp
+++ b/src/tools/draw_path_tool.cpp
@@ -954,9 +954,10 @@ void DrawPathTool::setDrawingSymbol(const Symbol* symbol)
 {
 	if (is_helper_tool)
 		return;
-	DrawLineAndAreaTool::setDrawingSymbol(symbol);
 	
+	DrawLineAndAreaTool::setDrawingSymbol(symbol);
 	updateDashPointDrawing();
+	updateStatusText();
 }
 
 void DrawPathTool::objectSelectionChanged()
@@ -1119,16 +1120,7 @@ void DrawPathTool::updateDashPointDrawing()
 		return;
 	
 	// Auto-activate dash points depending on if the selected symbol has a dash symbol.
-	if (editor->activeSymbol()->containsDashSymbol())
-	{
-		draw_dash_points = true;
-		updateStatusText();
-	}
-	else
-	{
-		draw_dash_points = false;
-	}
-	
+	draw_dash_points = editor->activeSymbol()->containsDashSymbol();
 	if (dash_points_button)
 		dash_points_button->setChecked(draw_dash_points);
 }


### PR DESCRIPTION
When drawing line objects for symbols with dash symbols, no dash points were set automatically if the symbol was a combined symbol.
When editing line objects for symbols with dash symbols, additional points were not added as dash points if the symbol was a combined symbol.
These deviations were known and marked as TODO.
This commit treats line symbols with dash symbols and combined symbols containing line symbols with dash symbols equally.