### PR TITLE
Make QPainterTest pass with Qt 5.15.9

### DIFF
--- a/src/core/image_transparency_fixup.h
+++ b/src/core/image_transparency_fixup.h
@@ -26,8 +26,12 @@ namespace OpenOrienteering {
 
 
 /**
+ * Repairs a pixel composing issue aka QTBUG-100327.
+ * 
  * ImageTransparencyFixup repairs a particular issue with composing
- * transparent pixels.
+ * transparent pixels with Qt5 < 5.15.9 and Qt6 < 6.2.4, tracked
+ * upstream as https://bugreports.qt.io/browse/QTBUG-100327, and
+ * does nothing otherwise.
  * 
  * QPainter::CompositionMode_Multiply and QPainter::CompositionMode_Darken
  * on a QImage of Format_ARGB32_Premultiplied calculate the resulting alpha
@@ -58,12 +62,8 @@ public:
 	 * 
 	 * The image must be of QImage::Format_ARGB32_Premultiplied.
 	 * It may be null.
-	 *
-	 * This fixup is needed for Qt5 < 5.15.9 and Qt6 < 6.2.4 which are
-	 * affected by https://bugreports.qt.io/browse/QTBUG-100327.
 	 */
-	inline ImageTransparencyFixup(QImage* image)
-	: dest(0), dest_end(0)
+	inline explicit ImageTransparencyFixup(QImage* image)
 	{
 		// NOTE: Here we may add a check for a setting which disables the 
 		//       fixup (for better application performance)
@@ -85,7 +85,7 @@ public:
 	 */
 	inline void operator()() const
 	{
-		for (QRgb* px = dest; px < dest_end; px++)
+		for (QRgb* px = dest; px != dest_end; px++)
 		{
 			if (*px == 0x01000000) /* qRgba(0, 0, 0, 1) */
 				*px = 0x00000000;  /* qRgba(0, 0, 0, 0) */
@@ -93,13 +93,13 @@ public:
 	}
 	
 protected:
-	QRgb* dest;
-	QRgb* dest_end;
+	QRgb* dest = nullptr;
+	QRgb* dest_end = nullptr;
 
 #else // ^^^ fixup / no-op vvv
 
 public:
-	inline ImageTransparencyFixup(QImage*) {}
+	inline explicit ImageTransparencyFixup(QImage*) {}
 	inline void operator()() const {}
 
 #endif

--- a/src/core/image_transparency_fixup.h
+++ b/src/core/image_transparency_fixup.h
@@ -51,6 +51,7 @@ namespace OpenOrienteering {
  */
 class ImageTransparencyFixup
 {
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 9) || (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0) && QT_VERSION < QT_VERSION_CHECK(6, 2, 4))
 public:
 	/**
 	 * Create a fixup functor for the given image.
@@ -84,18 +85,24 @@ public:
 	 */
 	inline void operator()() const
 	{
-#if QT_VERSION < QT_VERSION_CHECK(5, 15, 9) || (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0) && QT_VERSION < QT_VERSION_CHECK(6, 2, 4))
 		for (QRgb* px = dest; px < dest_end; px++)
 		{
 			if (*px == 0x01000000) /* qRgba(0, 0, 0, 1) */
 				*px = 0x00000000;  /* qRgba(0, 0, 0, 0) */
 		}
-#endif
 	}
 	
 protected:
 	QRgb* dest;
 	QRgb* dest_end;
+
+#else // ^^^ fixup / no-op vvv
+
+public:
+	inline ImageTransparencyFixup(QImage*) {}
+	inline void operator()() const {}
+
+#endif
 };
 
 

--- a/src/core/image_transparency_fixup.h
+++ b/src/core/image_transparency_fixup.h
@@ -57,6 +57,9 @@ public:
 	 * 
 	 * The image must be of QImage::Format_ARGB32_Premultiplied.
 	 * It may be null.
+	 *
+	 * This fixup is needed for Qt5 < 5.15.9 and Qt6 < 6.2.4 which are
+	 * affected by https://bugreports.qt.io/browse/QTBUG-100327.
 	 */
 	inline ImageTransparencyFixup(QImage* image)
 	: dest(0), dest_end(0)
@@ -81,11 +84,13 @@ public:
 	 */
 	inline void operator()() const
 	{
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 9) || (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0) && QT_VERSION < QT_VERSION_CHECK(6, 2, 4))
 		for (QRgb* px = dest; px < dest_end; px++)
 		{
 			if (*px == 0x01000000) /* qRgba(0, 0, 0, 1) */
 				*px = 0x00000000;  /* qRgba(0, 0, 0, 0) */
 		}
+#endif
 	}
 	
 protected:

--- a/test/qpainter_t.cpp
+++ b/test/qpainter_t.cpp
@@ -80,9 +80,10 @@ void QPainterTest::multiplyComposition()
 	QCOMPARE(compose(white_img, white_img, multiply).pixel(0,0), qRgba(255, 255, 255, 255));
 	QCOMPARE(compose(black_img, black_img, multiply).pixel(0,0), qRgba(0, 0, 0, 255));
 	
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 9) || (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0) && QT_VERSION < QT_VERSION_CHECK(6, 2, 4))
 	QEXPECT_FAIL("", "CompositionMode_Multiply incorrectly composes full transparency.", Continue);
+#endif
 	QCOMPARE(compose(trans_img, trans_img, multiply).pixel(0,0), qRgba(0, 0, 0, 0));
-	QCOMPARE(compose(trans_img, trans_img, multiply).pixel(0,0), qRgba(0, 0, 0, 1)); // This should fail!
 	
 	// ImageTransparencyFixup fixes the particular issue.
 	QImage result = compose(trans_img, trans_img, multiply);
@@ -107,9 +108,10 @@ void QPainterTest::darkenComposition()
 	QCOMPARE(compose(white_img, white_img, darken).pixel(0,0), qRgba(255, 255, 255, 255));
 	QCOMPARE(compose(black_img, black_img, darken).pixel(0,0), qRgba(0, 0, 0, 255));
 	
+#if QT_VERSION < QT_VERSION_CHECK(5, 15, 9) || (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0) && QT_VERSION < QT_VERSION_CHECK(6, 2, 4))
 	QEXPECT_FAIL("", "CompositionMode_Darken incorrectly composes full transparency.", Continue);
+#endif
 	QCOMPARE(compose(trans_img, trans_img, darken).pixel(0,0), qRgba(0, 0, 0, 0));
-	QCOMPARE(compose(trans_img, trans_img, darken).pixel(0,0), qRgba(0, 0, 0, 1)); // This should fail!
 	
 	// ImageTransparencyFixup fixes the particular issue.
 	QImage result = compose(trans_img, trans_img, darken);


### PR DESCRIPTION
https://bugreports.qt.io/browse/QTBUG-100327 was fixed in 5.15.9, so now we have a good result from the beginning and don't need ImageTransparencyFixup.

This fixes a test failure which can be seen in [this log](https://launchpadlibrarian.net/666512825/buildlog_ubuntu-mantic-amd64.openorienteering-mapper_0.9.5-3build8_BUILDING.txt.gz).