### PR TITLE
SymbolReportFeature: Generate reports for symbol sets

### DIFF
--- a/code-check-wrapper.sh
+++ b/code-check-wrapper.sh
@@ -96,6 +96,7 @@ for I in \
   stretch_map_dialog.cpp \
   style_t.cpp \
   /symbol.cpp \
+  symbol_report \
   symbol_replacement.cpp \
   symbol_replacement_dialog.cpp \
   symbol_rule_set.cpp \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -114,6 +114,7 @@ set(Mapper_Common_SRCS
   
   core/symbols/area_symbol.cpp
   core/symbols/combined_symbol.cpp
+  core/symbols/html_symbol_report.cpp
   core/symbols/line_symbol.cpp
   core/symbols/point_symbol.cpp
   core/symbols/symbol.cpp
@@ -175,6 +176,7 @@ set(Mapper_Common_SRCS
   gui/symbols/symbol_properties_widget.cpp
   gui/symbols/symbol_replacement.cpp
   gui/symbols/symbol_replacement_dialog.cpp
+  gui/symbols/symbol_report_feature.cpp
   gui/symbols/symbol_setting_dialog.cpp
   gui/symbols/text_symbol_settings.cpp
   

--- a/src/core/symbols/html_symbol_report.cpp
+++ b/src/core/symbols/html_symbol_report.cpp
@@ -1,0 +1,297 @@
+/*
+ *    Copyright 2024 Kai Pastor
+ *
+ *    This file is part of OpenOrienteering.
+ *
+ *    OpenOrienteering is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OpenOrienteering is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "html_symbol_report.h"
+
+#include <QBuffer>
+#include <QByteArray>
+#include <QChar>
+#include <QColor>
+#include <QCoreApplication>
+#include <QImage>
+#include <QImageWriter>
+#include <QLatin1String>
+#include <QLocale>
+#include <QString>
+#include <QTextDocumentFragment>
+
+#include "core/map.h"
+#include "core/map_color.h"
+#include "core/symbols/symbol.h"
+
+namespace OpenOrienteering {
+
+/**
+ * Generates HTML reports for colors and symbols in a Map.
+ * 
+ * The public interface of this class is the free-standing function
+ * makeHTMLSymbolReport(const Map& map).
+ */
+class HTMLSymbolReportGenerator
+{
+private:
+	/**
+	 * Efficiently produce PNG data from QImage.
+	 * 
+	 * An object of this class holds a buffer which is reused in multiple calls
+	 * to write(). So the number of actual memory allocations can be kept small.
+	 */
+	class PNGImageWriter
+	{
+		QByteArray png {"PNG"};
+		QByteArray png_data;
+		
+	public:
+		/**
+		 * Creates PNG data from an image.
+		 * 
+		 * @return A reference to a shared buffer. The buffer is invalidated
+		 *         when the function is called again (for the same writer).
+		 */
+		const QByteArray& write(const QImage& image)
+		{
+			png_data.clear();
+			QBuffer buffer(&png_data);
+			QImageWriter(&buffer, png).write(image);
+			return png_data;
+		}
+	};
+	
+	enum class ColorRowType {
+		Basic,    ///< A color row with number, icon and name
+		Extended  ///< A color row with all details
+	};
+	
+	const Map& map;
+	QImage icon_image;
+	QLocale locale;
+	PNGImageWriter image_writer;
+	
+	QString imgForColor(const QColor& c, const QString& alt)
+	{
+		icon_image.fill(c);
+		return QString::fromLatin1("<img alt=\"%1\" src=\"data:image/png;base64,").arg(alt)
+		       + QString::fromLatin1(image_writer.write(icon_image).toBase64())
+		       + QString::fromLatin1("\">");
+	}
+	
+	QString makeColorRow(const MapColor& c, ColorRowType row_type)
+	{
+		icon_image = QImage(16, 16, QImage::Format_ARGB32);
+		
+		auto details = QString {};
+		if (row_type == ColorRowType::Extended)
+		{
+			auto cmyk = c.getCmyk();
+			details = QString::fromLatin1(
+			              "<td>%1</td>" // c
+			              "<td>%2</td>" // m
+			              "<td>%3</td>" // y
+			              "<td>%4</td>" // k
+			              "<td style=\"font-family:monospace\">%5</td>" // rgb
+			              "<td>%6</td>" // spot color
+			              "<td>%7</td>" // knockout
+			              ).arg(
+			                  locale.toString(100*cmyk.c, 'g', 3),
+			                  locale.toString(100*cmyk.m, 'g', 3),
+			                  locale.toString(100*cmyk.y, 'g', 3),
+			                  locale.toString(100*cmyk.k, 'g', 3),
+			                  QColor(c.getRgb()).name(),
+			                  QString{c.getSpotColorName()}.replace(QString::fromLatin1(", "), QString::fromLatin1(",<br>")),
+			                  c.getKnockout() ? QString::fromLatin1("[X]") : QString{} );
+		}
+		
+		auto name = QTextDocumentFragment::fromHtml(c.getName()).toPlainText();
+		return QString::fromLatin1(
+		           "<tr>"
+		           "<td>%1</td>" // level
+		           "<td>%2</td>" // icon
+		           "<td class=\"name\">%3</td>" // name
+		           "%9"          // details
+		           "</tr>\n"
+		           ).arg(
+		        QString::number(c.getPriority()),
+		        imgForColor(c, name),
+		        name,
+		        details );
+	}
+	
+	QString makeColorSection()
+	{
+		QString color_data;
+		map.applyOnAllColors([this, &color_data](const MapColor* c) {
+			color_data.append(makeColorRow(*c, ColorRowType::Extended));
+		});
+		return QString::fromLatin1(
+		           "<h2>%1</h2>\n"
+		           "<table class=\"colors\">\n"
+		           "<thead>\n"
+		           "<tr>"
+		           "<th colspan=\"2\">%2</th>"
+		           "<th class=\"name\">%3</th>"
+		           "<th>C</th>"
+		           "<th>M</th>"
+		           "<th>Y</th>"
+		           "<th>K</th>"
+		           "<th>%4</th>"
+		           "<th>%5</th>"
+		           "<th>%6</th>"
+		           "</tr>\n"
+		           "</thead>\n"
+		           "<tbody>\n"
+		           "%9"
+		           "</tbody>\n"
+		           "</table>\n"
+		           ).arg(
+		        QCoreApplication::translate("OpenOrienteering::SymbolReport", "Map Colors"),
+		        QCoreApplication::translate("OpenOrienteering::SymbolReport", "Color"),
+		        QCoreApplication::translate("OpenOrienteering::SymbolReport", "Name"),
+		        QCoreApplication::translate("OpenOrienteering::SymbolReport", "RGB"),
+		        QCoreApplication::translate("OpenOrienteering::SymbolReport", "Spot colors"),
+		        QCoreApplication::translate("OpenOrienteering::SymbolReport", "Knockout"),
+		        color_data );
+	}
+	
+	QString imgForSymbol(const Symbol& s, const QString& alt)
+	{
+		// For better quality and compression,
+		// using multiple of display size but no antialiasing
+		auto const display_size = 48;
+		icon_image = s.createIcon(map, 4 * display_size, false);
+		return QString::fromLatin1("<img alt=\"%1\" width=\"%2\" src=\"data:image/png;base64,").arg(alt).arg(display_size)
+		       + QString::fromLatin1(image_writer.write(icon_image).toBase64())
+		       + QString::fromLatin1("\">");
+	}
+	
+	QString colorsForSymbol(const Symbol& s)
+	{
+		QString color_data;
+		map.applyOnAllColors([this, &s, &color_data](const MapColor* c){
+			if (s.containsColor(c))
+				color_data.append(makeColorRow(*c, ColorRowType::Basic));
+		});
+		return QString::fromLatin1(
+		           "<table>\n"
+		           "<tbody>\n"
+		           "%1"
+		           "</tbody>\n"
+		           "</table>\n"
+		           ).arg(
+		        color_data );
+	}
+	
+	QString makeSymbolRow(const Symbol& s)
+	{
+		auto label = QString { s.getNumberAsString()
+		                       + QChar::Space
+		                       + QTextDocumentFragment::fromHtml(s.getName()).toPlainText() };
+		auto extra_text = QString{};
+		if (s.isRotatable())
+			extra_text += QCoreApplication::translate("OpenOrienteering::SymbolReport", "[X] %1")
+			              .arg(QCoreApplication::translate("OpenOrienteering::SymbolReport", "Symbol orientation can be changed."))
+			              + QLatin1String("<br>\n");
+		if (s.hasRotatableFillPattern())
+			extra_text += QCoreApplication::translate("OpenOrienteering::SymbolReport", "[X] %1")
+			              .arg(QCoreApplication::translate("OpenOrienteering::SymbolReport", "Pattern orientation can be changed."))
+			              + QLatin1String("<br>\n");
+		if (s.isHelperSymbol())
+			extra_text += QCoreApplication::translate("OpenOrienteering::SymbolReport", "[X] %1")
+			              .arg(QCoreApplication::translate("OpenOrienteering::SymbolReport", "Helper symbol"))
+			              + QLatin1String("<br>\n");
+		return QString::fromLatin1(
+		           "<tr>"
+		           "<td style=\"vertical-align:top;\">%1</td>\n"          // icon
+		           "<td style=\"vertical-align:middle;\"><b>%2</b></td>"  // label
+		           "</tr>\n"
+		           "<tr>"
+		           "<td>&nbsp;</td>\n"
+		           "<td style=\"padding-bottom:18px;\">\n"
+		           "<div>\n%3</div>\n"  // description
+		           "<p>%4</p>\n"        // configuration properties
+		           "%5</td>"            // colors
+		           "</tr>\n"
+		           ).arg(
+		        imgForSymbol(s, label),
+		        label,
+		        QString(s.getDescription()).replace(QChar::LineFeed, QLatin1String("<br>\n")),
+		        extra_text,
+		        colorsForSymbol(s) );
+	}
+	
+	QString makeSymbolSection()
+	{
+		QString symbol_data;
+		map.applyOnAllSymbols([this, &symbol_data](const Symbol* s){
+			symbol_data.append(makeSymbolRow(*s));
+		});
+		return QString::fromLatin1(
+		           "<h2>%1</h2>\n"
+		           "<table class=\"symbols\">\n"
+		           "<tbody>\n"
+		           "%2"
+		           "</tbody>\n"
+		           "</table>\n"
+		           ).arg(
+		        QCoreApplication::translate("OpenOrienteering::SymbolReport", "Symbols"),
+		        symbol_data );
+	}
+	
+public:
+	explicit HTMLSymbolReportGenerator(const Map& map)
+	: map(map)
+	{}
+	
+	QString generate()
+	{
+		return QString::fromLatin1(
+		           "<!DOCTYPE html>\n"
+		           "<html>\n"
+		           "<head>\n"
+		           "<meta charset=\"utf-8\">"
+		           "<title>%0</title>\n"
+		           "<meta name=\"generator\" content=\"OpenOrienteering Mapper\">\n"
+		           "<style>\n"
+		           "th { font-size: 120%; text-align: center; }\n"
+		           "th, td { padding: 4px; }\n"
+		           "table.colors { text-align: center; }\n"
+		           "table.colors td:first-child { text-align: right; }\n"
+		           "table.colors td.name { text-align: left; }\n"
+		           "table.symbols { max-width: 60em; }\n"
+		           "</style>\n"
+		           "</head>\n"
+		           "<body>\n"
+		           "<h1>%0</h1>\n"
+		           "%1"
+		           "%2"
+		           "</body>\n"
+		           "</html>"
+		           ).arg(
+		        QCoreApplication::translate("OpenOrienteering::SymbolReport", "Symbol Set Report on '%0'").arg(map.symbolSetId()),
+		        makeColorSection(),
+		        makeSymbolSection() );
+	}
+};
+
+
+QString makeHTMLSymbolReport(const Map& map)
+{
+	return HTMLSymbolReportGenerator(map).generate();
+}
+
+}  // namespace OpenOrienteering

--- a/src/core/symbols/html_symbol_report.h
+++ b/src/core/symbols/html_symbol_report.h
@@ -1,0 +1,36 @@
+/*
+ *    Copyright 2024 Kai Pastor
+ *
+ *    This file is part of OpenOrienteering.
+ *
+ *    OpenOrienteering is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OpenOrienteering is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPENORIENTEERING_HTML_SYMBOL_REPORT_H
+#define OPENORIENTEERING_HTML_SYMBOL_REPORT_H
+
+class QString;
+
+namespace OpenOrienteering {
+
+class Map;
+
+/**
+ * Generates a symbol set report in HTML format.
+ */
+QString makeHTMLSymbolReport(const Map& map);
+
+}  // namespace OpenOrienteering
+
+#endif  // OPENORIENTEERING_HTML_SYMBOL_REPORT_H

