### PR TITLE
Fix "empty hole" quirks

### DIFF
--- a/src/core/virtual_path.cpp
+++ b/src/core/virtual_path.cpp
@@ -89,20 +89,17 @@ VirtualCoordVector::size_type PathCoordVector::update(VirtualCoordVector::size_t
 	{	
 		Q_ASSERT(virtual_coords.size() == flags.size());
 		
+		clear();
+		
 		if (flags[part_start].isHolePoint())
 		{
 			auto pos = virtual_coords[0];
 			qWarning("PathCoordVector at %g %g (mm) has an invalid hole at index %d.",
 			         pos.x(), -pos.y(), part_start);
-			clear();
 			return part_start;
 		}
 		
-		clear();
-		if (empty() || (part_start > 0 && flags[part_start-1].isHolePoint()))
-		{
-			emplace_back(virtual_coords[part_start], part_start, 0.0, 0.0);
-		}
+		emplace_back(virtual_coords[part_start], part_start, 0.0, 0.0);
 		
 		for (auto index = part_start + 1; index <= part_end; ++index)
 		{

--- a/src/core/virtual_path.cpp
+++ b/src/core/virtual_path.cpp
@@ -94,6 +94,8 @@ VirtualCoordVector::size_type PathCoordVector::update(VirtualCoordVector::size_t
 			auto pos = virtual_coords[0];
 			qWarning("PathCoordVector at %g %g (mm) has an invalid hole at index %d.",
 			         pos.x(), -pos.y(), part_start);
+			clear();
+			return part_start;
 		}
 		
 		clear();

--- a/test/path_object_t.h
+++ b/test/path_object_t.h
@@ -75,6 +75,9 @@ private slots:
 	/** Tests PathCoord and SplitPathCoord for a non-trivial zero-length path. */
 	void atypicalPathTest();
 	
+	/** Tests recalculation of path parts from input coords. */
+	void recalculatePartsTest();
+	void recalculatePartsTest_data();
 };
 
 #endif


### PR DESCRIPTION
The crash fixed in GH-2224/GH-2144 had an OCD import aspect (data source) and an map editor aspect (data usage). This PR adresses the second aspect. While it was easy to locate the crash and its trigger, a confusing fact was that the path part data in the map editor wasn't the same as the data observed while debugging the OCD import. It furned out that the initial calculation of map parts in `PathObject::recalculateParts()` (expected data) was overwritten by `PathObject::updatePathCoords()` (actual data).

This PR aligns map part calulation in the second function with the first function, and a adds a basic test. This fixes the crash. 

There is a certain risk that this creates new problems. But the generated data is fairly reasonable now.