### PR TITLE
MapFindFeature: Pass map to query parser

### DIFF
--- a/src/core/objects/object_query.cpp
+++ b/src/core/objects/object_query.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2016 Mitchell Krome
- *    Copyright 2017-2022 Kai Pastor
+ *    Copyright 2017-2024 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -637,6 +637,11 @@ bool operator==(const ObjectQuery& lhs, const ObjectQuery& rhs)
 
 
 // ### ObjectQueryParser ###
+
+ObjectQueryParser::ObjectQueryParser(const Map* map)
+: map{map}
+{}
+
 
 void ObjectQueryParser::setMap(const Map* map)
 {

--- a/src/core/objects/object_query.h
+++ b/src/core/objects/object_query.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2016 Mitchell Krome
- *    Copyright 2017-2020 Kai Pastor
+ *    Copyright 2017-2024 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -246,6 +246,9 @@ bool operator!=(const ObjectQuery::StringOperands& lhs, const ObjectQuery::Strin
 class ObjectQueryParser
 {
 public:
+	ObjectQueryParser() = default;
+	explicit ObjectQueryParser(const Map* map);
+	
 	/**
 	 * Sets the map for looking up symbols.
 	 */
@@ -290,7 +293,7 @@ private:
 	QStringRef input;
 	QStringRef token_text;
 	TokenType token;
-	int token_start;
+	int token_start = -1;
 	int pos;
 };
 

--- a/src/gui/map/map_find_feature.cpp
+++ b/src/gui/map/map_find_feature.cpp
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2017-2020 Kai Pastor
+ *    Copyright 2017-2024 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -153,7 +153,7 @@ ObjectQuery MapFindFeature::makeQuery() const
 			auto text = text_edit->toPlainText().trimmed();
 			if (!text.isEmpty())
 			{
-				query = ObjectQueryParser().parse(text);
+				query = ObjectQueryParser(controller.getMap()).parse(text);
 				if (!query || query.getOperator() == ObjectQuery::OperatorSearch)
 					query = ObjectQuery{ ObjectQuery(ObjectQuery::OperatorSearch, text),
 					        ObjectQuery::OperatorOr,


### PR DESCRIPTION
The map object is needed for SYMBOL queries.
Fixes GH-2183.