### PR TITLE
DrawPathTool: Highlight object that is going to be followed

### DIFF
--- a/src/tools/draw_path_tool.h
+++ b/src/tools/draw_path_tool.h
@@ -152,6 +152,10 @@ protected:
 	std::unique_ptr<SnappingToolHelper> snap_helper;
 	
 	PathObject* append_to_object;
+	std::unique_ptr<PathObject> followed_path;
+	std::unique_ptr<LineSymbol> covering_white_line;
+	std::unique_ptr<LineSymbol> covering_red_line;
+	std::unique_ptr<CombinedSymbol> follow_highlight_symbol;
 	
 	std::unique_ptr<FollowPathToolHelper> follow_helper;
 	MapCoordVector::size_type follow_start_index;


### PR DESCRIPTION
In complex map situations it is unclear which object will be followed when the user uses the Shift modifier key to follow lines or area object boundaries. This is a proposal how to make the object selection more obvious.

Note the dashed object boundary highlight in the video.

[Screencast from 2023-09-06 15-49-27.webm](https://github.com/OpenOrienteering/mapper/assets/5584406/64c26fdf-0430-4f8f-bbf5-dfa23eb4ee8c)
