### PR TITLE
Show color usage and warn on spot color deletion

### DIFF
--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012-2014 Thomas Schöps
- *    Copyright 2013-2020 Kai Pastor
+ *    Copyright 2013-2024 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -1308,17 +1308,20 @@ bool Map::isColorUsedByASymbol(const MapColor* color) const
 	return false;
 }
 
-int Map::countSpotColorUsage(const MapColor* spot_color) const
+void Map::determineSpotColorUsage(const MapColor* spot_color, std::vector< const MapColor* >& out) const
 {
-	auto is_match = [spot_color](const SpotColorComponent& component) {
-		return component.spot_color == spot_color;
-	};
-	return std::accumulate(begin(color_set->colors), end(color_set->colors), 0, [is_match](int count, const MapColor* c) {
-		const auto& composition = c->getComponents();
-		if (std::any_of(begin(composition), end(composition), is_match))
-			++count;
-		return count;
-	});
+	for (auto color : color_set->colors)
+	{
+		const auto& composition = color->getComponents();
+		for (auto component : composition)
+		{
+			if (component.spot_color == spot_color)
+			{
+				out.push_back(color);
+				break;
+			}
+		}
+	}
 }
 
 void Map::determineColorsInUse(const std::vector< bool >& by_which_symbols, std::vector< bool >& out) const

--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -1308,6 +1308,19 @@ bool Map::isColorUsedByASymbol(const MapColor* color) const
 	return false;
 }
 
