### PR TITLE
Map: Fix deleting object selection

### DIFF
--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012-2014 Thomas Schöps
- *    Copyright 2013-2020, 2024 Kai Pastor
+ *    Copyright 2013-2020, 2024, 2025 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -943,7 +943,6 @@ void Map::deleteSelectedObjects()
 			if (index >= 0)
 			{
 				undo_step->addObject(index, *obj);
-				part->releaseObject(index);
 			}
 			else
 			{
@@ -951,8 +950,7 @@ void Map::deleteSelectedObjects()
 			}
 		}
 		
-		setObjectsDirty();
-		clearObjectSelection(true);
+		undo_step->removeContainedObjects(true);
 		push(undo_step);
 	}
 }


### PR DESCRIPTION
Deleting a selection of objects lead to a corrupted undo step which could lead to a failure when undoing the undo step before. The reason was that the selected objects were added in a loop to the undo step including their object index. After adding an object it was removed which caused the indexes of the remaining (and sometimes to be removed as well) objects to be renumbered.
Use the AddObjectsUndoStep::removeContainedObjects() function to remove the objects once they all have been added.

Closes GH-2320 (Deleting objects corrupts undo step).