### PR TITLE
GeoreferencingDialog: Remove link to WorldofO

### DIFF
--- a/src/gui/georeferencing_dialog.cpp
+++ b/src/gui/georeferencing_dialog.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2020 Kai Pastor
+ *    Copyright 2012-2020, 2024 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -395,6 +395,7 @@ void GeoreferencingDialog::projectionChanged()
 	QString osm_link =
 	  QString::fromLatin1("https://www.openstreetmap.org/?mlat=%1&mlon=%2&zoom=18&layers=M").
 	  arg(latitude, 0, 'g', 10).arg(longitude, 0, 'g', 10);
+#ifdef MAPPER_WITH_WORLDOFO_LINK
 	QString worldofo_link =
 	  QString::fromLatin1("http://maps.worldofo.com/?zoom=15&lat=%1&lng=%2").
 	  arg(latitude).arg(longitude);
@@ -402,6 +403,9 @@ void GeoreferencingDialog::projectionChanged()
 	  tr("<a href=\"%1\">OpenStreetMap</a> | <a href=\"%2\">World of O Maps</a>").
 	  arg(osm_link, worldofo_link)
 	);
+#else
+	link_label->setText(tr("<a href=\"%1\">OpenStreetMap</a>").arg(osm_link));
+#endif
 	
 	QString error = georef->getErrorText();
 	if (error.length() == 0)


### PR DESCRIPTION
Since the link to 'World of O' to lookup maps is not working for quite a long time and as this service is apparently no longer provided, remove the link by commenting it out in the code.