### PR TITLE
Use WGS84 (G2139) as the geographic CRS

### DIFF
--- a/src/core/georeferencing.cpp
+++ b/src/core/georeferencing.cpp
@@ -304,7 +304,7 @@ bool ProjTransform::isGeographic() const
 
 QPointF ProjTransform::forward(const LatLon& lat_lon, bool* ok) const
 {
-	static auto const geographic_crs = ProjTransform(Georeferencing::ballpark_geographic_crs_spec);
+	static auto const geographic_crs = ProjTransform(Georeferencing::gnss_crs_spec);
 	
 	auto point = isGeographic()
 	             ? QPointF{lat_lon.longitude(), lat_lon.latitude()}
@@ -324,7 +324,7 @@ QPointF ProjTransform::forward(const LatLon& lat_lon, bool* ok) const
 
 LatLon ProjTransform::inverse(const QPointF& projected_coords, bool* ok) const
 {
-	static auto const geographic_crs = ProjTransform(Georeferencing::ballpark_geographic_crs_spec);
+	static auto const geographic_crs = ProjTransform(Georeferencing::gnss_crs_spec);
 	
 	double easting = projected_coords.x(), northing = projected_coords.y();
 	if (geographic_crs.isValid())
@@ -376,7 +376,7 @@ ProjTransform::ProjTransform(const QString& crs_spec)
 	if (crs_spec.isEmpty())
 		return;
 	
-	static auto const geographic_crs_spec_utf8 = Georeferencing::ballpark_geographic_crs_spec.toUtf8();
+	static auto const geographic_crs_spec_utf8 = Georeferencing::gnss_crs_spec.toUtf8();
 	
 	auto crs_spec_utf8 = crs_spec.toUtf8();
 #ifdef PROJ_ISSUE_1573
@@ -386,7 +386,7 @@ ProjTransform::ProjTransform(const QString& crs_spec)
 #if defined(ACCEPT_USE_OF_DEPRECATED_PROJ_API_H) || (PROJ_VERSION_MAJOR) < 8
 	pj = proj_create_crs_to_crs(PJ_DEFAULT_CTX, geographic_crs_spec_utf8, crs_spec_utf8, nullptr);
 #else
-	static auto const geographic_crs = crs(Georeferencing::ballpark_geographic_crs_spec);
+	static auto const geographic_crs = crs(Georeferencing::gnss_crs_spec);
 	auto const projected_crs = crs(crs_spec);
 	static const char* const options[] = {"AUTHORITY=any", nullptr};
 	pj = proj_create_crs_to_crs_from_pj(PJ_DEFAULT_CTX, geographic_crs.pj, projected_crs.pj, nullptr, options);

--- a/src/core/georeferencing.h
+++ b/src/core/georeferencing.h
@@ -133,7 +133,12 @@ public:
 	/**
 	 * A shared PROJ specification of a WGS84 geographic CRS.
 	 */
-	static const QString geographic_crs_spec;
+	static const QString ballpark_geographic_crs_spec;
+	
+	/**
+	 * A shared PROJ specification of an accurate realization of the WGS84 geographic CRS.
+	 */
+	static const QString gnss_crs_spec;
 	
 	
 	/**
@@ -480,7 +485,8 @@ public:
 	LatLon toGeographicCoords(const MapCoordF& map_coords, bool* ok = 0) const;
 	
 	/**
-	 * Transforms CRS coordinates to geographic coordinates (lat/lon).
+	 * Transforms CRS coordinates to geographic coordinates (lat/lon)
+	 * using a WGS84 datum.
 	 */
 	LatLon toGeographicCoords(const QPointF& projected_coords, bool* ok = 0) const;
 	

--- a/src/gdal/ogr_template.cpp
+++ b/src/gdal/ogr_template.cpp
@@ -296,7 +296,7 @@ try
 		{
 			is_georeferenced = true;
 			// Data is to be transformed to the map CRS directly.
-			track_crs_spec = Georeferencing::geographic_crs_spec;
+			track_crs_spec = Georeferencing::ballpark_geographic_crs_spec;
 			return true;
 		}
 	}
@@ -318,7 +318,7 @@ try
 			preserveRefPoints(*data_georef, initial_georef);
 		explicit_georef = std::move(data_georef);
 		// Data is to be transformed to the projected CRS.
-		track_crs_spec = Georeferencing::geographic_crs_spec;
+		track_crs_spec = Georeferencing::ballpark_geographic_crs_spec;
 		projected_crs_spec = explicit_georef->getProjectedCRSSpec();
 	}
 	
