### PR TITLE
TagSelectWidget: Change column width

### DIFF
--- a/src/gui/widgets/tag_select_widget.cpp
+++ b/src/gui/widgets/tag_select_widget.cpp
@@ -52,7 +52,7 @@ namespace OpenOrienteering {
 
 namespace {
 
-QTableWidgetItem* createPlaceholderItemFor(QWidget* widget)
+QTableWidgetItem* createPlaceholderItemFor(const QWidget* widget = nullptr)
 {
 	auto* item = new QTableWidgetItem();
 	item->setFlags(Qt::NoItemFlags);

--- a/src/gui/widgets/tag_select_widget.cpp
+++ b/src/gui/widgets/tag_select_widget.cpp
@@ -165,16 +165,6 @@ void TagSelectWidget::showEvent(QShowEvent* event)
 
 void TagSelectWidget::addRowItems(int row)
 {
-	auto* item = new QTableWidgetItem();
-	setItem(row, 1, item);
-	item = new QTableWidgetItem();
-	setItem(row, 3, item);
-
-	auto* compare_op = new QComboBox();
-	for (auto op : { ObjectQuery::OperatorIs, ObjectQuery::OperatorIsNot, ObjectQuery::OperatorContains })
-		compare_op->addItem(ObjectQuery::labelFor(op), QVariant::fromValue(op));
-	setCellWidget(row, 2, compare_op);
-	
 	auto* logical_op = new QComboBox();
 	auto and_label = QString { QLatin1String("  ") + ObjectQuery::labelFor(ObjectQuery::OperatorAnd) };
 	logical_op->addItem(and_label, QVariant::fromValue(ObjectQuery::OperatorAnd));
@@ -188,6 +178,15 @@ void TagSelectWidget::addRowItems(int row)
 		setItem(row, 0, createPlaceholderItemFor(logical_op));
 		delete logical_op;
 	}
+	
+	setItem(row, 1, new QTableWidgetItem());  // key
+	
+	auto* compare_op = new QComboBox();
+	for (auto op : { ObjectQuery::OperatorIs, ObjectQuery::OperatorIsNot, ObjectQuery::OperatorContains })
+		compare_op->addItem(ObjectQuery::labelFor(op), QVariant::fromValue(op));
+	setCellWidget(row, 2, compare_op);
+	
+	setItem(row, 3, new QTableWidgetItem());  // value
 }
 
 

--- a/src/gui/widgets/tag_select_widget.cpp
+++ b/src/gui/widgets/tag_select_widget.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2016 Mitchell Krome
- *    Copyright 2017-2019 Kai Pastor
+ *    Copyright 2017-2019, 2025 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -76,12 +76,12 @@ TagSelectWidget::TagSelectWidget(QWidget* parent)
 	
 	auto* header_view = horizontalHeader();
 	header_view->setSectionsClickable(false);
-	header_view->setSectionResizeMode(0, QHeaderView::Fixed);
+	header_view->setSectionResizeMode(0, QHeaderView::ResizeToContents);
 	header_view->setSectionResizeMode(1, QHeaderView::Stretch);
-	header_view->setSectionResizeMode(2, QHeaderView::Fixed);
+	header_view->setSectionResizeMode(2, QHeaderView::ResizeToContents);
 	header_view->setSectionResizeMode(3, QHeaderView::Stretch);
 	header_view->resizeSections(QHeaderView::ResizeToContents);
-	setMinimumWidth(10
+	setMinimumWidth(150
 	                + header_view->sectionSize(0)
 	                + header_view->sectionSize(1)
 	                + header_view->sectionSize(2)
@@ -222,6 +222,8 @@ void TagSelectWidget::addRow()
 	// Move the selection to the new row
 	int col = currentColumn();
 	setCurrentCell(row, col);
+	resizeColumnToContents(0);
+	resizeColumnToContents(2);
 }
 
 


### PR DESCRIPTION
The 'Find objects' dialog contains a table which is shown in the 'Query editor' view.
The 'Relation' and 'Comparision' columns were set up with a fixed width based on the width of the translated labels 'Relation' and 'Comparision'. The result looks good for English but not for other languages, e.g., German or Czech.
Set up both columns to automatically resize based on its contents.