### PR TITLE
SymbolReplacementDialog: Show active symbol replacement strategy

### DIFF
--- a/src/gui/symbols/symbol_replacement_dialog.cpp
+++ b/src/gui/symbols/symbol_replacement_dialog.cpp
@@ -157,6 +157,7 @@ SymbolReplacementDialog::SymbolReplacementDialog(QWidget* parent, Map& object_ma
 	mapping_table->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
 	mapping_table->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
 	mapping_table->setEditTriggers(QAbstractItemView::AllEditTriggers);
+	connect(mapping_table, &QTableWidget::cellChanged, this, &SymbolReplacementDialog::clearMatchCheckmarks);
 	
 	auto action = mapping_menu->addAction(tr("Clear replacements"));
 	connect(action, &QAction::triggered, this, &SymbolReplacementDialog::resetReplacements);
@@ -219,11 +220,20 @@ void SymbolReplacementDialog::resetReplacements()
 		item.symbol = nullptr;
 		item.type = SymbolRule::NoAssignment;
 	}
-	if (match_by_number_action)
-		match_by_number_action->setChecked(false);
-	if (match_by_name_action)
-		match_by_name_action->setChecked(false);
+	clearMatchCheckmarks();
 	updateMappingTable();
+}
+
+// slot
+void SymbolReplacementDialog::clearMatchCheckmarks()
+{
+	if (react_to_changes)
+	{
+		if (match_by_number_action)
+			match_by_number_action->setChecked(false);
+		if (match_by_name_action)
+			match_by_name_action->setChecked(false);
+	}
 }
 
 
@@ -308,6 +318,7 @@ void SymbolReplacementDialog::updateMappingTable()
 	if (!mapping_table)
 		return;
 	
+	react_to_changes = false;
 	mapping_table->setUpdatesEnabled(false);
 	
 	mapping_table->clearContents();
@@ -454,6 +465,7 @@ void SymbolReplacementDialog::updateMappingTable()
 	}
 	
 	mapping_table->setUpdatesEnabled(true);
+	react_to_changes = true;
 }
 
 

--- a/src/gui/symbols/symbol_replacement_dialog.h
+++ b/src/gui/symbols/symbol_replacement_dialog.h
@@ -81,6 +81,7 @@ private slots:
 	void matchByName();
 	void matchByNumber();
 	void resetReplacements();
+	void clearMatchCheckmarks();
 	
 	void openCrtFile();
 	bool saveCrtFile();
@@ -101,6 +102,7 @@ private:
 	std::vector<std::unique_ptr<SymbolDropDownDelegate>> symbol_widget_delegates;
 	
 	Mode mode;
+	bool react_to_changes = false;
 };
 
 


### PR DESCRIPTION
Add checkmark to show the active symbol replacement strategy (either name or number) in the 'Symbol mapping' drop-down menu.

Refer to #2359 for the context of this PR.