### PR TITLE
Enhance CRT transformations from OSM to ISOM/ISSprOM/ISSkiOM symbol sets

### DIFF
--- a/symbol sets/OSM-ISOM 2017-2.crt
+++ b/symbol sets/OSM-ISOM 2017-2.crt
@@ -174,7 +174,7 @@
 521    tourism = alpine_hut
 531    tourism = artwork
 521    tourism = chalet
-531    tourism = information AND (information = guidepost OR information = map OR information=board)
+531    tourism = information AND (information = guidepost OR information = map OR information = board)
 
 526    historic = boundary_stone
 526    historic = memorial

--- a/symbol sets/OSM-ISOM 2017-2.crt
+++ b/symbol sets/OSM-ISOM 2017-2.crt
@@ -55,6 +55,8 @@
 404    natural = wood AND wood:density = sparse
 408    natural = wood AND wood:density = dense
 
+603.0  natural = peak
+
 304    waterway = canal
 306    waterway = ditch
 305    waterway = drain
@@ -87,6 +89,8 @@
 401    leisure = park
 401    leisure = pitch
 
+531    leisure = picnic_table
+
 503    highway = cycleway
 
 505    highway = footway
@@ -102,8 +106,11 @@
 507    highway = path AND (smoothness = horrible OR smoothness = very_horrible)
 
 502    highway = primary
+502    highway = primary_link
 502    highway = secondary
+502    highway = secondary_link
 502    highway = tertiary
+502    highway = tertiary_link
 
 504    highway = track
 503    highway = track AND (smoothness = good OR smoothness = intermediate)
@@ -118,6 +125,8 @@
 # 503.1  (highway = unclassified OR highway = residential OR highway = service OR highway = living_street) AND (surface = compacted OR surface = gravel)
 503    (highway = unclassified OR highway = residential OR highway = service OR highway = living_street) AND (surface = ground OR surface = sand OR surface = unpaved)
 504    (highway = unclassified OR highway = residential) AND (surface = grass OR surface = dirt)
+
+532    highway = steps
 
 509    railway ~= "" AND railway != "abandoned" AND tunnel != "yes"
 
@@ -165,8 +174,11 @@
 521    tourism = alpine_hut
 531    tourism = artwork
 521    tourism = chalet
+531    tourism = information AND (information = guidepost OR information = map OR information=board)
 
 526    historic = boundary_stone
+526    historic = memorial
+531    historic = wayside_cross
 
 531    pipeline = marker
 

--- a/symbol sets/OSM-ISSkiOM 2019.crt
+++ b/symbol sets/OSM-ISSkiOM 2019.crt
@@ -136,7 +136,7 @@
 521    tourism = alpine_hut
 531    tourism = artwork
 521    tourism = chalet
-531    tourism = information AND (information = guidepost OR information = map OR information=board)
+531    tourism = information AND (information = guidepost OR information = map OR information = board)
 
 531    historic = memorial
 531    historic = wayside_cross

--- a/symbol sets/OSM-ISSkiOM 2019.crt
+++ b/symbol sets/OSM-ISSkiOM 2019.crt
@@ -77,17 +77,19 @@
 401    leisure = park
 401    leisure = pitch
 
+531    leisure = picnic_table
+
 503    highway = cycleway
-
-
 
 502.2  highway = motorway
 502    highway = motorway_link
 
-
 502    highway = primary
+502    highway = primary_link
 502    highway = secondary
+502    highway = secondary_link
 502    highway = tertiary
+502    highway = tertiary_link
 
 504    highway = track
 503    highway = track AND (smoothness = good OR smoothness = intermediate)
@@ -134,7 +136,10 @@
 521    tourism = alpine_hut
 531    tourism = artwork
 521    tourism = chalet
+531    tourism = information AND (information = guidepost OR information = map OR information=board)
 
+531    historic = memorial
+531    historic = wayside_cross
 
 531    pipeline = marker
 

--- a/symbol sets/OSM-ISSprOM 2019.crt
+++ b/symbol sets/OSM-ISSprOM 2019.crt
@@ -159,7 +159,7 @@
 521    tourism = alpine_hut
 531    tourism = artwork
 521    tourism = chalet
-531    tourism = information AND (information = guidepost OR information = map OR information=board)
+531    tourism = information AND (information = guidepost OR information = map OR information = board)
 
 526    historic = boundary_stone
 526    historic = memorial

--- a/symbol sets/OSM-ISSprOM 2019.crt
+++ b/symbol sets/OSM-ISSprOM 2019.crt
@@ -83,6 +83,8 @@
 401    leisure = park
 401    leisure = pitch
 
+531    leisure = picnic_table
+
 501.8  highway = cycleway
 
 505.1  highway = footway
@@ -90,8 +92,11 @@
 526    highway = milestone
 
 501.19 highway = primary
+501.18 highway = primary_link
 501.19 highway = secondary
+501.18 highway = secondary_link
 501.9  highway = tertiary
+501.8  highway = tertiary_link
 
 506    highway = path
 505.1  highway = path AND (smoothness = good OR smoothness = intermediate)
@@ -110,6 +115,8 @@
 # 503.1  (highway = unclassified OR highway = residential OR highway = service OR highway = living_street) AND (surface = compacted OR surface = gravel)
 501.8  (highway = unclassified OR highway = residential OR highway = service OR highway = living_street) AND (surface = ground OR surface = sand OR surface = unpaved)
 505.2  (highway = unclassified OR highway = residential) AND (surface = grass OR surface = dirt)
+
+532.6  highway = steps
 
 509.1  railway ~= "" AND railway != "abandoned" AND tunnel != "yes"
 
@@ -152,8 +159,11 @@
 521    tourism = alpine_hut
 531    tourism = artwork
 521    tourism = chalet
+531    tourism = information AND (information = guidepost OR information = map OR information=board)
 
 526    historic = boundary_stone
+526    historic = memorial
+526    historic = wayside_cross
 
 531    pipeline = marker
 


### PR DESCRIPTION
Adding more OSM tags which can be translated into orienteering map symbols.
Namely:

- natural=peak
- leisure=picnic_table
- highway=primary_link
- highway=secondary_link
- highway=tertiary_link
- highway=steps
- tourism=information (restricted to guidepost, map or board)
- historic=memorial
- historic=wayside_cross

All of these I considered useful when I was preparing a base for my latest map.