### PR TITLE
Progress,Job: Fix construction and assignment

### DIFF
--- a/3rd-party/cove/libvectorizer/Concurrency.cpp
+++ b/3rd-party/cove/libvectorizer/Concurrency.cpp
@@ -19,10 +19,6 @@
 
 #include "Concurrency.h"
 
-#include <memory>
-
-#include <QAtomicInteger>
-
 
 namespace cove {
 
@@ -35,6 +31,11 @@ ProgressObserver::~ProgressObserver() = default;
 namespace Concurrency {
 
 // ### Concurrency::Progress ###
+
+static_assert(std::is_copy_constructible<Progress>::value, "Concurrency::Progress must be copy constructible.");
+static_assert(std::is_move_constructible<Progress>::value, "Concurrency::Progress must be move constructible.");
+static_assert(!std::is_copy_assignable<Progress>::value, "Concurrency::Progress is not copy assignable.");
+static_assert(!std::is_move_assignable<Progress>::value, "Concurrency::Progress is not move assignable.");
 
 int Progress::getPercentage() const noexcept
 {
@@ -63,6 +64,15 @@ void TransformedProgress::setPercentage(int percentage)
 {
 	observer.setPercentage(qBound(0, qRound(offset + factor * percentage), 100));
 }
+
+
+// ### Concurrency::Job ###
+
+using ArbitraryResultType = int;
+static_assert(std::is_copy_constructible<Job<ArbitraryResultType>>::value, "Concurrency::Job must be copy constructible.");
+static_assert(std::is_move_constructible<Job<ArbitraryResultType>>::value, "Concurrency::Job must be move constructible.");
+static_assert(!std::is_copy_assignable<Job<ArbitraryResultType>>::value, "Concurrency::Job is not copy assignable.");
+static_assert(!std::is_move_assignable<Job<ArbitraryResultType>>::value, "Concurrency::Job is not move assignable.");
 
 
 }  // namespace Concurrency


### PR DESCRIPTION
Move construction of Progress: No problem, sharing from const ref.  
Copy construction of Job: No problem.  
Assignment of Progress or Job: Not possible.  
Fixes GH-2334.