### PR TITLE
TagsWidget: Disable editing if multiple objects are selected

### DIFF
--- a/src/gui/widgets/tags_widget.cpp
+++ b/src/gui/widgets/tags_widget.cpp
@@ -126,13 +126,14 @@ void TagsWidget::objectTagsChanged()
 	
 	react_to_changes = false;
 	
-	const auto* object = map->getFirstSelectedObject();
-	if (map->getNumSelectedObjects() == 1 && object)
+	if (map->getNumSelectedObjects() == 1)
 	{
-		int row = 0;
+		const auto* object = map->getFirstSelectedObject();
 		auto const& tags = object->tags();
 		tags_table->clearContents();
 		tags_table->setRowCount(tags.size() + 1);
+		
+		int row = 0;
 		for (auto const& tag : tags)
 		{
 			tags_table->setItem(row, 0, new QTableWidgetItem(tag.key));

--- a/src/gui/widgets/tags_widget.cpp
+++ b/src/gui/widgets/tags_widget.cpp
@@ -126,10 +126,10 @@ void TagsWidget::objectTagsChanged()
 	
 	react_to_changes = false;
 	
-	int row = 0;
-	const Object* object = map->getFirstSelectedObject();
-	if (object)
+	const auto* object = map->getFirstSelectedObject();
+	if (map->getNumSelectedObjects() == 1 && object)
 	{
+		int row = 0;
 		auto const& tags = object->tags();
 		tags_table->clearContents();
 		tags_table->setRowCount(tags.size() + 1);


### PR DESCRIPTION
If multiple objects were selected the tag editor would just operate on the so-called 'first selected object'.
If a group of objects is selected the user does not know which of them is the first selected object.