### PR TITLE
GeoreferencingDialog: Fix declination lookup

### DIFF
--- a/src/gui/georeferencing_dialog.cpp
+++ b/src/gui/georeferencing_dialog.cpp
@@ -452,6 +452,7 @@ void GeoreferencingDialog::requestDeclination(bool no_confirm)
 	
 	QUrlQuery query;
 	QDate today = QDate::currentDate();
+	query.addQueryItem(QString::fromLatin1("key"), QString::fromLatin1("zNEw7"));
 	query.addQueryItem(QString::fromLatin1("lat1"), QString::number(latlon.latitude()));
 	query.addQueryItem(QString::fromLatin1("lon1"), QString::number(latlon.longitude()));
 	query.addQueryItem(QString::fromLatin1("startYear"), QString::number(today.year()));


### PR DESCRIPTION
The declination lookup at www.ngdc.noaa.gov requests an additional parameter 'key'. OpenOrienteering Mapper is entitled due to registration to use the key which is also used by the Magnetic Field Calculators' homepage.

This PR is a straightforward version of #2088 and thus might supersede it.