### PR TITLE
Warn on spot color deletion

### DIFF
--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012-2014 Thomas Schöps
- *    Copyright 2013-2020 Kai Pastor
+ *    Copyright 2013-2020, 2024 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -1395,6 +1395,25 @@ bool Map::hasAlpha() const
 }
 
 
+void Map::applyOnMatchingColors(const std::function<void (const MapColor*)>& operation, const std::function<bool (const MapColor*)>& condition) const
+{
+	for (const auto* color : color_set->colors)
+	{
+		if (condition(color))
+			operation(color);
+	}
+}
+
+
+void Map::applyOnAllColors(const std::function<void (const MapColor*)>& operation) const
+{
+	for (const auto* color : color_set->colors)
+	{
+		operation(color);
+	}
+}
+
+
 void Map::setSymbolSetId(const QString& id)
 {
 	symbol_set_id = id;
@@ -1720,6 +1739,25 @@ void Map::determineSymbolUseClosure(std::vector< bool >& symbol_bitfield) const
 		}
 		
 	} while (change);
+}
+
+
+void Map::applyOnMatchingSymbols(const std::function<void (const Symbol*)>& operation, const std::function<bool (const Symbol*)>& condition) const
+{
+	for (const auto* symbol : symbols)
+	{
+		if (condition(symbol))
+			operation(symbol);
+	}
+}
+
+
+void Map::applyOnAllSymbols(const std::function<void (const Symbol*)>& operation) const
+{
+	for (const auto* symbol : symbols)
+	{
+		operation(symbol);
+	}
 }
 
 

--- a/src/core/map.h
+++ b/src/core/map.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012-2014 Thomas Schöps
- *    Copyright 2013-2020 Kai Pastor
+ *    Copyright 2013-2020, 2024 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -489,6 +489,16 @@ public:
 	 */
 	bool hasAlpha() const;
 	
+	/**
+	 * Applies a const operation on all colors which match a particular condition.
+	 */
+	void applyOnMatchingColors(const std::function<void (const MapColor*)>& operation, const std::function<bool (const MapColor*)>& condition) const;
+	
+	/**
+	 * Applies a const operation on all colors.
+	 */
+	void applyOnAllColors(const std::function<void (const MapColor*)>& operation) const;
+	
 	
 	// Symbols
 	
@@ -578,6 +588,16 @@ public:
 	 * display the symbols indicated by the bitfield because of symbol dependencies.
 	 */
 	void determineSymbolUseClosure(std::vector< bool >& symbol_bitfield) const;
+	
+	/**
+	 * Applies a const operation on all symbols which match a particular condition.
+	 */
+	void applyOnMatchingSymbols(const std::function<void (const Symbol*)>& operation, const std::function<bool (const Symbol*)>& condition) const;
+	
+	/**
+	 * Applies a const operation on all symbols.
+	 */
+	void applyOnAllSymbols(const std::function<void (const Symbol*)>& operation) const;
 	
 	/**
 	 * Returns the scale factor to be used for default symbol icons.

--- a/src/core/map_color.cpp
+++ b/src/core/map_color.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2013-2024 Kai Pastor
+ *    Copyright 2013-2020, 2024 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -204,6 +204,13 @@ void MapColor::setSpotColorComposition(const SpotColorComponents& components)
 	removeSpotColorComponent(this);
 	updateCompositionName();
 	updateCalculatedColors();
+}
+
+bool MapColor::hasSpotColorComponent(const MapColor* color) const
+{
+	return std::any_of(components.begin(), components.end(), [color](const auto& component) {
+		return component.spot_color == color;
+	});
 }
 
 bool MapColor::removeSpotColorComponent(const MapColor* color)

--- a/src/core/map_color.h
+++ b/src/core/map_color.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2013-2024 Kai Pastor
+ *    Copyright 2013-2020, 2024 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -313,6 +313,11 @@ public:
 	 * Returns an empty list if the spot color method is not CustomColor.
 	 */
 	const SpotColorComponents& getComponents() const;
