### PR TITLE
Consider minimum area and length in combined symbols

### DIFF
--- a/code-check-wrapper.sh
+++ b/code-check-wrapper.sh
@@ -77,6 +77,7 @@ for I in \
   map_printer \
   map_widget.cpp \
   mapper_proxystyle.cpp \
+  measure_widget.cpp \
   /object.cpp \
   object_mover.cpp \
   object_query.cpp \

--- a/src/core/symbols/area_symbol.h
+++ b/src/core/symbols/area_symbol.h
@@ -277,7 +277,7 @@ public:
 	// Getters / Setters
 	inline const MapColor* getColor() const {return color;}
 	inline void setColor(const MapColor* color) {this->color = color;}
-	inline int getMinimumArea() const {return minimum_area; }
+	inline int getMinimumArea() const override {return minimum_area; }
 	inline int getNumFillPatterns() const {return int(patterns.size());}
 	inline void setNumFillPatterns(int count) {patterns.resize(std::size_t(count));}
 	inline FillPattern& getFillPattern(int i) {return patterns[std::size_t(i)];}

--- a/src/core/symbols/area_symbol.h
+++ b/src/core/symbols/area_symbol.h
@@ -278,6 +278,7 @@ public:
 	inline const MapColor* getColor() const {return color;}
 	inline void setColor(const MapColor* color) {this->color = color;}
 	inline int getMinimumArea() const override {return minimum_area; }
+	void setMinimumArea(int area) { this->minimum_area = area; }
 	inline int getNumFillPatterns() const {return int(patterns.size());}
 	inline void setNumFillPatterns(int count) {patterns.resize(std::size_t(count));}
 	inline FillPattern& getFillPattern(int i) {return patterns[std::size_t(i)];}

--- a/src/core/symbols/combined_symbol.cpp
+++ b/src/core/symbols/combined_symbol.cpp
@@ -426,4 +426,17 @@ bool CombinedSymbol::containsDashSymbol() const
 }
 
 
+// override
+int CombinedSymbol::getMinimumArea() const
+{
+	auto minimum_area = std::numeric_limits<int>::max();
+	for (auto const* part : parts)
+	{
+		if (part)
+			minimum_area = qMin(minimum_area, part->getMinimumArea());
+	}
+	return minimum_area;
+}
+
+
 }  // namespace OpenOrienteering

--- a/src/core/symbols/combined_symbol.cpp
+++ b/src/core/symbols/combined_symbol.cpp
@@ -439,4 +439,17 @@ int CombinedSymbol::getMinimumArea() const
 }
 
 
+// override
+int CombinedSymbol::getMinimumLength() const
+{
+	auto minimum_length = std::numeric_limits<int>::max();
+	for (auto const* part : parts)
+	{
+		if (part)
+			minimum_length = qMin(minimum_length, part->getMinimumLength());
+	}
+	return minimum_length;
+}
+
+
 }  // namespace OpenOrienteering

--- a/src/core/symbols/combined_symbol.cpp
+++ b/src/core/symbols/combined_symbol.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2020, 2024 Kai Pastor
+ *    Copyright 2012-2020, 2024, 2025 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -429,26 +429,18 @@ bool CombinedSymbol::containsDashSymbol() const
 // override
 int CombinedSymbol::getMinimumArea() const
 {
-	auto minimum_area = std::numeric_limits<int>::max();
-	for (auto const* part : parts)
-	{
-		if (part)
-			minimum_area = qMin(minimum_area, part->getMinimumArea());
-	}
-	return minimum_area;
+	return std::accumulate(parts.begin(), parts.end(), 0, [](int acc, auto part) {
+		return part ? qMax(acc, part->getMinimumArea()) : acc;
+	});
 }
 
 
 // override
 int CombinedSymbol::getMinimumLength() const
 {
-	auto minimum_length = std::numeric_limits<int>::max();
-	for (auto const* part : parts)
-	{
-		if (part)
-			minimum_length = qMin(minimum_length, part->getMinimumLength());
-	}
-	return minimum_length;
+	return std::accumulate(parts.begin(), parts.end(), 0, [](int acc, auto part) {
+		return part ? qMax(acc, part->getMinimumLength()) : acc;
+	});
 }
 
 

--- a/src/core/symbols/combined_symbol.h
+++ b/src/core/symbols/combined_symbol.h
@@ -120,6 +120,8 @@ public:
 	
 	int getMinimumArea() const override;
 	
+	int getMinimumLength() const override;
+	
 protected:
 	void saveImpl(QXmlStreamWriter& xml, const Map& map) const override;
 	bool loadImpl(QXmlStreamReader& xml, const Map& map, SymbolDictionary& symbol_dict, int version) override;

--- a/src/core/symbols/combined_symbol.h
+++ b/src/core/symbols/combined_symbol.h
@@ -118,6 +118,8 @@ public:
 	
 	bool containsDashSymbol() const override;
 	
