### PR TITLE
MapEditorController: Disable menu item if no symbols are selected

### DIFF
--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -454,7 +454,6 @@ void MapEditorController::setEditingInProgress(bool value)
 		select_all_act->setEnabled(!editing_in_progress);
 		select_nothing_act->setEnabled(!editing_in_progress);
 		invert_selection_act->setEnabled(!editing_in_progress);
-		select_by_current_symbol_act->setEnabled(!editing_in_progress);
 		find_feature->setEnabled(!editing_in_progress);
 		
 		// Map menu
@@ -2514,6 +2513,8 @@ void MapEditorController::updateSymbolDependentActions()
 {
 	const Symbol* symbol = activeSymbol();
 	const Symbol::Type type = (symbol && !editing_in_progress) ? symbol->getType() : Symbol::NoSymbol;
+	
+	select_by_current_symbol_act->setEnabled(!editing_in_progress && symbol_widget && symbol_widget->selectedSymbolsCount());
 	
 	updateDrawPointGPSAvailability();
 	draw_point_act->setEnabled(type == Symbol::Point && !symbol->isHidden());


### PR DESCRIPTION
The 'Select all objects with selected symbols' menu item below the 'Edit' menu was enabled even if no symbols were selected. The same menu item in the popup symbol menu of the symbol pane however was disabled if no symbols were selected.
Move the enabling or disabling of the menu item to a function which is called by a change of the selected symbols and disable the menu item if no symbols are selected.