### PR TITLE
Licensing: Consider derivative distributions

### DIFF
--- a/doc/licensing/CMakeLists.txt
+++ b/doc/licensing/CMakeLists.txt
@@ -36,23 +36,19 @@ endforeach()
 if(ANDROID OR APPLE OR WIN32)
 	set(default_provider OFF)
 elseif(UNIX)
+	set(default_provider NOTFOUND)
 	execute_process(
 	  COMMAND sh -c ". /etc/os-release; echo \"$ID $ID_LIKE\""
-	  OUTPUT_VARIABLE system_candidates
+	  OUTPUT_VARIABLE system_ids
 	  OUTPUT_STRIP_TRAILING_WHITESPACE 
 	)
-	string(REPLACE " " ";" system_candidates "${system_candidates}")
-	foreach(system_candidate ${system_candidates})
-		if(system_candidate IN_LIST known_providers)
-			set(system "${system_candidate}")
+	string(REPLACE " " ";" system_ids "${system_ids}")
+	foreach(system IN LISTS system_ids)
+		if(system IN_LIST known_providers)
+			set(default_provider "${system}")
 			break()
 		endif()
 	endforeach()
-	if(system)
-		set(default_provider "${system}")
-	else()
-		set(default_provider NOTFOUND)
-	endif()
 endif()
 
 set(LICENSING_PROVIDER "${default_provider}" CACHE STRING

--- a/doc/licensing/CMakeLists.txt
+++ b/doc/licensing/CMakeLists.txt
@@ -37,10 +37,17 @@ if(ANDROID OR APPLE OR WIN32)
 	set(default_provider OFF)
 elseif(UNIX)
 	execute_process(
-	  COMMAND sh -c ". /etc/os-release; echo $ID"
-	  OUTPUT_VARIABLE system
+	  COMMAND sh -c ". /etc/os-release; echo \"$ID $ID_LIKE\""
+	  OUTPUT_VARIABLE system_candidates
 	  OUTPUT_STRIP_TRAILING_WHITESPACE 
 	)
+	string(REPLACE " " ";" system_candidates "${system_candidates}")
+	foreach(system_candidate ${system_candidates})
+		if(system_candidate IN_LIST known_providers)
+			set(system "${system_candidate}")
+			break()
+		endif()
+	endforeach()
 	if(system)
 		set(default_provider "${system}")
 	else()

--- a/doc/licensing/ubuntu-licensing.cmake
+++ b/doc/licensing/ubuntu-licensing.cmake
@@ -1,1 +1,3 @@
+message(WARNING "LICENSING_PROVIDER=ubuntu is deprecated. Switching to debian.")
+set(LICENSING_PROVIDER "debian" CACHE STRING "Provider for 3rd-party licensing information" FORCE)
 include("${CMAKE_CURRENT_LIST_DIR}/debian-licensing.cmake")


### PR DESCRIPTION
The `$ID_LIKE` variable in `/etc/os-release` file may list space separated names that the current distribution is similar to. For example in some random distribution that derives from Ubuntu the values could be:

    ID="random-distro"
    ID_LIKE="ubuntu debian"

When trying to guess the current system, use all those values in order and use the first one that is known.

Here's documentation for the `ID_LIKE` variable: https://www.freedesktop.org/software/systemd/man/latest/os-release.html#ID_LIKE=