+	int getMinimumArea() const override;
+	
 protected:
 	void saveImpl(QXmlStreamWriter& xml, const Map& map) const override;
 	bool loadImpl(QXmlStreamReader& xml, const Map& map, SymbolDictionary& symbol_dict, int version) override;

--- a/src/core/symbols/line_symbol.h
+++ b/src/core/symbols/line_symbol.h
@@ -216,7 +216,7 @@ public:
 	inline void setLineWidth(double width) {line_width = qRound(1000 * width);}
 	inline const MapColor* getColor() const {return color;}
 	inline void setColor(const MapColor* color) {this->color = color;}
-	inline int getMinimumLength() const {return minimum_length;}
+	inline int getMinimumLength() const override {return minimum_length;}
 	inline void setMinimumLength(int length) {this->minimum_length = length;}
 	inline CapStyle getCapStyle() const {return cap_style;}
 	inline void setCapStyle(CapStyle style) {cap_style = style;}

--- a/src/core/symbols/symbol.cpp
+++ b/src/core/symbols/symbol.cpp
@@ -25,7 +25,6 @@
 #include <cmath>
 #include <cstddef>
 #include <iterator>
-#include <limits>
 #include <memory>
 
 #include <QtGlobal>
@@ -998,14 +997,14 @@ bool Symbol::containsDashSymbol() const
 // virtual function, derived classes AreaSymbol and CombinedSymbol override default behaviour below.
 int Symbol::getMinimumArea() const
 {
-	return std::numeric_limits<int>::max();
+	return 0;
 }
 
 
 // virtual function, derived classes LineSymbol and CombinedSymbol override default behaviour below.
 int Symbol::getMinimumLength() const
 {
-	return std::numeric_limits<int>::max();
+	return 0;
 }
 
 

--- a/src/core/symbols/symbol.cpp
+++ b/src/core/symbols/symbol.cpp
@@ -1002,4 +1002,11 @@ int Symbol::getMinimumArea() const
 }
 
 
+// virtual function, derived classes LineSymbol and CombinedSymbol override default behaviour below.
+int Symbol::getMinimumLength() const
+{
+	return std::numeric_limits<int>::max();
+}
+
+
 }  // namespace OpenOrienteering

--- a/src/core/symbols/symbol.cpp
+++ b/src/core/symbols/symbol.cpp
@@ -25,6 +25,7 @@
 #include <cmath>
 #include <cstddef>
 #include <iterator>
+#include <limits>
 #include <memory>
 
 #include <QtGlobal>
@@ -991,6 +992,13 @@ bool Symbol::lessByColor::operator() (const Symbol* s1, const Symbol* s2) const
 bool Symbol::containsDashSymbol() const
 {
 	return false;
+}
+
+
+// virtual function, derived classes AreaSymbol and CombinedSymbol override default behaviour below.
+int Symbol::getMinimumArea() const
+{
+	return std::numeric_limits<int>::max();
 }
 
 

--- a/src/core/symbols/symbol.h
+++ b/src/core/symbols/symbol.h
@@ -511,12 +511,12 @@ public:
 	virtual bool containsDashSymbol() const;
 	
 	/**
-	 * Returns the specified minimum area of this symbol otherwise the maximum int value.
+	 * Returns the specified minimum area of this symbol otherwise 0.
 	 */
 	virtual int getMinimumArea() const;
 	
 	/**
-	 * Returns the specified minimum length of this symbol otherwise the maximum int value.
+	 * Returns the specified minimum length of this symbol otherwise 0.
 	 */
 	virtual int getMinimumLength() const;
 	

--- a/src/core/symbols/symbol.h
+++ b/src/core/symbols/symbol.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2020, 2024 Kai Pastor
+ *    Copyright 2012-2020, 2024, 2025 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -511,12 +511,20 @@ public:
 	virtual bool containsDashSymbol() const;
 	
 	/**
-	 * Returns the specified minimum area of this symbol otherwise 0.
+	 * Returns the specified minimum area of this symbol.
+	 * 
+	 * This function shall be overriden by symbol types with area personality.
+	 * The default implementation returns zero, representing the absence of
+	 * a minimum required area.
 	 */
 	virtual int getMinimumArea() const;
 	
 	/**
-	 * Returns the specified minimum length of this symbol otherwise 0.
+	 * Returns the specified minimum length of this symbol.
+	 * 
+	 * This function shall be overriden by symbol types with line personality.
+	 * The default implementation returns zero, representing the absence of
+	 * a minimum required length.
 	 */
 	virtual int getMinimumLength() const;
 	

--- a/src/core/symbols/symbol.h
+++ b/src/core/symbols/symbol.h
@@ -515,6 +515,11 @@ public:
 	 */
 	virtual int getMinimumArea() const;
 	