--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -127,6 +127,7 @@
 #include "gui/map/map_widget.h"
 #include "gui/map/rotate_map_dialog.h"
 #include "gui/symbols/symbol_replacement.h"
+#include "gui/symbols/symbol_report_feature.h"
 #include "gui/widgets/action_grid_bar.h"
 #include "gui/widgets/color_list_widget.h"
 #include "gui/widgets/compass_display.h"
@@ -476,6 +477,7 @@ void MapEditorController::setEditingInProgress(bool value)
 		scale_all_symbols_act->setEnabled(!editing_in_progress);
 		load_symbols_from_act->setEnabled(!editing_in_progress);
 		load_crt_act->setEnabled(!editing_in_progress);
+		symbol_report_feature->setEnabled(!editing_in_progress);
 		
 		// Templates menu
 		paint_feature->setEnabled(!editing_in_progress);
@@ -1018,6 +1020,7 @@ void MapEditorController::createActions()
 	load_symbols_from_act = newAction("loadsymbols", tr("Replace symbol set..."), this, SLOT(loadSymbolsFromClicked()), nullptr, tr("Replace the symbols with those from another map file"), "symbol_replace_dialog.html");
 	load_crt_act = newAction("loadcrt", tr("Load CRT file..."), this, SLOT(loadCrtClicked()), nullptr, tr("Assign new symbols by cross-reference table"), "symbol_replace_dialog.html");
 	/*QAction* load_colors_from_act = newAction("loadcolors", tr("Load colors from..."), this, SLOT(loadColorsFromClicked()), nullptr, tr("Replace the colors with those from another map file"));*/
