### PR TITLE
MapView: Restore map visibility after loading

### DIFF
--- a/src/core/map_view.cpp
+++ b/src/core/map_view.cpp
@@ -34,6 +34,7 @@
 
 #include "core/map.h"
 #include "core/map_coord.h"
+#include "fileformats/xml_file_format.h"
 #include "gui/util_gui.h"
 #include "templates/template.h" // IWYU pragma: keep
 #include "util/util.h"
@@ -43,7 +44,7 @@
 namespace literal
 {
 	static const QLatin1String zoom("zoom");
-	static const QLatin1String rotation("rotation");
+	//static const QLatin1String rotation("rotation");
 	static const QLatin1String position_x("position_x");
 	static const QLatin1String position_y("position_y");
 	static const QLatin1String grid("grid");
@@ -174,7 +175,10 @@ void MapView::load(QXmlStreamReader& xml)
 		{
 			XmlElementReader map_element(xml);
 			map_visibility.opacity = map_element.attribute<qreal>(literal::opacity);
-			map_visibility.visible = map_element.attribute<bool>(literal::visible);
+			if (XMLFileFormat::active_version_read > 5)
+				map_visibility.visible = map_element.attribute<bool>(literal::visible);
+			else
+				map_visibility.visible = true;
 		}
 		else if (xml.name() == literal::templates)
 		{

--- a/src/core/map_view.cpp
+++ b/src/core/map_view.cpp
@@ -34,7 +34,6 @@
 
 #include "core/map.h"
 #include "core/map_coord.h"
-#include "fileformats/xml_file_format.h"
 #include "gui/util_gui.h"
 #include "templates/template.h" // IWYU pragma: keep
 #include "util/util.h"
@@ -44,7 +43,6 @@
 namespace literal
 {
 	static const QLatin1String zoom("zoom");
-	//static const QLatin1String rotation("rotation");
 	static const QLatin1String position_x("position_x");
 	static const QLatin1String position_y("position_y");
 	static const QLatin1String grid("grid");
@@ -146,7 +144,7 @@ void MapView::save(QXmlStreamWriter& xml, const QLatin1String& element_name, boo
 	}
 }
 
-void MapView::load(QXmlStreamReader& xml)
+void MapView::load(QXmlStreamReader& xml, int version)
 {
 	// We do not load transient attributes such as rotation (for compass) or pan offset.
 	XmlElementReader mapview_element(xml);
@@ -175,7 +173,8 @@ void MapView::load(QXmlStreamReader& xml)
 		{
 			XmlElementReader map_element(xml);
 			map_visibility.opacity = map_element.attribute<qreal>(literal::opacity);
-			if (XMLFileFormat::active_version_read > 5)
+			// Some old maps before version 6 lack visible="true".
+			if (version >= 6)
 				map_visibility.visible = map_element.attribute<bool>(literal::visible);
 			else
 				map_visibility.visible = true;

--- a/src/core/map_view.cpp
+++ b/src/core/map_view.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2014-2020 Kai Pastor
+ *    Copyright 2014-2020, 2025 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -25,8 +25,6 @@
 #include <cmath>
 #include <iterator>
 #include <stdexcept>
-
-#include <QRectF>
 
 #include <Qt>
 #include <QLatin1String>
@@ -176,10 +174,7 @@ void MapView::load(QXmlStreamReader& xml)
 		{
 			XmlElementReader map_element(xml);
 			map_visibility.opacity = map_element.attribute<qreal>(literal::opacity);
-			if (map_element.hasAttribute(literal::visible))
-				map_visibility.visible = map_element.attribute<bool>(literal::visible);
-			else
-				map_visibility.visible = true;
+			map_visibility.visible = map_element.attribute<bool>(literal::visible);
 		}
 		else if (xml.name() == literal::templates)
 		{

--- a/src/core/map_view.h
+++ b/src/core/map_view.h
@@ -127,7 +127,7 @@ public:
 	void save(QXmlStreamWriter& xml, const QLatin1String& element_name, bool template_details = true) const;
 	
 	/** Loads the map view state from the current element of an xml stream. */
-	void load(QXmlStreamReader& xml, int version = -1);
+	void load(QXmlStreamReader& xml, int version);
 	
 	/**
 	 * Redraws all map widgets completely.

--- a/src/core/map_view.h
+++ b/src/core/map_view.h
@@ -127,7 +127,7 @@ public:
 	void save(QXmlStreamWriter& xml, const QLatin1String& element_name, bool template_details = true) const;
 	
 	/** Loads the map view state from the current element of an xml stream. */
-	void load(QXmlStreamReader& xml);
+	void load(QXmlStreamReader& xml, int version = -1);
 	
 	/**
 	 * Redraws all map widgets completely.

--- a/src/fileformats/xml_file_format.cpp
+++ b/src/fileformats/xml_file_format.cpp
@@ -1,7 +1,7 @@
 /*
  *    Copyright 2012 Pete Curtis
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2020 Kai Pastor
+ *    Copyright 2012-2020, 2025 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -26,8 +26,8 @@
 #include <cstddef>
 #include <functional>
 #include <memory>
-#include <vector>
 #include <utility>
+#include <vector>
 
 #include <QtGlobal>
 #include <QByteArray>
@@ -74,7 +74,7 @@ constexpr int XMLFileFormat::current_version = 9;
 
 int XMLFileFormat::active_version = 5; // updated by XMLFileExporter::doExport()
 
-
+int XMLFileFormat::active_version_read = -1; // updated by XMLFileImporter::importImplementation()
 
 namespace {
 
@@ -556,6 +556,7 @@ bool XMLFileImporter::importImplementation()
 	
 	XmlElementReader map_element(xml);
 	version = map_element.attribute<int>(literal::version);
+	XMLFileFormat::active_version_read = version;
 	if (version < 1)
 		xml.raiseError(::OpenOrienteering::Importer::tr("Invalid file format version."));
 	else if (version < XMLFileFormat::minimum_version)

--- a/src/fileformats/xml_file_format.cpp
+++ b/src/fileformats/xml_file_format.cpp
@@ -74,7 +74,7 @@ constexpr int XMLFileFormat::current_version = 9;
 
 int XMLFileFormat::active_version = 5; // updated by XMLFileExporter::doExport()
 
-int XMLFileFormat::active_version_read = -1; // updated by XMLFileImporter::importImplementation()
+
 
 namespace {
 
@@ -556,7 +556,6 @@ bool XMLFileImporter::importImplementation()
 	
 	XmlElementReader map_element(xml);
 	version = map_element.attribute<int>(literal::version);
-	XMLFileFormat::active_version_read = version;
 	if (version < 1)
 		xml.raiseError(::OpenOrienteering::Importer::tr("Invalid file format version."));
 	else if (version < XMLFileFormat::minimum_version)
@@ -1051,7 +1050,7 @@ void XMLFileImporter::importView()
 		else if (xml.name() == literal::map_view)
 		{
 			if (view)
-				view->load(xml);
+				view->load(xml, version);
 			else
 				xml.skipCurrentElement();
 		}

--- a/src/fileformats/xml_file_format.h
+++ b/src/fileformats/xml_file_format.h
@@ -71,10 +71,6 @@ public:
 	 */
 	static int active_version;
 	
-	/** @brief The actual XML file format version read from the map file.
-	 */
-	static int active_version_read;
-	
 };
 
 

--- a/src/fileformats/xml_file_format.h
+++ b/src/fileformats/xml_file_format.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012-2014 Pete Curtis
- *    Copyright 2012-2019 Kai Pastor
+ *    Copyright 2012-2019, 2025 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -18,14 +18,12 @@
  *    along with OpenOrienteering.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef OPENORIENTEERING_FILE_FORMAT_XML_H
-#define OPENORIENTEERING_FILE_FORMAT_XML_H
-
-#include <memory>
-
-#include <QString>
+#ifndef OPENORIENTEERING_XML_FILE_FORMAT_H
+#define OPENORIENTEERING_XML_FILE_FORMAT_H
 
 #include "fileformats/file_format.h"
+
+class QString;
 
 namespace OpenOrienteering {
 
@@ -72,6 +70,10 @@ public:
 	 * This value must be less than or equal to current_version.
 	 */
 	static int active_version;
+	
+	/** @brief The actual XML file format version read from the map file.
+	 */
+	static int active_version_read;
 	
 };
 
@@ -126,4 +128,4 @@ public:
 
 */
 
-#endif // OPENORIENTEERING_FILE_FORMAT_XML_H
+#endif // OPENORIENTEERING_XML_FILE_FORMAT_H

--- a/src/gui/print_widget.cpp
+++ b/src/gui/print_widget.cpp
@@ -86,6 +86,7 @@
 #include "core/map_coord.h"
 #include "core/map_printer.h"
 #include "core/map_view.h"
+#include "fileformats/xml_file_format.h"
 #include "gui/file_dialog.h"
 #include "gui/main_window.h"
 #include "gui/print_progress_dialog.h"
@@ -547,7 +548,7 @@ void PrintWidget::setActive(bool active)
 			// Restore view
 			QXmlStreamReader reader(saved_view_state);
 			reader.readNextStartElement();
-			main_view->load(reader);
+			main_view->load(reader, XMLFileFormat::current_version);
 			
 			editor->setViewOptionsEnabled(true);
 		}


### PR DESCRIPTION
Although the map visibility is stored in the map file the map became always visible after loading.

Amends commit 701902d (MapView/MapWidget: Review, fast pinching support).
Closes GH-2316 (Map is always visible after loading).