@@ -600,7 +600,7 @@ bool OgrTemplate::finishTypeSpecificTemplateConfiguration()
 			// Data is to be transformed to the map CRS directly.
 			Q_ASSERT(projected_crs_spec.isEmpty());
 		}
-		else if (!track_crs_spec.contains(QLatin1String("+proj=latlong")))
+		else if (!ProjTransform::crs(track_crs_spec).isGeographic())
 		{
 			// Nothing to do with this configuration
 			Q_ASSERT(projected_crs_spec.isEmpty());

--- a/src/gdal/ogr_template.cpp
+++ b/src/gdal/ogr_template.cpp
@@ -296,7 +296,7 @@ try
 		{
 			is_georeferenced = true;
 			// Data is to be transformed to the map CRS directly.
-			track_crs_spec = Georeferencing::ballpark_geographic_crs_spec;
+			track_crs_spec = Georeferencing::gnss_crs_spec;
 			return true;
 		}
 	}
@@ -318,7 +318,7 @@ try
 			preserveRefPoints(*data_georef, initial_georef);
 		explicit_georef = std::move(data_georef);
 		// Data is to be transformed to the projected CRS.
-		track_crs_spec = Georeferencing::ballpark_geographic_crs_spec;
+		track_crs_spec = Georeferencing::gnss_crs_spec;
 		projected_crs_spec = explicit_georef->getProjectedCRSSpec();
 	}
 	

--- a/src/gui/select_crs_dialog.cpp
+++ b/src/gui/select_crs_dialog.cpp
@@ -130,7 +130,7 @@ QString SelectCRSDialog::currentCRSSpec() const
 		// nothing
 		break;
 	case SpecialCRS::Geographic:
-		spec = Georeferencing::ballpark_geographic_crs_spec;
+		spec = Georeferencing::gnss_crs_spec;
 		break;
 	case SpecialCRS::TemplateFile:
 		spec = options.template_file.crs_spec;