+	symbol_report_feature = std::make_unique<SymbolReportFeature>(*this);
 	
 	scale_all_symbols_act = newAction("scaleall", tr("Scale all symbols..."), this, SLOT(scaleAllSymbolsClicked()), nullptr, tr("Scale the whole symbol set"), "map_menu.html");
 	georeferencing_act = newAction("georef", tr("Georeferencing..."), this, SLOT(editGeoreferencing()), nullptr, QString{}, "georeferencing.html");
@@ -1270,6 +1273,8 @@ void MapEditorController::createMenuAndToolbars()
 	symbols_menu->addAction(load_symbols_from_act);
 	symbols_menu->addAction(load_crt_act);
 	/*symbols_menu->addAction(load_colors_from_act);*/
+	symbols_menu->addSeparator();
+	symbols_menu->addAction(symbol_report_feature->showDialogAction());
 	
 	// Templates menu
 	QMenu* template_menu = window->menuBar()->addMenu(tr("&Templates"));

--- a/src/gui/map/map_editor.h
+++ b/src/gui/map/map_editor.h
@@ -71,6 +71,7 @@ class PaintOnTemplateFeature;
 class PrintWidget;
 class ReopenTemplateDialog;
 class Symbol;
+class SymbolReportFeature;
 class SymbolWidget;
 class Template;
 class TemplateListWidget;
