### PR TITLE
Scale tool: add support for non-uniform scaling, controlled by Shift key

### DIFF
--- a/src/core/objects/object.cpp
+++ b/src/core/objects/object.cpp
@@ -544,25 +544,25 @@ void Object::move(const MapCoord& offset)
 
 void Object::scale(const MapCoordF& center, double factor)
 {
-	for (MapCoord& coord : coords)
-	{
-		coord.setX(center.x() + (coord.x() - center.x()) * factor);
-		coord.setY(center.y() + (coord.y() - center.y()) * factor);
-	}
-	
-	setOutputDirty();
+	scale(center, factor, factor);
 }
 
 void Object::scale(double factor_x, double factor_y)
 {
+	scale(MapCoordF(0, 0), factor_x, factor_y);
+}
+
+void Object::scale(const MapCoordF& center, double factor_x, double factor_y)
+{
 	for (MapCoord& coord : coords)
 	{
-		coord.setX(coord.x() * factor_x);
-		coord.setY(coord.y() * factor_y);
+		coord.setX(center.x() + (coord.x() - center.x()) * factor_x);
+		coord.setY(center.y() + (coord.y() - center.y()) * factor_y);
 	}
-	
+
 	setOutputDirty();
 }
+
 
 // virtual
 void Object::rotatePatternOrigin(const MapCoordF& /*center*/, qreal /*sin_angle*/, qreal /*cos_angle*/)

--- a/src/core/objects/object.h
+++ b/src/core/objects/object.h
@@ -208,6 +208,13 @@ public:
 	 * @param factor_y vertical scaling factor
 	 */
 	virtual void scale(double factor_x, double factor_y);
+
+	/** Scales all coordinates.
+	 * @param center center of the scaling operation
+	 * @param factor_x horizontal scaling factor
+	 * @param factor_y vertical scaling factor
+	 */
+	virtual void scale(const MapCoordF& center, double factor_x, double factor_y);
 	
 protected:
 	/** Rotates the pattern origin around the center point.

--- a/src/tools/scale_tool.h
+++ b/src/tools/scale_tool.h
@@ -68,9 +68,11 @@ protected:
 	void objectSelectionChangedImpl() override;
 	
 	MapCoordF scaling_center;
-	double reference_length = 0;
-	double scaling_factor   = 1;
+	MapCoordF scaling_start_point;
+	QPointF reference_point = QPointF(0,0);
+	QPointF scaling_factor = QPointF(1, 1);
 	bool using_scaling_center = true;
+	bool uniform_scaling = true;
 };
 
 


### PR DESCRIPTION
Here's a commit that fixes #195. It lets you scale with different amounts horizontally and vertically if you hold the shift key while scaling.

It generalizes the existing logic to be able to operate on x and y directions independently.

I'm unsure what to do with the absmax function, if it should be a static ScaleTool method, part of some utility function collection, or if it's ok for it to just hang out where it does as it does now. Please advise on this.