### PR TITLE
Highlight destructive options in the Save file dialog

### DIFF
--- a/src/gui/main_window.cpp
+++ b/src/gui/main_window.cpp
@@ -706,10 +706,16 @@ bool MainWindow::showSaveOnCloseDialog()
 		}
 		else
 		{
-			ret = QMessageBox::warning(this, appName(),
-			                           tr("The file has been modified.\n"
-			                              "Do you want to save your changes?"),
-			                           QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel);
+			QMessageBox msgBox(QMessageBox::Warning, appName(),
+			                   tr("The file has been modified.\nDo you want to save your changes?"),
+			                   QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel, this);
+			// Restyle destructive buttons
+			for (auto const& btn : msgBox.buttons())
+				if (msgBox.buttonRole(btn) == QMessageBox::ButtonRole::DestructiveRole)
+					btn->setStyleSheet(QLatin1Literal("QPushButton { color: red; }"));
+			msgBox.setDefaultButton(QMessageBox::Cancel);
+			auto exec = msgBox.exec();
+			ret = (exec == -1) ? QMessageBox::Cancel : msgBox.standardButton(msgBox.clickedButton());
 		}
 		
 		switch (ret)


### PR DESCRIPTION
This change highlights the "discard changes" option in the file save dialog. Although it's a tiny change, anytime I see the red highlight on the button, I enjoy its usefulness. I'm sharing the change with OpenOrienteering in the hope that the joy will spread.

![Screenshot From 2025-05-01 10-29-34](https://github.com/user-attachments/assets/9c1f6cf3-3ddc-4c43-b58c-a56f9321545a)