+int Map::countSpotColorUsage(const MapColor* spot_color) const
+{
+	auto is_match = [spot_color](const SpotColorComponent& component) {
+		return component.spot_color == spot_color;
+	};
+	return std::accumulate(begin(color_set->colors), end(color_set->colors), 0, [is_match](int count, const MapColor* c) {
+		const auto& composition = c->getComponents();
+		if (std::any_of(begin(composition), end(composition), is_match))
+			++count;
+		return count;
+	});
+}
+
 void Map::determineColorsInUse(const std::vector< bool >& by_which_symbols, std::vector< bool >& out) const
 {
 	if (getNumSymbols() == 0)

--- a/src/core/map.h
+++ b/src/core/map.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012-2014 Thomas Schöps
- *    Copyright 2013-2020 Kai Pastor
+ *    Copyright 2013-2024 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -470,9 +470,9 @@ public:
 	bool isColorUsedByASymbol(const MapColor* color) const;
 	
 	/**
-	 * Returns the number of map colors which use the given spot color.
+	 * Returns the map colors which use the given spot color.
 	 */
-	int countSpotColorUsage(const MapColor* spot_color) const;
+	void determineSpotColorUsage(const MapColor* spot_color, std::vector< const MapColor* >& out) const;
 	
 	/**
 	 * Checks which colors are in use by the symbols in this map.

--- a/src/core/map.h
+++ b/src/core/map.h
@@ -470,6 +470,11 @@ public:
 	bool isColorUsedByASymbol(const MapColor* color) const;
 	
 	/**
+	 * Returns the number of map colors which use the given spot color.
+	 */
+	int countSpotColorUsage(const MapColor* spot_color) const;
+	
+	/**
 	 * Checks which colors are in use by the symbols in this map.
 	 * 
 	 * WARNING (FIXME): returns an empty list if the map does not contain symbols!

--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2021 Kai Pastor
+ *    Copyright 2012-2024 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -2002,7 +2002,7 @@ void MapEditorController::spotColorPresenceChanged(bool has_spot_colors)
 		}
 		else
 		{
-			if(overprinting_simulation_act->isChecked())
+			if (overprinting_simulation_act->isChecked())
 				overprinting_simulation_act->trigger();
 			overprinting_simulation_act->setEnabled(false);
 		}

--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -2002,7 +2002,8 @@ void MapEditorController::spotColorPresenceChanged(bool has_spot_colors)
 		}
 		else
 		{
-			overprinting_simulation_act->setChecked(false);
+			if(overprinting_simulation_act->isChecked())
+				overprinting_simulation_act->trigger();
 			overprinting_simulation_act->setEnabled(false);
 		}
 	}

--- a/src/gui/widgets/color_list_widget.cpp
+++ b/src/gui/widgets/color_list_widget.cpp
@@ -274,16 +274,18 @@ void ColorListWidget::deleteColor()
 	
 	if (affected_colors_num || affected_symbols_num)
 	{
+		QString spot_color_text = tr("Map color \"%1\" defines spot color \"%2\"."
+									" %n other map color(s) use this spot color."
+									" Deleting the map color will remove the spot color from these map colors.",
+									nullptr,
+									affected_colors_num).arg(color_to_be_removed->getName(), color_to_be_removed->getSpotColorName());
+		
 		if (!affected_symbols_num)
 		{
-		if (QMessageBox::warning(this, tr("Confirmation"),
-								 tr("%n map color(s) use spot color \"%1\"."
-									" Deleting it will remove the spot color from these map colors."
-									" Do you really want to do that?",
-									nullptr,
-									affected_colors_num).arg(color_to_be_removed->getSpotColorName()),
-								 QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
-			return;
+			if (QMessageBox::warning(this, tr("Confirmation"),
+									 spot_color_text + tr("\nDo you really want to do that?"),
+									 QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
+				return;
 		}
 		else
 		{
@@ -293,25 +295,18 @@ void ColorListWidget::deleteColor()
 				if (affected_colors_num)
 					warning_text += tr(", %n object(s)", nullptr, affected_objects_num);
 				else
-					warning_text += tr("and %n object(s)", nullptr, affected_objects_num);
+					warning_text += tr(" and %n object(s)", nullptr, affected_objects_num);
 			}
 			if (affected_colors_num)
 				warning_text += tr(" and %n other map color(s)", nullptr, affected_colors_num);
-			warning_text +=  tr(" with this color. Deleting it will remove the color from them! Do you really want to do that?");
+			warning_text +=  tr(" with this color. Deleting it will remove the color from them!") + tr("\nDo you really want to do that?");
 			
 			QMessageBox msgBox;
 			msgBox.setWindowTitle(tr("Confirmation"));
 			msgBox.setIcon(QMessageBox::Warning);
 			msgBox.setText(warning_text);
 			if (affected_colors_num)
-			{
-				QString detailed_text = tr("Map color \"%1\" defines spot color \"%2\"."
-										" %n other map color(s) use this spot color."
-										" Deleting the map color will remove the spot color from these map colors.",
-										nullptr,
-										affected_colors_num).arg(color_to_be_removed->getName(), color_to_be_removed->getSpotColorName());
-				msgBox.setDetailedText(detailed_text);
-			}
+				msgBox.setDetailedText(spot_color_text);
 			msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
 			if (msgBox.exec() == QMessageBox::No)
 				return;

--- a/src/gui/widgets/color_list_widget.cpp
+++ b/src/gui/widgets/color_list_widget.cpp
@@ -224,10 +224,26 @@ void ColorListWidget::deleteColor()
 	if (row < 0) return; // In release mode
 	
 	// Show a warning if the color is used
-	if (map->isColorUsedByASymbol(map->getColor(row)))
+	auto const* color_to_be_removed = map->getColor(row);
+	if (map->isColorUsedByASymbol(color_to_be_removed))
 	{
 		if (QMessageBox::warning(this, tr("Confirmation"), tr("The map contains symbols with this color. Deleting it will remove the color from these objects! Do you really want to do that?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
 			return;
+	}
+	
+	if (color_to_be_removed->getSpotColorMethod() == MapColor::SpotColor)
+	{
+		if (auto color_in_use = map->countSpotColorUsage(color_to_be_removed))
+		{
+			if (QMessageBox::warning(this, tr("Confirmation"),
+			                         tr("%n map color(s) use spot color \"%1\"."
+			                            " Deleting it will remove the spot color from these map colors."
+			                            " Do you really want to do that?",
+			                            nullptr,
+			                            color_in_use).arg(color_to_be_removed->getName()),
+			                         QMessageBox::Yes | QMessageBox::No) == QMessageBox::No)
+				return;
+		}
 	}
 	
 	map->deleteColor(row);

--- a/src/gui/widgets/color_list_widget.h
+++ b/src/gui/widgets/color_list_widget.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012, 2013, 2014, 2017 Kai Pastor
+ *    Copyright 2012-2024 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -23,7 +23,6 @@
 #define OPENORIENTEERING_COLOR_LIST_WIDGET_H
 
 #include <QObject>
-#include <QString>
 #include <QWidget>
 
 class QAction;
@@ -76,6 +75,7 @@ protected:
 private:
 	void addRow(int row);
 	void updateRow(int row);
+	bool confirmColorDeletion(const OpenOrienteering::MapColor* color_to_be_removed) const;
 	
 	// Color list
 	QTableWidget* color_table;


### PR DESCRIPTION
When a user wants to delete a color, the warning message was ambiguous by mixing up symbols and objects (see #2127).
This PR merges #2127, #2222, #2209.
It shows one warning dialog if

- the color is used by symbols
- the color is used as a spot color by other colors.

In addition the warning messages specifies the number of symbols, objects and other map colors that will be affected by the color removal.
A more detailed warning is available when removing spot colors.