--- a/src/gui/select_crs_dialog.cpp
+++ b/src/gui/select_crs_dialog.cpp
@@ -101,7 +101,7 @@ SelectCRSDialog::SelectCRSDialog(
 		crs_selector->setCurrentIndex(crs_selector->findData(SpecialCRS::TemplateFile));
 	else if (crs_spec == georef.getProjectedCRSSpec())
 		crs_selector->setCurrentIndex(crs_selector->findData(SpecialCRS::SameAsMap));
-	else if (crs_spec == Georeferencing::geographic_crs_spec)
+	else if (crs_spec == Georeferencing::ballpark_geographic_crs_spec)
 		crs_selector->setCurrentIndex(crs_selector->findData(SpecialCRS::Geographic));
 	else
 		crs_selector->setCurrentCRS(CRSTemplateRegistry().find(QString::fromLatin1("PROJ.4")), { crs_spec });
@@ -130,7 +130,7 @@ QString SelectCRSDialog::currentCRSSpec() const
 		// nothing
 		break;
 	case SpecialCRS::Geographic:
-		spec = Georeferencing::geographic_crs_spec;
+		spec = Georeferencing::ballpark_geographic_crs_spec;
 		break;
 	case SpecialCRS::TemplateFile:
 		spec = options.template_file.crs_spec;

--- a/src/templates/template_track.cpp
+++ b/src/templates/template_track.cpp
@@ -152,7 +152,7 @@ TemplateTrack::TemplateTrack(const QString& path, Map* map)
  : Template(path, map)
 {
 	// set default value
-	track_crs_spec = Georeferencing::ballpark_geographic_crs_spec;
+	track_crs_spec = Georeferencing::gnss_crs_spec;
 	
 	const Georeferencing& georef = map->getGeoreferencing();
 	connect(&georef, &Georeferencing::projectionChanged, this, &TemplateTrack::updateGeoreferencing);
@@ -580,7 +580,7 @@ void TemplateTrack::configureForGPSTrack()
 {
 	is_georeferenced = true;
 	
-	track_crs_spec = Georeferencing::ballpark_geographic_crs_spec;
+	track_crs_spec = Georeferencing::gnss_crs_spec;
 	
 	projected_crs_spec.clear();
 	track.changeMapGeoreferencing(map->getGeoreferencing());

--- a/src/templates/template_track.cpp
+++ b/src/templates/template_track.cpp
@@ -152,7 +152,7 @@ TemplateTrack::TemplateTrack(const QString& path, Map* map)
  : Template(path, map)
 {
 	// set default value
-	track_crs_spec = Georeferencing::geographic_crs_spec;
+	track_crs_spec = Georeferencing::ballpark_geographic_crs_spec;
 	
 	const Georeferencing& georef = map->getGeoreferencing();
 	connect(&georef, &Georeferencing::projectionChanged, this, &TemplateTrack::updateGeoreferencing);
@@ -257,7 +257,7 @@ bool TemplateTrack::loadTemplateFileImpl()
 		return false;
 	}
 	
-	if (!track_crs_spec.isEmpty() && track_crs_spec != Georeferencing::geographic_crs_spec)
+	if (!track_crs_spec.isEmpty() && track_crs_spec != Georeferencing::ballpark_geographic_crs_spec)
 	{
 		setErrorString(tr("This template must be loaded with GDAL/OGR."));
 		return false;
@@ -580,7 +580,7 @@ void TemplateTrack::configureForGPSTrack()
 {
 	is_georeferenced = true;
 	
-	track_crs_spec = Georeferencing::geographic_crs_spec;
+	track_crs_spec = Georeferencing::ballpark_geographic_crs_spec;
 	
 	projected_crs_spec.clear();
 	track.changeMapGeoreferencing(map->getGeoreferencing());

--- a/test/template_t.cpp
+++ b/test/template_t.cpp
@@ -494,8 +494,8 @@ private slots:
 		QVERIFY(map.getTemplate(template_index)->loadTemplateFile());
 		QCOMPARE(temp->getTemplateState(), Template::Loaded);
 
-		QEXPECT_FAIL("TemplateTrack NAD83", "Unsupported WGS 84 -> NAD 83 transformation", Continue);
-		QEXPECT_FAIL("OgrTemplate NAD83", "Unsupported WGS 84 -> NAD 83 transformation", Continue);
+		QEXPECT_FAIL("TemplateTrack from v0.8.4", "WGS 84 -> NAD 83 transformation updated", Continue);
+		QEXPECT_FAIL("OGRTemplate from v0.9.3", "WGS 84 -> NAD 83 transformation updated", Continue);
 		auto const expected_center = map.calculateExtent().center();
 		if (QLineF(center(temp), expected_center).length() > 0.25) // 1 m
 			QCOMPARE(center(temp), expected_center);
@@ -567,10 +567,6 @@ private slots:
 			ogr_template_center = center(temp);
 		}
 		
-#if !defined(ACCEPT_USE_OF_DEPRECATED_PROJ_API_H) || PJ_VERSION >= 600
-		QEXPECT_FAIL("TemplateTrack NAD83", "Unsupported WGS 84 -> NAD 83 transformation", Continue);
-		QEXPECT_FAIL("OgrTemplate NAD83", "Unsupported WGS 84 -> NAD 83 transformation", Continue);
-#endif
 		if (QLineF(ogr_template_center, template_track_center).length() > 0.1) // 40 cm
 			QCOMPARE(ogr_template_center, template_track_center);
 		else


### PR DESCRIPTION
These changes replace the geographic CRS spec string "+proj=latlong +datum=WGS84" with "EPSG:9755" for most Georeferencing purposes. EPSG:9755 is code for the current realization (G2139) of WGS84.

When creating a template with GDAL, OgrFileImport::setSRS will now recognize whether the data SRS (as detected by GDAL) is geographic and uses the ensemble/ballpark WGS84. In that case it changes the data SRS to EPSG:9755. As a result, alignment of tracks is more accurate, and tracks are aligned the same whether or not imported with GDAL.

**map file format**
The old spec string "+proj=latlong +datum=WGS84" continues to be used when Mapper saves to file. In Mapper's file format, this string appears as the map's geographic CRS and as the CRS of some templates. Because the file format is unchanged, this version of Mapper is interoperable with v0.9.5 and earlier.

However, this compatibility has unfortunate consequences.

1. Because the file has <geographic_crs_spec> elements, a Mapper that uses EPSG:9755 should put "EPSG:9755" in the file. The current PR throws away this information.
2. Future users of Mapper may need to work with old maps in a way that preserves the original alignment of tracks and images. It should be possible to distinguish old maps from new.

In the future, I plan to extend this PR with a change to the file format for new maps.

**fixes**
This is a draft, intended to address #2196 (Inaccurate import of images and tracks), along the lines suggested by @sfroyen. It fixes #1709 (Tracks positioned differently with GDAL enabled). It fixes #1264 (UTM coordinates should vary with datum).

There has been plenty of discussion of fixing these problems, along with hopes for a fix that would use PROJ to transform directly from CRS to CRS without an intermediate geographic CRS "pivot". Those efforts have not succeeded. This draft is worth considering because it is a simple change.