+	/**
+	 * Returns the specified minimum length of this symbol otherwise the maximum int value.
+	 */
+	virtual int getMinimumLength() const;
+	
 protected:
 	/**
 	 * Sets the rotatability state of the symbol.

--- a/src/core/symbols/symbol.h
+++ b/src/core/symbols/symbol.h
@@ -510,6 +510,11 @@ public:
 	 */
 	virtual bool containsDashSymbol() const;
 	
+	/**
+	 * Returns the specified minimum area of this symbol otherwise the maximum int value.
+	 */
+	virtual int getMinimumArea() const;
+	
 protected:
 	/**
 	 * Sets the rotatability state of the symbol.

--- a/src/gui/widgets/measure_widget.cpp
+++ b/src/gui/widgets/measure_widget.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2018, 2024 Kai Pastor
+ *    Copyright 2012-2018, 2024, 2025 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -20,8 +20,6 @@
 
 
 #include "measure_widget.h"
-
-#include <limits>
 
 #include <QBuffer>
 #include <QIcon>

--- a/src/gui/widgets/measure_widget.cpp
+++ b/src/gui/widgets/measure_widget.cpp
@@ -132,8 +132,7 @@ void MeasureWidget::objectSelectionChanged()
 				                          paper_area_text, tr("mm²", "square millimeters"),
 				                          real_area_text , tr("m²", "square meters")));
 				
-				auto minimum_area_int = symbol->getMinimumArea();
-				auto minimum_area = 0.001 * (minimum_area_int == std::numeric_limits<int>::max() ? 0 : minimum_area_int);
+				auto minimum_area = 0.001 * symbol->getMinimumArea();
 				auto minimum_area_text = locale().toString(minimum_area, 'f', 2);
 				
 				if (paper_area < minimum_area && paper_area_text != minimum_area_text)
@@ -151,8 +150,7 @@ void MeasureWidget::objectSelectionChanged()
 				                          paper_length_text, tr("mm", "millimeters"),
 				                          real_length_text, tr("m", "meters")));
 				
-				auto minimum_length_int = symbol->getMinimumLength();
-				auto minimum_length = 0.001 * (minimum_length_int == std::numeric_limits<int>::max() ? 0 : minimum_length_int);
+				auto minimum_length = 0.001 * symbol->getMinimumLength();
 				auto minimum_length_text = locale().toString(minimum_length, 'f', 2);
 				
 				if (paper_length < minimum_length && paper_length_text != minimum_length_text)

--- a/src/gui/widgets/measure_widget.cpp
+++ b/src/gui/widgets/measure_widget.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2015, 2024 Kai Pastor
+ *    Copyright 2012-2018, 2024 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -21,16 +21,22 @@
 
 #include "measure_widget.h"
 
+#include <limits>
+
 #include <QBuffer>
+#include <QIcon>
+#include <QIODevice>
+#include <QLatin1String>
 #include <QLocale>
+#include <QPixmap>
 #include <QScroller>
+#include <QSize>
 #include <QStyle>
 
 #include "core/map.h"
 #include "core/objects/object.h"
-#include "core/symbols/symbol.h"
-#include "core/symbols/area_symbol.h"
 #include "core/symbols/line_symbol.h"
+#include "core/symbols/symbol.h"
 
 
 namespace OpenOrienteering {
@@ -78,8 +84,8 @@ void MeasureWidget::objectSelectionChanged()
 	}
 	else
 	{
-		const Object* object = *begin(selected_objects);
-		const Symbol* symbol = object->getSymbol();
+		const auto* object = *begin(selected_objects);
+		const auto* symbol = object->getSymbol();
 		headline = symbol->getNumberAsString() + QLatin1Char(' ') + symbol->getName();
 		
 		if (object->getType() != Object::Path)
@@ -127,13 +133,9 @@ void MeasureWidget::objectSelectionChanged()
 				                          paper_area_text, tr("mm²", "square millimeters"),
 				                          real_area_text , tr("m²", "square meters")));
 				
-				auto minimum_area = 0.0;
-				auto minimum_area_text = QString{ };
-				if (symbol->getType() == Symbol::Area)
-				{
-					minimum_area      = 0.001 * static_cast<const AreaSymbol*>(symbol)->getMinimumArea();
-					minimum_area_text = locale().toString(minimum_area, 'f', 2);
-				}
+				auto minimum_area_int = symbol->getMinimumArea();
+				auto minimum_area = 0.001 * (minimum_area_int == std::numeric_limits<int>::max() ? 0 : minimum_area_int);
+				auto minimum_area_text = locale().toString(minimum_area, 'f', 2);
 				
 				if (paper_area < minimum_area && paper_area_text != minimum_area_text)
 				{

--- a/src/gui/widgets/measure_widget.cpp
+++ b/src/gui/widgets/measure_widget.cpp
@@ -21,15 +21,24 @@
 
 #include "measure_widget.h"
 
+#include <iterator>
+#include <set>
+// IWYU pragma: no_include <memory>
+
+#include <QtGlobal>
 #include <QBuffer>
-#include <QIcon>
+#include <QByteArray>
+#include <QFlags>
 #include <QIODevice>
+#include <QIcon>
+#include <QLatin1Char>
 #include <QLatin1String>
 #include <QLocale>
 #include <QPixmap>
 #include <QScroller>
 #include <QSize>
 #include <QStyle>
+#include <QWidget>
 
 #include "core/map.h"
 #include "core/objects/object.h"

--- a/src/gui/widgets/measure_widget.cpp
+++ b/src/gui/widgets/measure_widget.cpp
@@ -35,7 +35,6 @@
 
 #include "core/map.h"
 #include "core/objects/object.h"
-#include "core/symbols/line_symbol.h"
 #include "core/symbols/symbol.h"
 
 
@@ -152,13 +151,9 @@ void MeasureWidget::objectSelectionChanged()
 				                          paper_length_text, tr("mm", "millimeters"),
 				                          real_length_text, tr("m", "meters")));
 				
-				auto minimum_length  = 0.0;
-				auto minimum_length_text = QString{ };
-				if (symbol->getType() == Symbol::Line)
-				{
-					minimum_length      = 0.001 * static_cast<const LineSymbol*>(symbol)->getMinimumLength();
-					minimum_length_text = locale().toString(minimum_length, 'f', 2);
-				}
+				auto minimum_length_int = symbol->getMinimumLength();
+				auto minimum_length = 0.001 * (minimum_length_int == std::numeric_limits<int>::max() ? 0 : minimum_length_int);
+				auto minimum_length_text = locale().toString(minimum_length, 'f', 2);
 				
 				if (paper_length < minimum_length && paper_length_text != minimum_length_text)
 				{

--- a/test/symbol_t.cpp
+++ b/test/symbol_t.cpp
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2018-2020, 2022, 2024 Kai Pastor
+ *    Copyright 2018-2020, 2022, 2024, 2025 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -390,6 +390,10 @@ private slots:
 		CombinedSymbol c;
 		c.setNumParts(10);
 		
+		Symbol& s = c;
+		QCOMPARE(s.getMinimumLength(), 0);
+		QCOMPARE(s.getMinimumArea(), 0);
+		
 		auto make_line_symbol = [](int len) {
 			auto* l = new LineSymbol();
 			l->setMinimumLength(len);
@@ -408,7 +412,6 @@ private slots:
 		c.setPart(6, make_area_symbol(30), true);
 		c.setPart(7, make_area_symbol(29), true);
 		
-		Symbol& s = c;
 		QCOMPARE(s.getMinimumLength(), 20);
 		QCOMPARE(s.getMinimumArea(), 30);
 	}

--- a/test/symbol_t.cpp
+++ b/test/symbol_t.cpp
@@ -44,6 +44,8 @@
 #include "core/map.h"
 #include "core/map_color.h"
 #include "core/renderables/renderable.h"
+#include "core/symbols/area_symbol.h"
+#include "core/symbols/combined_symbol.h"
 #include "core/symbols/line_symbol.h"
 #include "core/symbols/point_symbol.h"
 #include "core/symbols/symbol.h"
@@ -383,6 +385,33 @@ private slots:
 		QVERIFY(clone->equals(&l));
 	}
 	
+	void CombinedSymbolTest()
+	{
+		CombinedSymbol c;
+		c.setNumParts(10);
+		
+		auto make_line_symbol = [](int len) {
+			auto* l = new LineSymbol();
+			l->setMinimumLength(len);
+			return l;
+		};
+		c.setPart(1, make_line_symbol(18), true);
+		c.setPart(2, make_line_symbol(20), true);
+		c.setPart(3, make_line_symbol(19), true);
+		
+		auto make_area_symbol = [](int area) {
+			auto* a = new AreaSymbol();
+			a->setMinimumArea(area);
+			return a;
+		};
+		c.setPart(5, make_area_symbol(28), true);
+		c.setPart(6, make_area_symbol(30), true);
+		c.setPart(7, make_area_symbol(29), true);
+		
+		Symbol& s = c;
+		QCOMPARE(s.getMinimumLength(), 20);
+		QCOMPARE(s.getMinimumArea(), 30);
+	}
 	
 	void lessByColorTest_data()
 	{


### PR DESCRIPTION
Combined symbols may contain areas with a minimum size, either in area symbols or private sub-symbols.
Combined symbols may contain lines with a minimum size, either in line symbols or private sub-symbols.
This is an alternative implementation of GH-2084.

Closes GH-2083.
