### PR TITLE
XMLFileImporter: Fix screen attributes import

### DIFF
--- a/src/fileformats/xml_file_format.cpp
+++ b/src/fileformats/xml_file_format.cpp
@@ -797,12 +797,11 @@ void XMLFileImporter::importColors()
 						if (xml.name() == literal::namedcolor)
 						{
 							XmlElementReader color_element(xml);
+							const auto angle = color_element.attribute<double>(literal::screen_angle);
+							const auto frequency = color_element.attribute<double>(literal::screen_frequency);
 							color->setSpotColorName(xml.readElementText());
-							if (color_element.hasAttribute(literal::screen_frequency))
-							{
-								color->setScreenAngle(color_element.attribute<double>(literal::screen_angle));
-								color->setScreenFrequency(std::max(0.0, color_element.attribute<double>(literal::screen_frequency)));
-							}
+							color->setScreenAngle(angle);
+							color->setScreenFrequency(frequency);
 							color->setKnockout(knockout);
 						}
 						else if (xml.name() == literal::component)

--- a/src/fileformats/xml_file_format.cpp
+++ b/src/fileformats/xml_file_format.cpp
@@ -797,12 +797,12 @@ void XMLFileImporter::importColors()
 						if (xml.name() == literal::namedcolor)
 						{
 							XmlElementReader color_element(xml);
+							color->setSpotColorName(xml.readElementText());
 							if (color_element.hasAttribute(literal::screen_frequency))
 							{
 								color->setScreenAngle(color_element.attribute<double>(literal::screen_angle));
 								color->setScreenFrequency(std::max(0.0, color_element.attribute<double>(literal::screen_frequency)));
 							}
-							color->setSpotColorName(xml.readElementText());
 							color->setKnockout(knockout);
 						}
 						else if (xml.name() == literal::component)

--- a/src/fileformats/xml_file_format.cpp
+++ b/src/fileformats/xml_file_format.cpp
@@ -22,7 +22,6 @@
 #include "xml_file_format.h"
 #include "xml_file_format_p.h"
 
-#include <algorithm>
 #include <cstddef>
 #include <functional>
 #include <memory>

--- a/src/fileformats/xml_file_format.h
+++ b/src/fileformats/xml_file_format.h
@@ -21,6 +21,8 @@
 #ifndef OPENORIENTEERING_XML_FILE_FORMAT_H
 #define OPENORIENTEERING_XML_FILE_FORMAT_H
 
+#include <memory>
+
 #include "fileformats/file_format.h"
 
 class QString;

--- a/test/file_format_t.cpp
+++ b/test/file_format_t.cpp
@@ -249,7 +249,14 @@ namespace
 		}
 		else for (int i = 0; i < actual.getNumColors(); ++i)
 		{
-			QCOMPARE(*actual.getColor(i), *expected.getColor(i));
+			const auto& actual_color = *actual.getColor(i);
+			const auto& expected_color = *expected.getColor(i);
+			QCOMPARE(actual_color, expected_color);
+			if (expected_color.getSpotColorMethod() == MapColor::SpotColor)
+			{
+				QCOMPARE(actual_color.getScreenAngle(), expected_color.getScreenAngle());
+				QCOMPARE(actual_color.getScreenFrequency(), expected_color.getScreenFrequency());
+			}
 		}
 		
 		// Symbols
@@ -939,6 +946,8 @@ void FileFormatTest::pristineMapTest()
 	auto spot_color = std::make_unique<MapColor>(QString::fromLatin1("spot color"), 0);
 	spot_color->setSpotColorName(QString::fromLatin1("SPOTCOLOR"));
 	spot_color->setCmyk({0.1f, 0.2f, 0.3f, 0.4f});
+	spot_color->setScreenFrequency(55.0);
+	spot_color->setScreenAngle(73.0);
 	spot_color->setRgbFromCmyk();
 	
 	auto mixed_color = std::make_unique<MapColor>(QString::fromLatin1("mixed color"), 1);


### PR DESCRIPTION
When importing a spot color, setting the screen angle and screen frequency properties was ignored since the color was not yet defined as a spot color.

Close GH-2348 (Impossible to load screen frequency).