### PR TITLE
ColorListWidget: Warn about spot color removal

### DIFF
--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -2002,6 +2002,7 @@ void MapEditorController::spotColorPresenceChanged(bool has_spot_colors)
 		}
 		else
 		{
+			overprintingSimulation(false);
 			overprinting_simulation_act->setChecked(false);
 			overprinting_simulation_act->setEnabled(false);
 		}


### PR DESCRIPTION
A color entry may serve as a spot color without direct use in symbols. So far Mapper allowed silent removal of these color entries. This patch adds a warning that triggers when the user tries to remove such a spot color.

~~The problem with disabling the Overprint simulation option while the map is still displayed in overprint mode (as seen in the video further down) is not addressed by this patch. The mechanism for disabling overprint upon the last color deletion seems to be in place but does not work.~~

EDIT: The second patch fixes the problem with disabling the Overprint simulation option presented at the end of the video.

A video documenting the current behavior:
[spot-color-no-warning.webm](https://github.com/OpenOrienteering/mapper/assets/5584406/2ac06646-1295-41da-8b5d-c749642c23b0)
