### PR TITLE
ColorListWidget: Fix table column resize mode

### DIFF
--- a/src/gui/widgets/color_list_widget.cpp
+++ b/src/gui/widgets/color_list_widget.cpp
@@ -163,6 +163,13 @@ ColorListWidget::ColorListWidget(Map* map, MainWindow* window, QWidget* parent)
 	header_view->setSectionResizeMode(5, QHeaderView::Fixed); // Knockout
 	header_view->resizeSection(5, 32);
 	header_view->setSectionsClickable(false);
+	if (map->getNumColors() == 0)
+	{
+		header_view->resizeSection(1, 160); // Name
+		header_view->resizeSection(2, 128); // Spot colors
+		header_view->resizeSection(3, 96);  // CMYK
+		header_view->resizeSection(4, 64);  // RGB
+	}
 	
 	currentCellChange(color_table->currentRow(), 0, 0, 0);	// enable / disable move color buttons
 	

--- a/src/gui/widgets/color_list_widget.cpp
+++ b/src/gui/widgets/color_list_widget.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2017 Kai Pastor
+ *    Copyright 2012-2024 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -160,8 +160,6 @@ ColorListWidget::ColorListWidget(Map* map, MainWindow* window, QWidget* parent)
 	header_view->resizeSections(QHeaderView::ResizeToContents);
 	header_view->setSectionResizeMode(0, QHeaderView::Fixed); // Color
 	header_view->resizeSection(0, 32);
-	header_view->setSectionResizeMode(1, QHeaderView::Stretch); // Name
-	header_view->setSectionResizeMode(1, QHeaderView::Interactive); // Spot colors
 	header_view->setSectionResizeMode(5, QHeaderView::Fixed); // Knockout
 	header_view->resizeSection(5, 32);
 	header_view->setSectionsClickable(false);


### PR DESCRIPTION
The individual setting 'QHeaderView::Stretch' of the 'Name' column's resize mode was erroneously overwritten by the setting which was intended for the 'Spot color' column.
Since 'QHeaderView::Stretch' results in undesired behaviour the default setting 'QHeaderView::Interactive' is kept.