### PR TITLE
MeasureWidget: Show warning icon for small objects

### DIFF
--- a/src/gui/widgets/measure_widget.h
+++ b/src/gui/widgets/measure_widget.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2015 Kai Pastor
+ *    Copyright 2015, 2024 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -23,6 +23,7 @@
 #define OPENORIENTEERING_MEASURE_WIDGET_H
 
 #include <QObject>
+#include <QString>
 #include <QTextBrowser>
 
 class QWidget;
@@ -55,6 +56,7 @@ protected slots:
 	
 private:
 	Map* map;
+	QString warning_icon;
 };
 
 


### PR DESCRIPTION
This change enhances visibility of the small object warning in the measure tool. The use case is to shrink the measure tool window to a minimum size so that only the top line is visible and keep it in the view field during drawing. New sub-size object will trigger the colored warning icon, giving the user opportunity to fix the legibility issue on the go.

Idea contributed by @ollesmaps.

![Screenshot from 2024-06-28 01-10-21](https://github.com/OpenOrienteering/mapper/assets/5584406/33ee74dc-9e9a-4d4c-8348-b271a257732c)


