### PR TITLE
Fix include guards

### DIFF
--- a/src/fileformats/file_import_export.h
+++ b/src/fileformats/file_import_export.h
@@ -18,8 +18,8 @@
  *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef OPENORIENTEERING_IMPORT_EXPORT_H
-#define OPENORIENTEERING_IMPORT_EXPORT_H
+#ifndef OPENORIENTEERING_FILE_IMPORT_EXPORT_H
+#define OPENORIENTEERING_FILE_IMPORT_EXPORT_H
 
 #include <vector>
 
@@ -334,4 +334,4 @@ protected:
 
 }  // namespace OpenOrienteering
 
-#endif // OPENORIENTEERING_IMPORT_EXPORT_H
+#endif // OPENORIENTEERING_FILE_IMPORT_EXPORT_H

--- a/src/fileformats/iof_course_export.h
+++ b/src/fileformats/iof_course_export.h
@@ -78,4 +78,4 @@ private:
 
 }  // namespace OpenOrienteering
 
-#endif // OPENORIENTEERING_KML_COURSE_EXPORT_H
+#endif // OPENORIENTEERING_IOF_COURSE_EXPORT_H

--- a/src/fileformats/kml_course_export.h
+++ b/src/fileformats/kml_course_export.h
@@ -17,8 +17,8 @@
  *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef OPENORIENTEERING_KML_EXPORT_EXPORT_H
-#define OPENORIENTEERING_KML_EXPORT_EXPORT_H
+#ifndef OPENORIENTEERING_KML_COURSE_EXPORT_H
+#define OPENORIENTEERING_KML_COURSE_EXPORT_H
 
 #include <vector>
 
@@ -74,4 +74,4 @@ private:
 
 }  // namespace OpenOrienteering
 
-#endif // OPENORIENTEERING_KML_EXPORT_EXPORT_H
+#endif // OPENORIENTEERING_KML_COURSE_EXPORT_H

--- a/src/fileformats/ocd_file_export.h
+++ b/src/fileformats/ocd_file_export.h
@@ -351,4 +351,4 @@ private:
 
 }  // namespace OpenOrienteering
 
-#endif
+#endif // OPENORIENTEERING_OCD_FILE_EXPORT_H

--- a/src/fileformats/ocd_file_format.h
+++ b/src/fileformats/ocd_file_format.h
@@ -17,8 +17,8 @@
  *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef OPENORIENTEERING_OCD_FILE_FORMAT
-#define OPENORIENTEERING_OCD_FILE_FORMAT
+#ifndef OPENORIENTEERING_OCD_FILE_FORMAT_H
+#define OPENORIENTEERING_OCD_FILE_FORMAT_H
 
 #include <memory>
 #include <vector>
@@ -95,4 +95,4 @@ private:
 
 }  // namespace OpenOrienteering
 
-#endif // OPENORIENTEERING_OCD_FILE_FORMAT
+#endif // OPENORIENTEERING_OCD_FILE_FORMAT_H

--- a/src/fileformats/ocd_file_import.h
+++ b/src/fileformats/ocd_file_import.h
@@ -20,8 +20,8 @@
  *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef OPENORIENTEERING_OCD_FILE_IMPORT
-#define OPENORIENTEERING_OCD_FILE_IMPORT
+#ifndef OPENORIENTEERING_OCD_FILE_IMPORT_H
+#define OPENORIENTEERING_OCD_FILE_IMPORT_H
 
 #include <cstddef>
 #include <initializer_list>
@@ -365,4 +365,4 @@ protected:
 
 }  // namespace OpenOrienteering
 
-#endif // OPENORIENTEERING_OCD_FILE_IMPORT
+#endif // OPENORIENTEERING_OCD_FILE_IMPORT_H

--- a/src/fileformats/ocd_icon.h
+++ b/src/fileformats/ocd_icon.h
@@ -73,4 +73,4 @@ struct OcdIcon
 
 }  // namespace OpenOrienteering
 
-#endif
+#endif // OPENORIENTEERING_OCD_ICON_H


### PR DESCRIPTION
Fix some include guards in fileformats folder.
I noticed that the comment after the final #endif is mostly missing so I'm not going to further fix it.