@@ -746,6 +747,8 @@ private:
 	QAction* rotate_map_act = {};
 	QAction* map_notes_act = {};
 	QAction* symbol_set_id_act = {};
+	std::unique_ptr<SymbolReportFeature> symbol_report_feature;
+	
 	
 	QAction* color_window_act = {};
 	QPointer<EditorDockWidget> color_dock_widget;

--- a/src/gui/symbols/symbol_report_feature.cpp
+++ b/src/gui/symbols/symbol_report_feature.cpp
@@ -1,0 +1,115 @@
+/*
+ *    Copyright 2024 Kai Pastor
+ *
+ *    This file is part of OpenOrienteering.
+ *
+ *    OpenOrienteering is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OpenOrienteering is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "symbol_report_feature.h"
+
+#include <algorithm>
+#include <iterator>
+
+#include <Qt>
+#include <QAction>
+#include <QDesktopServices>
+#include <QIODevice>
+#include <QLatin1String>
+#include <QSaveFile>
+#include <QString>
+#include <QStringList>
+#include <QUrl>
+
+#include "core/symbols/html_symbol_report.h"
+#include "gui/file_dialog.h"
+#include "gui/main_window.h"
+#include "gui/map/map_editor.h"
+#include "gui/util_gui.h"
+
+namespace OpenOrienteering {
+
+
+namespace {
+
+static const char* const html_extensions[2] = { ".htm", ".html" };
+static const char* const html_filter        = { "*.htm *.html" };
+
+QString htmlFileFilter()
+{
+	static const QString filter_template(QLatin1String("%1 (%2)"));
+	QStringList filters = {
+	    filter_template.arg(::OpenOrienteering::SymbolReportFeature::tr("HTML"), QLatin1String(html_filter)),
+	    ::OpenOrienteering::SymbolReportFeature::tr("All files (*.*)")
+	};
+	return filters.join(QLatin1String(";;"));
+}
+
+QString ensureHtmlExtension(QString filepath)
+{
+	using std::begin; using std::end;
+	auto const has_html_extension = std::any_of(begin(html_extensions), end(html_extensions), [&filepath](const auto& extension) {
+		return filepath.endsWith(QString::fromLatin1(extension), Qt::CaseInsensitive);
+	});
+	if (!has_html_extension)
+		filepath.append(QString::fromLatin1(html_extensions[0]));
+	return filepath;
+}
+
+}
+
+SymbolReportFeature::SymbolReportFeature(MapEditorController& controller)
+: QObject{nullptr}
+, controller{controller}
+{
+	show_action = new QAction(tr("Create symbol set report..."), this);
+	show_action->setMenuRole(QAction::NoRole);
+	show_action->setWhatsThis(Util::makeWhatThis("symbols_menu.html"));
+	connect(show_action, &QAction::triggered, this, &SymbolReportFeature::showDialog);
+}
+
+SymbolReportFeature::~SymbolReportFeature() = default;
+
+void SymbolReportFeature::setEnabled(bool enabled)
+{
+	show_action->setEnabled(enabled);
+}
+
+void SymbolReportFeature::showDialog()
+{
+	const auto* map = controller.getMap();
+	auto* window = controller.getWindow();
+	if (!map || !window)
+		return;
+	
+	auto filepath = FileDialog::getSaveFileName(
+	    window,
+	    ::OpenOrienteering::MainWindow::tr("Save file"),
+	    {},
+	    htmlFileFilter() );
+	if (filepath.isEmpty())
+		return;
+	
+	filepath = ensureHtmlExtension(filepath);
+	QSaveFile file(filepath);
+	if (file.open(QIODevice::WriteOnly | QIODevice::Text))
+	{
+		const auto report = makeHTMLSymbolReport(*map);
+		file.write(report.toUtf8());
+		if(file.commit())
+			QDesktopServices::openUrl(QUrl::fromLocalFile(filepath));
+	}
+}
+
+}

--- a/src/gui/symbols/symbol_report_feature.h
+++ b/src/gui/symbols/symbol_report_feature.h
@@ -1,0 +1,60 @@
+/*
+ *    Copyright 2024 Kai Pastor
+ *
+ *    This file is part of OpenOrienteering.
+ *
+ *    OpenOrienteering is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU General Public License as published by
+ *    the Free Software Foundation, either version 3 of the License, or
+ *    (at your option) any later version.
+ *
+ *    OpenOrienteering is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPENORIENTEERING_SYMBOL_REPORT_FEATURE_H
+#define OPENORIENTEERING_SYMBOL_REPORT_FEATURE_H
+
+#include <QtGlobal>
+#include <QObject>
+// IWYU pragma: no_include <QString>
+
+class QAction;
+
+namespace OpenOrienteering {
+
+class MapEditorController;
+
+/**
+ * Provides a UI feature for generating symbol set reports.
+ */
+class SymbolReportFeature : public QObject
+{
+	Q_OBJECT
+	
+public:
+	SymbolReportFeature(MapEditorController& controller);
+	
+	~SymbolReportFeature() override;
+	
+	void setEnabled(bool enabled);
+	
+	QAction* showDialogAction() { return show_action; }
+	
+private:
+	void showDialog();
+	
+	MapEditorController& controller;
+	QAction* show_action;
+	
+	Q_DISABLE_COPY(SymbolReportFeature)
+};
+	
+}  // namespace OpenOrienteering
+
+#endif  // OPENORIENTEERING_SYMBOL_REPORT_FEATURE_H


### PR DESCRIPTION
This feature is to help with validation symbol sets with regard to specifications and existing symbol sets.

UI: Symbols > Create symbol set report

The current implementation create a single-file HTML report which directly embeds all images.