### PR TITLE
MapEditorController: Delete object in destructor

### DIFF
--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -336,6 +336,7 @@ MapEditorController::~MapEditorController()
 	delete gps_display;
 	delete gps_track_recorder;
 	delete compass_display;
+	delete gps_marker_display;
 	delete map;
 }
 


### PR DESCRIPTION
The pointer variables `gps_display`, `gps_track_recorder`, `compass_display` and `gps_marker_display` are all zero-initialized in the constructor. In `MapEditorController::detach()` all of their associated objects are deleted and the variables are set to nullptr. In the destructor however the `gps_marker_display` object was not deleted whereas the other three objects were.