### PR TITLE
TextSymbolSettings: Fix initial state of standard buttons

### DIFF
--- a/src/gui/symbols/text_symbol_settings.cpp
+++ b/src/gui/symbols/text_symbol_settings.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2019, 2024 Kai Pastor
+ *    Copyright 2012-2019, 2024, 2025 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -21,7 +21,7 @@
 
 #include "text_symbol_settings.h"
 
-#include <algorithm>
+// IWYU pragma: no_include <algorithm>
 #include <vector>
 
 #include <QAbstractButton>
@@ -39,13 +39,15 @@
 #include <QLatin1Char>
 #include <QLineEdit>
 #include <QListWidget>
+#include <QListWidgetItem>
 #include <QLocale>
 #include <QPainterPath>
 #include <QPushButton>
 #include <QRadioButton>
 #include <QRectF>
 #include <QSignalBlocker>
-// IWYU pragma: no_include <QTabWidget>
+// IWYU pragma: no_include <QSpacerItem>
+#include <QTabWidget>  // IWYU pragma: keep
 #include <QVBoxLayout>
 #include <QWidget>
 

--- a/src/gui/symbols/text_symbol_settings.cpp
+++ b/src/gui/symbols/text_symbol_settings.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2019 Kai Pastor
+ *    Copyright 2012-2019, 2024 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -39,14 +39,13 @@
 #include <QLatin1Char>
 #include <QLineEdit>
 #include <QListWidget>
-#include <QListWidgetItem>
 #include <QLocale>
 #include <QPainterPath>
 #include <QPushButton>
 #include <QRadioButton>
 #include <QRectF>
 #include <QSignalBlocker>
-#include <QSpacerItem>
+// IWYU pragma: no_include <QTabWidget>
 #include <QVBoxLayout>
 #include <QWidget>
 
@@ -84,9 +83,9 @@ SymbolPropertiesWidget* TextSymbol::createPropertiesWidget(SymbolSettingDialog* 
 // ### TextSymbolSettings ###
 
 TextSymbolSettings::TextSymbolSettings(TextSymbol* symbol, SymbolSettingDialog* dialog)
-: SymbolPropertiesWidget(symbol, dialog), 
-  symbol(symbol), 
-  dialog(dialog)
+: SymbolPropertiesWidget(symbol, dialog)
+, symbol(symbol)
+, dialog(dialog)
 {
 	auto map = dialog->getPreviewMap();
 	react_to_changes = true;
@@ -543,10 +542,10 @@ void TextSymbolSettings::updateGeneralContents()
 	kerning_check->setChecked(symbol->kerning);
 	icon_text_edit->setText(symbol->getIconText());
 	framing_check->setChecked(symbol->framing);
+	setTabEnabled(indexOf(framing_widget), symbol->framing);
 	ocad_compat_check->setChecked(symbol->line_below || symbol->getNumCustomTabs() > 0);
 	react_to_changes = true;
 	
-	framingCheckClicked(framing_check->isChecked());
 	ocadCompatibilityButtonClicked(ocad_compat_check->isChecked());
 }
 


### PR DESCRIPTION
When entering the text symbol settings dialog the 'OK' and 'Reset' buttons where initially enabled.
Don't misuse the `framingCheckClicked()` function to enable/disable the `framing_widget` tab in `updateGeneralContents()` as `framingCheckClicked()` will signal modified properties.