### PR TITLE
TextObject: Apply inverse rotation

### DIFF
--- a/code-check-wrapper.sh
+++ b/code-check-wrapper.sh
@@ -114,6 +114,7 @@ for I in \
   template_t.cpp \
   template_tool \
   template_track.cpp \
+  text_object.cpp \
   text_object_editor_helper.cpp \
   text_browser_dialog \
   toast.cpp \

--- a/src/core/objects/text_object.cpp
+++ b/src/core/objects/text_object.cpp
@@ -275,7 +275,7 @@ QTransform TextObject::calcTextToMapTransform() const
 	const TextSymbol* text_symbol = reinterpret_cast<const TextSymbol*>(symbol);
 	
 	QTransform transform;
-	double scaling = 1.0f / text_symbol->calculateInternalScaling();
+	auto const scaling = 1.0 / text_symbol->calculateInternalScaling();
 	transform.translate(coords[0].x(), coords[0].y());
 	if (getRotation() != 0)
 		transform.rotate(-qRadiansToDegrees(getRotation()));
@@ -289,8 +289,8 @@ QTransform TextObject::calcMapToTextTransform() const
 	const TextSymbol* text_symbol = reinterpret_cast<const TextSymbol*>(symbol);
 	
 	QTransform transform;
-	double scaling = 1.0f / text_symbol->calculateInternalScaling();
-	transform.scale(1.0f / scaling, 1.0f / scaling);
+	auto const scaling = text_symbol->calculateInternalScaling();
+	transform.scale(scaling, scaling);
 	if (getRotation() != 0)
 		transform.rotate(qRadiansToDegrees(getRotation()));
 	transform.translate(-coords[0].x(), -coords[0].y());
@@ -416,7 +416,6 @@ void TextObject::prepareLineInfos() const
 	
 	//double next_line_x_offset = 0; // to keep indentation after word wrap in a line with tabs
 	int num_paragraphs = 0;
-	int line_num = 0;
 	int line_start = 0;
 	while (line_start <= text_end) 
 	{
@@ -511,7 +510,6 @@ void TextObject::prepareLineInfos() const
 			line_y += paragraph_spacing;
 			num_paragraphs++;
 		}
-		line_num++;
 		line_start = next_line_start;
 	}
 	

--- a/src/core/objects/text_object.h
+++ b/src/core/objects/text_object.h
@@ -22,7 +22,6 @@
 #ifndef OPENORIENTEERING_TEXT_OBJECT_H
 #define OPENORIENTEERING_TEXT_OBJECT_H
 
-#include <memory>
 #include <vector>
 
 #include <QtGlobal>

--- a/test/object_t.cpp
+++ b/test/object_t.cpp
@@ -43,7 +43,7 @@ class ObjectTest : public QObject
 	Q_OBJECT
 	
 private slots:
-	void ObjectLengthTest_data()
+	void objectLengthTest_data()
 	{
 		QTest::addColumn<int>("map_scale");
 		QTest::addColumn<MapCoordVector>("coords");
@@ -58,7 +58,7 @@ private slots:
 		QTest::newRow("Line object 1 at 1:15000") << 15000 << coords << 30.0f << 50.0f;
 	}
 	
-	void ObjectLengthTest()
+	void objectLengthTest()
 	{
 		QFETCH(int, map_scale);
 		QFETCH(MapCoordVector, coords);
@@ -93,7 +93,7 @@ private slots:
 	}
 	
 	
-	void ObjectAreaTest_data()
+	void objectAreaTest_data()
 	{
 		QTest::addColumn<int>("map_scale");
 		QTest::addColumn<MapCoordVector>("coords");
@@ -115,7 +115,7 @@ private slots:
 		QTest::newRow("Area object 2 at 1:10000") << 10000 << coords2 << 30.0f << 44.0f;
 	}
 	
-	void ObjectAreaTest()
+	void objectAreaTest()
 	{
 		QFETCH(int, map_scale);
 		QFETCH(MapCoordVector, coords);
@@ -186,7 +186,7 @@ private slots:
  * We don't need a real GUI window.
  */
 namespace {
-	auto Q_DECL_UNUSED qpa_selected = qputenv("QT_QPA_PLATFORM", "minimal");  // clazy:exclude=non-pod-global-static
+	auto const Q_DECL_UNUSED qpa_selected = qputenv("QT_QPA_PLATFORM", "minimal");  // clazy:exclude=non-pod-global-static
 }
 
 QTEST_MAIN(ObjectTest)


### PR DESCRIPTION
If the user clicks inside a rotated text object, rotate the position of the mouse click inverse to the rotation of the text in order to compare the position against the (unrotated) text object dimensions.

Closes GH-2368 (Rotated text cannot be selected).