### PR TITLE
CI: Increase job timeout

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -334,6 +334,7 @@ jobs:
 
 - job: Windows_mingw32_Release
   displayName: Windows x32 (Release, MinGW)
+  timeoutInMinutes: 90
   variables:
     IMAGE_NAME: 'windows-2019'
     SUPBERBUILD_IMAGE_NAME: $(IMAGE_NAME)

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -362,6 +362,7 @@ jobs:
 
 - job: Windows_mingw64_Release
   displayName: Windows x64 (Release, MinGW)
+  timeoutInMinutes: 90
   variables:
     IMAGE_NAME: 'windows-2019'
     SUPBERBUILD_IMAGE_NAME: $(IMAGE_NAME)


### PR DESCRIPTION
Increasing job level timeout to task level timeout (now 90min due to #2253).
Referring to [Task control options' Note](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/tasks?view=azure-devops&tabs=yaml#task-control-options)
