### PR TITLE
Use function Symbol::getNumberAndPlainTextName()

### DIFF
--- a/src/core/symbols/html_symbol_report.cpp
+++ b/src/core/symbols/html_symbol_report.cpp
@@ -198,9 +198,7 @@ private:
 	
 	QString makeSymbolRow(const Symbol& s)
 	{
-		auto label = QString { s.getNumberAsString()
-		                       + QChar::Space
-		                       + QTextDocumentFragment::fromHtml(s.getName()).toPlainText() };
+		auto label = s.getNumberAndPlainTextName();
 		auto extra_text = QString{};
 		if (s.isRotatable())
 			extra_text += QCoreApplication::translate("OpenOrienteering::SymbolReport", "[X] %1")

--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -2458,7 +2458,7 @@ void MapEditorController::selectedSymbolsChanged()
 			symbol_button->setMenu(mobile_symbol_button_menu);
 			const auto actions = mobile_symbol_button_menu->actions();
 			int i = 0;
-			actions[i]->setText(symbol->getNumberAsString() + QLatin1Char(' ') + symbol->getPlainTextName());
+			actions[i]->setText(symbol->getNumberAndPlainTextName());
 			actions[++i]->setVisible(!symbol->getDescription().isEmpty());
 			++i;  // separator
 			actions[++i]->setChecked(symbol->isHidden());
@@ -2483,7 +2483,7 @@ void MapEditorController::selectedSymbolsChanged()
 		}
 		
 		if (symbol)
-			window->showStatusBarMessage(symbol->getNumberAsString() + QLatin1Char(' ') + symbol->getPlainTextName(), 1000);
+			window->showStatusBarMessage(symbol->getNumberAndPlainTextName(), 1000);
 	}
 	
 	// Even when the symbol (pointer) hasn't changed,
@@ -2657,7 +2657,7 @@ void MapEditorController::updateObjectDependentActions()
 	bool const boolean_prerequisite = first_selected_is_path && num_selected_paths >= 2;
 	QString const extra_status_tip = QLatin1Char(' ') +
 	                                 ( boolean_prerequisite
-	                                 ? tr("Resulting symbol: %1 %2.").arg(first_selected_symbol->getNumberAsString(), first_selected_symbol->getPlainTextName())
+	                                 ? tr("Resulting symbol: %1.").arg(first_selected_symbol->getNumberAndPlainTextName())
 	                                 : tr("Select at least two area or path objects activate this tool.") );
 	boolean_union_act->setEnabled(boolean_prerequisite);
 	boolean_union_act->setStatusTip(tr("Unify overlapping objects.") + extra_status_tip);

--- a/src/gui/widgets/color_list_widget.cpp
+++ b/src/gui/widgets/color_list_widget.cpp
@@ -237,7 +237,7 @@ bool ColorListWidget::confirmColorDeletion(const MapColor* color_to_be_removed) 
 				if (symbol->getType() == Symbol::NoSymbol)
 					return;
 				if (symbol->containsColor(color_to_be_removed))
-					direct_usage += symbol->getNumberAsString() + QChar::Space + symbol->getPlainTextName() + QChar::LineFeed;
+					direct_usage += symbol->getNumberAndPlainTextName() + QChar::LineFeed;
 				else
 					remaining_symbols.push_back(symbol);
 			}
@@ -277,7 +277,7 @@ bool ColorListWidget::confirmColorDeletion(const MapColor* color_to_be_removed) 
 				{
 					if (symbol->containsColor(color))
 					{
-						transitive_usage += symbol->getNumberAsString() + QChar::Space + symbol->getPlainTextName() + QChar::LineFeed;
+						transitive_usage += symbol->getNumberAndPlainTextName() + QChar::LineFeed;
 						break;
 					}
 				}

--- a/test/file_format_t.cpp
+++ b/test/file_format_t.cpp
@@ -164,8 +164,8 @@ namespace
 		auto const fill_a = QString().fill(QChar::Space, +diff); \
 		auto const fill_b = QString().fill(QChar::Space, -diff); \
 		QFAIL(QString::fromLatin1( \
-		       "Compared values are not the same (%1 %2)\n   Actual   (%3)%4: %7\n   Expected (%5)%6: %8") \
-		      .arg((symbol).getNumberAsString(), (symbol).getPlainTextName(), \
+		       "Compared values are not the same (%1)\n   Actual   (%2)%3: %6\n   Expected (%4)%5: %7") \
+		      .arg((symbol).getNumberAndPlainTextName(), \
 		           QString::fromUtf8(#a), fill_a, \
 		           QString::fromUtf8(#b), fill_b) \
 		      .arg(a).arg(b) \
@@ -185,8 +185,7 @@ namespace
 	#define VERIFY_SYMBOL_PROPERTY(cond, symbol) \
 	if (cond) \
 	{ \
-		QVERIFY2(cond, QByteArray((symbol).getNumberAsString().toUtf8() + ' ' \
-		                          + (symbol).getPlainTextName().toUtf8())); \
+		QVERIFY2(cond, QByteArray((symbol).getNumberAndPlainTextName().toUtf8())); \
 	} \
 	else \
 	{ \
@@ -411,7 +410,7 @@ namespace
 		if (actual)
 			fuzzyCompareSymbol(*actual, *expected, format_id);
 		else
-			QFAIL(qPrintable(QString::fromLatin1("Missing symbol: %1 %2").arg(expected->getNumberAsString(), expected->getPlainTextName())));
+			QFAIL(qPrintable(QString::fromLatin1("Missing symbol: %1").arg(expected->getNumberAndPlainTextName())));
 	}
 	
 	/**


### PR DESCRIPTION
Use function Symbol::getNumberAndPlainTextName() which was introduced by GH-2125 instead of concatenating symbol number and symbol name.