### PR TITLE
CI: Migrate from PCCR@V1 to ReportGenerator

### DIFF
--- a/ci/publish-coverage.yml
+++ b/ci/publish-coverage.yml
@@ -46,9 +46,13 @@ steps:
       --print-summary
   displayName: 'Process test coverage results'
 
-- task: PublishCodeCoverageResults@1
+- task: UseDotNet@2
+  displayName: 'Use .NET Core sdk 7.0.x'
   inputs:
-    codeCoverageTool: 'Cobertura'
+    version: 7.0.x
+
+- task: PublishCodeCoverageResults@2
+  inputs:
     summaryFileLocation: '$(Build.SourcesDirectory)/coverage/coverage.xml'
   displayName: 'Publish test coverage results'
 

--- a/ci/publish-coverage.yml
+++ b/ci/publish-coverage.yml
@@ -52,4 +52,5 @@ steps:
     reports: '$(Build.SourcesDirectory)/coverage/coverage.xml'
     targetdir: '$(Build.SourcesDirectory)/coverage'
     publishCodeCoverageResults: true
+  displayName: 'Publish test coverage results'
 

--- a/ci/publish-coverage.yml
+++ b/ci/publish-coverage.yml
@@ -46,11 +46,6 @@ steps:
       --print-summary
   displayName: 'Process test coverage results'
 
-- task: UseDotNet@2
-  displayName: 'Use .NET Core sdk 7.0.x'
-  inputs:
-    version: 7.0.x
-
 - task: reportgenerator@5
   displayName: 'ReportGenerator'
   inputs:

--- a/ci/publish-coverage.yml
+++ b/ci/publish-coverage.yml
@@ -47,7 +47,6 @@ steps:
   displayName: 'Process test coverage results'
 
 - task: reportgenerator@5
-  displayName: 'ReportGenerator'
   inputs:
     reports: '$(Build.SourcesDirectory)/coverage/coverage.xml'
     targetdir: '$(Build.SourcesDirectory)/coverage'

--- a/ci/publish-coverage.yml
+++ b/ci/publish-coverage.yml
@@ -51,8 +51,10 @@ steps:
   inputs:
     version: 7.0.x
 
-- task: PublishCodeCoverageResults@2
+- task: reportgenerator@5
+  displayName: 'ReportGenerator'
   inputs:
-    summaryFileLocation: '$(Build.SourcesDirectory)/coverage/coverage.xml'
-  displayName: 'Publish test coverage results'
+    reports: '$(Build.SourcesDirectory)/coverage/coverage.xml'
+    targetdir: '$(Build.SourcesDirectory)/coverage'
+    publishCodeCoverageResults: true
 


### PR DESCRIPTION
Although the current V1 version of the publish code coverage results task is still available it's recommended to stop using the V1 version and migrate to V2 version.