### PR TITLE
CI: Migrate to DownloadPipelineArtifact@2 task

### DIFF
--- a/ci/setup-common.yml
+++ b/ci/setup-common.yml
@@ -64,7 +64,8 @@ steps:
     buildVersionToDownload: 'specific'
     pipelineId: 2865
 #    pipelineId: $(openorienteering.superbuild.buildId)
-    definition: 1
+    definition: $(openorienteering.superbuild.definitionId)
+#    definition: 1
     artifactName: 'superbuild-$(SUPBERBUILD_IMAGE_NAME)$(OUTPUT_SUFFIX)'
     targetPath: $(SUPERBUILD_INSTALL_DIR)
   displayName: 'Download superbuild artifacts'

--- a/ci/setup-common.yml
+++ b/ci/setup-common.yml
@@ -1,6 +1,6 @@
 # This file is part of OpenOrienteering.
 
-# Copyright 2019-2021 Kai Pastor
+# Copyright 2019-2021, 2024 Kai Pastor
 #
 # Redistribution and use is allowed according to the terms of the BSD license:
 #
@@ -57,9 +57,13 @@ steps:
     env | sort
   displayName: 'Update environment'
 
-- task: DownloadPipelineArtifact@0
+- task: DownloadPipelineArtifact@2
   inputs:
-    pipelineId: $(openorienteering.superbuild.buildId)
+    buildType: 'specific'
+    project: $(System.TeamProjectId)
+    buildVersionToDownload: 'latest'
+#    pipelineId: $(openorienteering.superbuild.buildId)
+    definition: 1
     artifactName: 'superbuild-$(SUPBERBUILD_IMAGE_NAME)$(OUTPUT_SUFFIX)'
     targetPath: $(SUPERBUILD_INSTALL_DIR)
   displayName: 'Download superbuild artifacts'

--- a/ci/setup-common.yml
+++ b/ci/setup-common.yml
@@ -61,7 +61,8 @@ steps:
   inputs:
     buildType: 'specific'
     project: $(System.TeamProjectId)
-    buildVersionToDownload: 'latest'
+    buildVersionToDownload: 'specific'
+    pipelineId: 2865
 #    pipelineId: $(openorienteering.superbuild.buildId)
     definition: 1
     artifactName: 'superbuild-$(SUPBERBUILD_IMAGE_NAME)$(OUTPUT_SUFFIX)'


### PR DESCRIPTION
React to warning that the DownloadPipelineArtifact@0 task is deprecated and that the latest version of the DownloadPipelineArtifact task shall be used instead.