### PR TITLE
MapColor: Fix warning and simplify implementation

### DIFF
--- a/src/core/map_color.cpp
+++ b/src/core/map_color.cpp
@@ -209,7 +209,7 @@ void MapColor::setSpotColorComposition(const SpotColorComponents& components)
 bool MapColor::removeSpotColorComponent(const MapColor* color)
 {
 	auto size_before = components.size();
-	auto match = [this, color](const SpotColorComponent& scc) { return scc.spot_color == color; };
+	auto match = [color](const SpotColorComponent& scc) { return scc.spot_color == color; };
 	components.erase(std::remove_if(begin(components), end(components), match), end(components));
 	bool changed = components.size() != size_before;
 	if (changed)
@@ -228,12 +228,9 @@ void MapColor::setKnockout(bool flag)
 	if (spot_color_method != MapColor::UndefinedMethod)
 	{
 		if (flag)
-		{
-			if (!getKnockout())
-				flags += MapColor::Knockout;
-		}
-		else if (getKnockout())
-			flags -= MapColor::Knockout;
+			flags |= MapColor::Knockout;
+		else
+			flags &= ~MapColor::Knockout;
 		
 		Q_ASSERT(getKnockout() == flag);
 	}

--- a/src/core/map_color.cpp
+++ b/src/core/map_color.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2013-2020 Kai Pastor
+ *    Copyright 2013-2024 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -223,16 +223,16 @@ bool MapColor::removeSpotColorComponent(const MapColor* color)
 	return changed;
 }
 
-void MapColor::setKnockout(bool flag)
+void MapColor::setKnockout(bool enabled)
 {
 	if (spot_color_method != MapColor::UndefinedMethod)
 	{
-		if (flag)
+		if (enabled)
 			flags |= MapColor::Knockout;
 		else
 			flags &= ~MapColor::Knockout;
 		
-		Q_ASSERT(getKnockout() == flag);
+		Q_ASSERT(getKnockout() == enabled);
 	}
 }
 

--- a/src/core/map_color.h
+++ b/src/core/map_color.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2013-2020 Kai Pastor
+ *    Copyright 2013-2024 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -325,9 +325,9 @@ public:
 	/**
 	 * Sets the value of knockout flag for spot color printing.
 	 * 
-	 * The color must have a spot color definition, or no change will be done.
+	 * This function has no effect if the color does not have a spot color definition.
 	 */
-	void setKnockout(bool flag);
+	void setKnockout(bool enabled);
 	
 	/**
 	 * Returns the value of the knockout flag.


### PR DESCRIPTION
Avoid warning by removing unused 'this' from capture clause.
Simplify implementation by removing unnecessary checks and using bitmask values in the typical way.