### PR TITLE
IofCourseExport: Add 'Map' element

### DIFF
--- a/src/fileformats/iof_course_export.cpp
+++ b/src/fileformats/iof_course_export.cpp
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2021 Kai Pastor
+ *    Copyright 2021, 2025 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -22,6 +22,8 @@
 #include <Qt>
 #include <QDateTime>
 #include <QLatin1String>
+#include <QPointF>
+#include <QRectF>
 #include <QString>
 #include <QXmlStreamWriter>
 
@@ -97,8 +99,32 @@ void IofCourseExport::writeXml(const PathObject& object)
 	}
 	{
 		XmlElementWriter event(*xml, QLatin1String("RaceCourseData"));
+		writeMap();
 		writeControls(object.getRawCoordinateVector());
 		writeCourse(object.getRawCoordinateVector());
+	}
+}
+
+void IofCourseExport::writeMap()
+{
+	XmlElementWriter map_data(*xml, QLatin1String("Map"));
+	xml->writeTextElement(QLatin1String("Scale"), QString::number(map->getScaleDenominator()));
+	
+	// IOF.xsd proposes for 'MapPositionTopLeft': "The position of the map's top left corner given in the map's coordinate system, usually (0, 0)."
+	// However, the real coordinates from the map_extent structure are used below.
+	// NOTE: templates are considered when determining the map extent.
+	const auto map_extent = map->calculateExtent(true, true, view);
+	{
+		XmlElementWriter map_position_topleft(*xml, QLatin1String("MapPositionTopLeft"));
+		map_position_topleft.writeAttribute(QLatin1String("x"), QString::number(map_extent.topLeft().x()));
+		map_position_topleft.writeAttribute(QLatin1String("y"), QString::number(map_extent.topLeft().y()));
+		map_position_topleft.writeAttribute(QLatin1String("unit"), QLatin1String("mm"));	// optional attribute, default is 'mm'
+	}
+	{
+		XmlElementWriter map_position_bottomright(*xml, QLatin1String("MapPositionBottomRight"));
+		map_position_bottomright.writeAttribute(QLatin1String("x"), QString::number(map_extent.bottomRight().x()));
+		map_position_bottomright.writeAttribute(QLatin1String("y"), QString::number(map_extent.bottomRight().y()));
+		map_position_bottomright.writeAttribute(QLatin1String("unit"), QLatin1String("mm"));	// optional attribute, default is 'mm'
 	}
 }
 

--- a/src/fileformats/iof_course_export.h
+++ b/src/fileformats/iof_course_export.h
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2021 Kai Pastor
+ *    Copyright 2021, 2025 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -31,8 +31,8 @@ namespace OpenOrienteering {
 
 class LatLon;
 class Map;
-class MapView;
 class MapCoord;
+class MapView;
 class PathObject;
 class SimpleCourseExport;
 
@@ -59,6 +59,8 @@ protected:
 	bool exportImplementation() override;
 	
 	void writeXml(const PathObject& object);
+	
+	void writeMap();
 	
 	void writeControls(const std::vector<MapCoord>& coords);
 	

--- a/test/data/export/iof-3.0-course.xml
+++ b/test/data/export/iof-3.0-course.xml
@@ -1,9 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<CourseData xmlns="http://www.orienteering.org/datastandard/3.0" iofVersion="3.0" creator="OpenOrienteering Mapper Debug 0.9.6" createTime="2021-05-20T09:28:32">
+<CourseData xmlns="http://www.orienteering.org/datastandard/3.0" iofVersion="3.0" creator="OpenOrienteering Mapper Debug 0.9.6" createTime="2023-07-08T15:07:40">
     <Event>
         <Name>Test event</Name>
     </Event>
     <RaceCourseData>
+        <Map>
+            <Scale>10000</Scale>
+            <MapPositionTopLeft x="-3.196" y="-3.80311" unit="mm"/>
+            <MapPositionBottomRight x="53.675" y="3.80311" unit="mm"/>
+        </Map>
         <Control>
             <Id>S1</Id>
             <Position lng="8" lat="51"/>


### PR DESCRIPTION
The 'Map' element is added to the IOF 3.0 compliant xml export of course data.

This commit partly solves #2167, #2166.