### PR TITLE
OcdFileImport: Warn about ignored point symbol in text symbol

### DIFF
--- a/src/fileformats/ocd_file_import.cpp
+++ b/src/fileformats/ocd_file_import.cpp
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2013-2022 Kai Pastor
+ *    Copyright 2013-2024 Kai Pastor
  *
  *    Some parts taken from file_format_oc*d8{.h,_p.h,cpp} which are
  *    Copyright 2012 Pete Curtis
@@ -1660,6 +1660,11 @@ TextSymbol* OcdFileImport::importTextSymbol(const S& ocd_symbol)
 	setBasicAttributes(symbol, convertOcdString(ocd_symbol.font_name), ocd_symbol.basic);
 	setSpecialAttributes(symbol, ocd_symbol.special);
 	setFraming(symbol, ocd_symbol.framing);
+	if (ocd_version >= 10)
+	{
+		if (ocd_symbol.framing.point_symbol_on_V10)
+			addSymbolWarning(symbol, OcdFileImport::tr("Additional point symbol '%1.%2' is ignored.").arg(ocd_symbol.framing.point_symbol_number_V10 / 1000).arg(ocd_symbol.framing.point_symbol_number_V10 % 1000));
+	}
 	symbol->setRotatable(ocd_symbol.base.flags & Ocd::SymbolRotatable);
 	return symbol;
 }

--- a/src/fileformats/ocd_file_import.cpp
+++ b/src/fileformats/ocd_file_import.cpp
@@ -1663,7 +1663,9 @@ TextSymbol* OcdFileImport::importTextSymbol(const S& ocd_symbol)
 	if (ocd_version >= 10)
 	{
 		if (ocd_symbol.framing.point_symbol_on_V10)
-			addSymbolWarning(symbol, OcdFileImport::tr("Additional point symbol '%1.%2' is ignored.").arg(ocd_symbol.framing.point_symbol_number_V10 / 1000).arg(ocd_symbol.framing.point_symbol_number_V10 % 1000));
+			addSymbolWarning(symbol, OcdFileImport::tr("Not importing unsupported reference to point symbol '%1.%2'.") .
+			                         arg(ocd_symbol.framing.point_symbol_number_V10 / S::BaseSymbol::symbol_number_factor) .
+			                         arg(ocd_symbol.framing.point_symbol_number_V10 % S::BaseSymbol::symbol_number_factor));
 	}
 	symbol->setRotatable(ocd_symbol.base.flags & Ocd::SymbolRotatable);
 	return symbol;

--- a/src/fileformats/ocd_file_import.cpp
+++ b/src/fileformats/ocd_file_import.cpp
@@ -1663,7 +1663,7 @@ TextSymbol* OcdFileImport::importTextSymbol(const S& ocd_symbol)
 	if (ocd_version >= 10)
 	{
 		if (ocd_symbol.framing.point_symbol_on_V10)
-			addSymbolWarning(symbol, OcdFileImport::tr("Not importing unsupported reference to point symbol '%1.%2'.") .
+			addSymbolWarning(symbol, OcdFileImport::tr("Skipping unsupported reference to point symbol '%1.%2'.") .
 			                         arg(ocd_symbol.framing.point_symbol_number_V10 / S::BaseSymbol::symbol_number_factor) .
 			                         arg(ocd_symbol.framing.point_symbol_number_V10 % S::BaseSymbol::symbol_number_factor));
 	}


### PR DESCRIPTION
Text symbols in .ocd files can contain an additional point symbol that is currently silently ignored when importing such files. This change issues a detailed warning when ignoring an additional point symbol.