+	
+	/**
+	 * Test if another color is part of the spot color composition.
+	 */
+	bool hasSpotColorComponent(const MapColor* color) const;
 	
 	/**
 	 * Removes a component color.

--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2021 Kai Pastor
+ *    Copyright 2012-2021, 2024 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -2002,7 +2002,8 @@ void MapEditorController::spotColorPresenceChanged(bool has_spot_colors)
 		}
 		else
 		{
-			overprinting_simulation_act->setChecked(false);
+			if (overprinting_simulation_act->isChecked())
+				overprinting_simulation_act->trigger();
 			overprinting_simulation_act->setEnabled(false);
 		}
 	}

--- a/src/gui/widgets/color_list_widget.cpp
+++ b/src/gui/widgets/color_list_widget.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2024 Kai Pastor
+ *    Copyright 2012-2018, 2021, 2024 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -41,6 +41,7 @@
 #include <QMessageBox>
 #include <QPalette>
 #include <QShowEvent>
+#include <QString>
 #include <QStringList>
 #include <QStyle>
 #include <QStyleOption>
@@ -52,12 +53,12 @@
 
 #include "core/map.h"
 #include "core/map_color.h"
+#include "core/symbols/symbol.h"
 #include "gui/color_dialog.h"
 #include "gui/main_window.h"
 #include "gui/util_gui.h"
 #include "gui/widgets/segmented_button_layout.h"
 #include "util/item_delegates.h"
-#include "util/util.h"
 
 // IWYU pragma: no_forward_declare QTableWidgetItem
 
@@ -222,6 +223,85 @@ void ColorListWidget::newColor()
 	editCurrentColor();
 }
 
+bool ColorListWidget::confirmColorDeletion(const MapColor* color_to_be_removed) const
+{
+	QString detailed_text;
+	
+	std::vector<const Symbol*> remaining_symbols;
+	remaining_symbols.reserve(std::size_t(map->getNumSymbols()));
+	{
+		// First: direct usage in symbols
+		QString direct_usage;
+		map->applyOnAllSymbols(
+			[&direct_usage, &remaining_symbols, color_to_be_removed](const Symbol* symbol) {
+				if (symbol->getType() == Symbol::NoSymbol)
+					return;
+				if (symbol->containsColor(color_to_be_removed))
+					direct_usage += symbol->getNumberAsString() + QChar::Space + symbol->getPlainTextName() + QChar::LineFeed;
+				else
+					remaining_symbols.push_back(symbol);
+			}
+		);
+		if (!direct_usage.isEmpty())
+		{
+			detailed_text += tr("This color is used by the following symbols:") + QChar::LineFeed
+							 + direct_usage + QChar::LineFeed;
+		}
+	}
+	
+	if (color_to_be_removed->getSpotColorMethod() == MapColor::SpotColor)
+	{
+		// Second: usage as spot color
+		QString spotcolor_usage;
+		std::vector<const MapColor*> affected_colors;
+		affected_colors.reserve(std::size_t(map->getNumColors()));
+		map->applyOnMatchingColors(
+			[&spotcolor_usage, &affected_colors](const auto* color) {
+				spotcolor_usage += color->getName() + QChar::LineFeed;
+				affected_colors.push_back(color);
+			},
+			[&color_to_be_removed](const auto* color) {
+				return color->hasSpotColorComponent(color_to_be_removed);
+			}
+		);
+		if (!affected_colors.empty())
+		{
+			detailed_text += tr("This color is used as a spot color by the following map colors:") + QChar::LineFeed
+							 + spotcolor_usage + QChar::LineFeed;
+			
+			// Third: Additional transitive usage via spot color composition
+			QString transitive_usage;
+			for (const auto* symbol : remaining_symbols)
+			{
+				for (const auto* color : affected_colors)
+				{
+					if (symbol->containsColor(color))
+					{
+						transitive_usage += symbol->getNumberAsString() + QChar::Space + symbol->getPlainTextName() + QChar::LineFeed;
+						break;
+					}
+				}
+			}
+			if (!transitive_usage.isEmpty())
+			{
+				detailed_text += tr("This spot color is used by the following symbols:") + QChar::LineFeed
+								 + transitive_usage;
+			}
+		}
+	}
+		
+	if (detailed_text.isEmpty())
+		return true;
+	
+	QMessageBox msgBox;
+	msgBox.setWindowTitle(tr("Confirmation"));
+	msgBox.setIcon(QMessageBox::Warning);
+	msgBox.setText(tr("Color \"%1\" is used by other elements. Removing the color will change the appearance of these elements. Do you really want to remove it?").arg(color_to_be_removed->getName()));
+	msgBox.setDetailedText(detailed_text);
+	msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+	return msgBox.exec() == QMessageBox::Yes;
+}
+
 void ColorListWidget::deleteColor()
 {
 	int row = color_table->currentRow();
@@ -229,11 +309,8 @@ void ColorListWidget::deleteColor()
 	if (row < 0) return; // In release mode
 	
 	// Show a warning if the color is used
-	if (map->isColorUsedByASymbol(map->getColor(row)))
-	{
-		if (QMessageBox::warning(this, tr("Confirmation"), tr("The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
-			return;
-	}
+	if (!confirmColorDeletion(map->getColor(row)))
+		return;
 	
 	map->deleteColor(row);
 	

--- a/src/gui/widgets/color_list_widget.h
+++ b/src/gui/widgets/color_list_widget.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012, 2013, 2014, 2017 Kai Pastor
+ *    Copyright 2012-2014, 2017, 2024 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -23,7 +23,6 @@
 #define OPENORIENTEERING_COLOR_LIST_WIDGET_H
 
 #include <QObject>
-#include <QString>
 #include <QWidget>
 
 class QAction;
@@ -76,6 +75,7 @@ protected:
 private:
 	void addRow(int row);
 	void updateRow(int row);
+	bool confirmColorDeletion(const OpenOrienteering::MapColor* color_to_be_removed) const;
 	
 	// Color list
 	QTableWidget* color_table;


### PR DESCRIPTION
Modification of GH-2209, GH-2235

- Don't use more than `overprinting_simulation_act` in `MapEditorController::spotColorPresenceChanged`.
- Add and use iteration functions for colors and symbols (long-standing wishlist item :innocent:)
- Show the color name in the spot color removal message. Feels more comfortable when confirming.