### PR TITLE
Search for dynamic object properties

### DIFF
--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -1114,6 +1114,10 @@ void Map::ensureVisibilityOfSelectedObjects(SelectionVisibility visibility)
 					widget->ensureVisibilityOfRect(rect, MapWidget::DiscreteZoom);
 				break;
 				
+			case CenterFullVisibility:
+				widget->ensureVisibilityOfRect(rect, MapWidget::DiscreteZoom, true);
+				break;
+				
 			case IgnoreVisibilty:
 				break; // Do nothing
 				

--- a/src/core/map.h
+++ b/src/core/map.h
@@ -121,6 +121,7 @@ public:
 	{
 		FullVisibility,
 		PartialVisibility,
+		CenterFullVisibility,
 		IgnoreVisibilty
 	};
 	

--- a/src/core/objects/object.cpp
+++ b/src/core/objects/object.cpp
@@ -22,6 +22,7 @@
 #include "object.h"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstddef>
 #include <iterator>
@@ -79,17 +80,38 @@ namespace literal
 	static const QLatin1String tags("tags");
 	
 	// object properties
-	static const QLatin1String UndefinedSymbol("UndefinedSymbol");
-	static const QLatin1String AreaTooSmall("AreaTooSmall");
-	static const QLatin1String LineTooShort("LineTooShort");
-	static const QLatin1String PaperArea("PaperArea");
-	static const QLatin1String RealArea("RealArea");
-	static const QLatin1String PaperLength("PaperLength");
-	static const QLatin1String RealLength("RealLength");
+	// boolean operations
+	static const QLatin1String UndefinedSymbol(".UndefinedSymbol");
+	static const QLatin1String AreaTooSmall(".AreaTooSmall");
+	static const QLatin1String LineTooShort(".LineTooShort");
+	// comparisons
+	static const QLatin1String PaperArea(".PaperArea");
+	static const QLatin1String RealArea(".RealArea");
+	static const QLatin1String PaperLength(".PaperLength");
+	static const QLatin1String RealLength(".RealLength");
 }
 
 
 namespace OpenOrienteering {
+
+static const std::array<QLatin1String, 7> object_properties = {literal::UndefinedSymbol, literal::AreaTooSmall, literal::LineTooShort, 
+															   literal::PaperArea, literal::RealArea, literal::PaperLength, literal::RealLength};
+
+bool Object::isObjectProperty(const QString& property)
+{
+	return std::find(object_properties.begin(), object_properties.end(), property) != object_properties.end();
+}
+
+bool Object::isBooleanObjectProperty(const QString& property)
+{
+	return std::find(object_properties.begin(), object_properties.begin() + 2, property) != object_properties.begin() + 2;
+}
+
+bool Object::isComparisonObjectProperty(const QString& property)
+{
+	return std::find(object_properties.begin() + 3, object_properties.end(), property) != object_properties.end();
+}
+
 
 // ### Object implementation ###
 
@@ -775,13 +797,6 @@ QVariant Object::getObjectProperty(const QString& property) const
 	return QVariant();
 }
 
-bool Object::isObjectProperty(const QString& property) const
-{
-	if (property == literal::UndefinedSymbol)
-		return true;
-	
-	return false;
-}
 
 // ### PathPart ###
 
@@ -3271,20 +3286,6 @@ QVariant PathObject::getObjectProperty(const QString& property) const
 	return Object::getObjectProperty(property);	// pass to base class function
 }
 
-// override
-bool PathObject::isObjectProperty(const QString& property) const
-{
-	if (property == literal::AreaTooSmall
-		|| property == literal::LineTooShort
-		|| property == literal::PaperArea
-		|| property == literal::RealArea
-		|| property == literal::PaperLength
-		|| property == literal::RealLength
-		)
-		return true;
-	
-	return Object::isObjectProperty(property);	// pass to base class function
-}
 
 
 // ### PointObject ###

--- a/src/core/objects/object.cpp
+++ b/src/core/objects/object.cpp
@@ -65,6 +65,7 @@ class QRectF;
 
 namespace literal
 {
+	// map file
 	static const QLatin1String object("object");
 	static const QLatin1String symbol("symbol");
 	static const QLatin1String type("type");
@@ -76,8 +77,16 @@ namespace literal
 	static const QLatin1String rotation("rotation");
 	static const QLatin1String size("size");
 	static const QLatin1String tags("tags");
+	
+	// object properties
+	static const QLatin1String UndefinedSymbol("UndefinedSymbol");
+	static const QLatin1String AreaTooSmall("AreaTooSmall");
+	static const QLatin1String LineTooShort("LineTooShort");
+	static const QLatin1String PaperArea("PaperArea");
+	static const QLatin1String RealArea("RealArea");
+	static const QLatin1String PaperLength("PaperLength");
+	static const QLatin1String RealLength("RealLength");
 }
-
 
 
 namespace OpenOrienteering {
@@ -755,6 +764,24 @@ void Object::includeControlPointsRect(QRectF& rect) const
 }
 
 
+QVariant Object::getObjectProperty(const QString& property) const
+{
+	if (property == literal::UndefinedSymbol)
+	{
+		if (map && symbol)
+			return QVariant(map->findSymbolIndex(symbol) < 0);
+	}
+	
+	return QVariant();
+}
+
+bool Object::isObjectProperty(const QString& property) const
+{
+	if (property == literal::UndefinedSymbol)
+		return true;
+	
+	return false;
+}
 
 // ### PathPart ###
 
@@ -3217,6 +3244,46 @@ bool PathObject::isLineTooShort() const
 {
 	int minimum_length = symbol ? symbol->getMinimumLength() : 0;
 	return getPaperLength() < 0.001 * minimum_length;
+}
+
+
+// override
+QVariant PathObject::getObjectProperty(const QString& property) const
+{
+	if (property == literal::AreaTooSmall)
+		return QVariant(isAreaTooSmall());
+
+	if (property == literal::LineTooShort)
+		return QVariant(isLineTooShort());
+	
+	if (property == literal::PaperArea)
+		return QVariant(calculatePaperArea());
+	
+	if (property == literal::RealArea)
+		return QVariant(calculateRealArea());
+	
+	if (property == literal::PaperLength)
+		return QVariant(getPaperLength());
+	
+	if (property == literal::RealLength)
+		return QVariant(getRealLength());
+	
+	return Object::getObjectProperty(property);	// pass to base class function
+}
+
+// override
+bool PathObject::isObjectProperty(const QString& property) const
+{
+	if (property == literal::AreaTooSmall
+		|| property == literal::LineTooShort
+		|| property == literal::PaperArea
+		|| property == literal::RealArea
+		|| property == literal::PaperLength
+		|| property == literal::RealLength
+		)
+		return true;
+	
+	return Object::isObjectProperty(property);	// pass to base class function
 }
 
 

--- a/src/core/objects/object.cpp
+++ b/src/core/objects/object.cpp
@@ -22,7 +22,6 @@
 #include "object.h"
 
 #include <algorithm>
-#include <array>
 #include <cmath>
 #include <cstddef>
 #include <iterator>
@@ -94,8 +93,8 @@ namespace literal
 
 namespace OpenOrienteering {
 
-static const std::array<QLatin1String, 7> object_properties = {literal::UndefinedSymbol, literal::AreaTooSmall, literal::LineTooShort, 
-															   literal::PaperArea, literal::RealArea, literal::PaperLength, literal::RealLength};
+static const std::vector<QLatin1String> object_properties = {literal::UndefinedSymbol, literal::AreaTooSmall, literal::LineTooShort, 
+                                                             literal::PaperArea, literal::RealArea, literal::PaperLength, literal::RealLength};
 
 bool Object::isObjectProperty(const QString& property)
 {
@@ -104,7 +103,7 @@ bool Object::isObjectProperty(const QString& property)
 
 bool Object::isBooleanObjectProperty(const QString& property)
 {
-	return std::find(object_properties.begin(), object_properties.begin() + 2, property) != object_properties.begin() + 2;
+	return std::find(object_properties.begin(), object_properties.begin() + 3, property) != object_properties.begin() + 3;
 }
 
 bool Object::isComparisonObjectProperty(const QString& property)
@@ -112,6 +111,10 @@ bool Object::isComparisonObjectProperty(const QString& property)
 	return std::find(object_properties.begin() + 3, object_properties.end(), property) != object_properties.end();
 }
 
+const std::vector<QLatin1String>& Object::getObjectProperties()
+{
+	return object_properties;
+}
 
 // ### Object implementation ###
 

--- a/src/core/objects/object.h
+++ b/src/core/objects/object.h
@@ -96,6 +96,8 @@ public:
 	/** Creates an empty object with the given type, symbol, coords and (optional) map. */
 	explicit Object(Type type, const Symbol* symbol, MapCoordVector coords, Map* map = nullptr);
 	
+	//static constexpr QLatin1String ObjectProperties[] = {QLatin1String{"aaa"}};
+	
 protected:
 	/**
 	 * Constructs an Object, initialized from the given prototype.
@@ -327,10 +329,10 @@ public:
 	
 	/**
 	 * Returns true if property is a dynamic object property that is provided for all objects.
-	 * Derived object classes (i.e., PathObject) override this function to test for class specific object properties.
-	 * If derived object classes don't provide a requested property, they invoke the base class function.
 	 */
-	virtual bool isObjectProperty(const QString& property) const;
+	static bool isObjectProperty(const QString& property);
+	static bool isBooleanObjectProperty(const QString& property);
+	static bool isComparisonObjectProperty(const QString& property);
 	
 protected:
 	virtual void updateEvent() const;
@@ -947,12 +949,6 @@ public:
 	 */
 	QVariant getObjectProperty(const QString& property) const override;
 	
-	/**
-	 * Returns true if property is a dynamic object property that is provided by the PathObject class.
-	 * Note: Overrides the base class function that returns true for dynamic object properties that are common for all objects.
-	 * If a requested property is not provided by PathObject, the base class function is invoked.
-	 */
-	bool isObjectProperty(const QString& property) const override;
 	
 protected:
 	/**
@@ -1162,7 +1158,6 @@ struct ObjectPathCoord : public PathCoord
 	 */
 	double findClosestPointTo(const MapCoordF& map_coord);
 };
-
 
 
 //### Object inline code ###

--- a/src/core/objects/object.h
+++ b/src/core/objects/object.h
@@ -96,7 +96,6 @@ public:
 	/** Creates an empty object with the given type, symbol, coords and (optional) map. */
 	explicit Object(Type type, const Symbol* symbol, MapCoordVector coords, Map* map = nullptr);
 	
-	//static constexpr QLatin1String ObjectProperties[] = {QLatin1String{"aaa"}};
 	
 protected:
 	/**
@@ -327,12 +326,17 @@ public:
 	 */
 	virtual QVariant getObjectProperty(const QString& property) const;
 	
-	/**
-	 * Returns true if property is a dynamic object property that is provided for all objects.
-	 */
+	/** Returns true if property is a dynamic object property. */
 	static bool isObjectProperty(const QString& property);
+	
+	/** Returns true if property is a dynamic object property that returns a boolean value. */
 	static bool isBooleanObjectProperty(const QString& property);
+	
+	/** Returns true if property is a dynamic object property that returns a value for comparison. */
 	static bool isComparisonObjectProperty(const QString& property);
+	
+	/** Returns keywords of the available dynamic object properties. */
+	static const std::vector<QLatin1String>& getObjectProperties();
 	
 protected:
 	virtual void updateEvent() const;

--- a/src/core/objects/object.h
+++ b/src/core/objects/object.h
@@ -317,6 +317,21 @@ public:
 	 */
 	void includeControlPointsRect(QRectF& rect) const;
 	
+	
+	/**
+	 * Returns dynamic object properties that are common for all objects.
+	 * Derived object classes (i.e., PathObject) override this function to return class specific object properties.
+	 * If derived object classes don't provide a requested property, they invoke the base class function.
+	 */
+	virtual QVariant getObjectProperty(const QString& property) const;
+	
+	/**
+	 * Returns true if property is a dynamic object property that is provided for all objects.
+	 * Derived object classes (i.e., PathObject) override this function to test for class specific object properties.
+	 * If derived object classes don't provide a requested property, they invoke the base class function.
+	 */
+	virtual bool isObjectProperty(const QString& property) const;
+	
 protected:
 	virtual void updateEvent() const;
 	
@@ -924,6 +939,20 @@ public:
 	/** Returns true if the object is shorter than the minimum length required by its symbol. */
 	bool isLineTooShort() const;
 	
+	
+	/**
+	 * Returns dynamic object properties that are specific for the PathObject class.
+	 * Note: Overrides the base class function that returns dynamic object properties that are common for all objects.
+	 * If a requested property is not provided by PathObject, the base class function is invoked.
+	 */
+	QVariant getObjectProperty(const QString& property) const override;
+	
+	/**
+	 * Returns true if property is a dynamic object property that is provided by the PathObject class.
+	 * Note: Overrides the base class function that returns true for dynamic object properties that are common for all objects.
+	 * If a requested property is not provided by PathObject, the base class function is invoked.
+	 */
+	bool isObjectProperty(const QString& property) const override;
 	
 protected:
 	/**

--- a/src/core/objects/object_query.cpp
+++ b/src/core/objects/object_query.cpp
@@ -487,7 +487,6 @@ bool ObjectQuery::operator()(const Object* object) const
 			return it != container.end() && it->value.contains(tags.value);
 		} (object->tags(), tags);
 	case OperatorSearch:
-		qDebug("\nOperatorSearch");
 		bool value;
 		if (getBooleanObjectProperty(object, tags, value))
 			return value;
@@ -503,7 +502,6 @@ bool ObjectQuery::operator()(const Object* object) const
 	case OperatorObjectText:
 		if (Object::isObjectProperty(tags.value))	// don't search for object properties keywords
 			return false;
-		qDebug("\nOperatorObjectText");
 		if (object->getType() == Object::Text)
 			return static_cast<const TextObject*>(object)->getText().contains(tags.value, Qt::CaseInsensitive);
 		return false;

--- a/src/core/objects/object_query.cpp
+++ b/src/core/objects/object_query.cpp
@@ -210,7 +210,7 @@ ObjectQuery::ObjectQuery(const ObjectQuery& query)
 	{
 		; // nothing
 	}
-	else if (op < 16)
+	else if (IsLogicalOperator(op))
 	{
 		new (&subqueries) LogicalOperands(query.subqueries);
 	}
@@ -266,10 +266,8 @@ ObjectQuery::ObjectQuery(const QString& key, ObjectQuery::Operator op, const QSt
 {
 	// Can't have an empty key (but can have empty value)
 	// Must be a key/value operator
-	Q_ASSERT(op >= 16);
-	Q_ASSERT(op <= 18);
-	if (op < 16 || op > 18
-	    || key.length() == 0)
+	Q_ASSERT(IsTagOperator(op));	// 16..18
+	if (!IsTagOperator(op) || key.length() == 0)
 	{
 		reset();
 	}
@@ -280,12 +278,10 @@ ObjectQuery::ObjectQuery(ObjectQuery::Operator op, const QString& value)
 : op { op }
 , tags { {}, value }
 {
-	// Can't have an empty key (but can have empty value)
-	// Must be a key/value operator
-	Q_ASSERT(op >= 19);
-	Q_ASSERT(op <= 20);
-	if (op < 19 || op > 20
-	    || value.length() == 0)
+	// Can't have an empty value (but can have empty key)
+	// Must be a value operator
+	Q_ASSERT(IsValueOperator(op));	// 19..20
+	if (!IsValueOperator(op) || value.length() == 0)
 	{
 		reset();
 	}
@@ -298,10 +294,8 @@ ObjectQuery::ObjectQuery(const ObjectQuery& first, ObjectQuery::Operator op, con
 {
 	// Both sub-queries must be valid.
 	// Must be a logical operator
-	Q_ASSERT(op >= 1);
-	Q_ASSERT(op <= 3);
-	if (op < 1 || op > 3
-	    || !first || !second)
+	Q_ASSERT(IsLogicalOperator(op));	// 1..3
+	if (!IsLogicalOperator(op) || !first || !second)
 	{
 		reset();
 	}
@@ -319,10 +313,8 @@ ObjectQuery::ObjectQuery(ObjectQuery&& first, ObjectQuery::Operator op, ObjectQu
 {
 	// Both sub-queries must be valid.
 	// Must be a logical operator
-	Q_ASSERT(op >= 1);
-	Q_ASSERT(op <= 3);
-	if (op < 1 || op > 3
-	    || !first || !second)
+	Q_ASSERT(IsLogicalOperator(op));	// 1..3
+	if (!IsLogicalOperator(op) || !first || !second)
 	{
 		reset();
 	}
@@ -535,14 +527,13 @@ bool ObjectQuery::operator()(const Object* object) const
 const ObjectQuery::LogicalOperands* ObjectQuery::logicalOperands() const
 {
 	const LogicalOperands* result = nullptr;
-	if (op >= 1 && op <= 3)
+	if (IsLogicalOperator(op))
 	{
 		result = &subqueries;
 	}
 	else
 	{
-		Q_ASSERT(op >= 1);
-		Q_ASSERT(op <= 3);
+		Q_ASSERT(IsLogicalOperator(op));
 	}
 	return result;
 }
@@ -551,14 +542,13 @@ const ObjectQuery::LogicalOperands* ObjectQuery::logicalOperands() const
 const ObjectQuery::StringOperands* ObjectQuery::tagOperands() const
 {
 	const StringOperands* result = nullptr;
-	if (op >= 16 && op <= 20)
+	if (IsStringOperator(op))	// 16..20
 	{
 		result = &tags;
 	}
 	else
 	{
-		Q_ASSERT(op >= 16);
-		Q_ASSERT(op <= 20);
+		Q_ASSERT(IsStringOperator(op));
 	}
 	return result;
 }
@@ -637,7 +627,7 @@ void ObjectQuery::reset()
 	{
 		; // nothing
 	}
-	else if (op < 16)
+	else if (IsLogicalOperator(op))
 	{
 		subqueries.~LogicalOperands();
 		op = ObjectQuery::OperatorInvalid;
@@ -662,7 +652,7 @@ void ObjectQuery::consume(ObjectQuery&& other)
 	{
 		; // nothing else
 	}
-	else if (op < 16)
+	else if (IsLogicalOperator(op))
 	{
 		new (&subqueries) ObjectQuery::LogicalOperands(std::move(other.subqueries));
 		other.subqueries.~LogicalOperands();

--- a/src/core/objects/object_query.h
+++ b/src/core/objects/object_query.h
@@ -1,6 +1,7 @@
 /*
  *    Copyright 2016 Mitchell Krome
  *    Copyright 2017-2025 Kai Pastor
+ *    Copyright 2025 Matthias Kühlewein
  *
  *    This file is part of OpenOrienteering.
  *
@@ -67,6 +68,12 @@ public:
 		
 		OperatorSearch   = 19, ///< Tests if the symbol name, a tag key or a tag value contains the given value (case-insensitive)
 		OperatorObjectText = 20, ///< Text object content (case-insensitive)
+		
+		// Operators 24 .. 27 operate on object properties
+		OperatorLess           = 24,
+		OperatorLessOrEqual    = 25,
+		OperatorGreater        = 26,
+		OperatorGreaterOrEqual = 27,
 		
 		// More operators, 32 ..
 		OperatorSymbol   = 32, ///< Test the symbol for equality.
@@ -206,12 +213,15 @@ private:
 	
 	//QVariant getObjectProperty(const Object* object, const StringOperands& tags) const;
 	bool getBooleanObjectProperty(const Object* object, const StringOperands& tags, bool& value) const;
+	//bool getDoubleObjectProperty(const Object* object, const StringOperands& tags, double& value) const;
 	bool isObjectProperty(const Object* object, const QString& tag_value) const;
+	bool compareObjectProperty(const Object* object, const StringOperands& tags, Operator op) const;
 	
 	bool IsLogicalOperator(Operator op) const { return op >= 1 && op <= 3; }
 	bool IsTagOperator(Operator op) const { return op >= 16 && op <= 18; }
 	bool IsValueOperator(Operator op) const { return op >= 19 && op <= 20; }
 	bool IsStringOperator(Operator op) const { return op >= 16 && op <= 20; }
+	bool IsNumericalOperator(Operator op) const { return op >= 24 && op <= 27; }
 	
 	using SymbolOperand = const Symbol*;
 	
@@ -292,6 +302,7 @@ public:
 		TokenNot,
 		TokenLeftParen,
 		TokenRightParen,
+		TokenNumericalOperator,
 	};
 	
 private:

--- a/src/core/objects/object_query.h
+++ b/src/core/objects/object_query.h
@@ -53,6 +53,7 @@ class ObjectQuery
 	Q_DECLARE_TR_FUNCTIONS(OpenOrienteering::ObjectQuery)
 	
 public:
+	// Important: When adding operators update the Is... functions below
 	enum Operator {
 		// Operators 1 .. 15 operate on other queries
 		OperatorAnd      = 1,  ///< And-chains two object queries
@@ -63,6 +64,7 @@ public:
 		OperatorIs       = 16, ///< Tests an existing tag for equality with the given value (case-sensitive)
 		OperatorIsNot    = 17, ///< Tests an existing tag for inequality with the given value (case-sensitive)
 		OperatorContains = 18, ///< Tests an existing tag for containing the given value (case-sensitive)
+		
 		OperatorSearch   = 19, ///< Tests if the symbol name, a tag key or a tag value contains the given value (case-insensitive)
 		OperatorObjectText = 20, ///< Text object content (case-insensitive)
 		
@@ -205,6 +207,11 @@ private:
 	//QVariant getObjectProperty(const Object* object, const StringOperands& tags) const;
 	bool getBooleanObjectProperty(const Object* object, const StringOperands& tags, bool& value) const;
 	bool isObjectProperty(const Object* object, const QString& tag_value) const;
+	
+	bool IsLogicalOperator(Operator op) const { return op >= 1 && op <= 3; }
+	bool IsTagOperator(Operator op) const { return op >= 16 && op <= 18; }
+	bool IsValueOperator(Operator op) const { return op >= 19 && op <= 20; }
+	bool IsStringOperator(Operator op) const { return op >= 16 && op <= 20; }
 	
 	using SymbolOperand = const Symbol*;
 	

--- a/src/core/objects/object_query.h
+++ b/src/core/objects/object_query.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2016 Mitchell Krome
- *    Copyright 2017-2024 Kai Pastor
+ *    Copyright 2017-2025 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -27,6 +27,7 @@
 #include <QMetaType>
 #include <QString>
 #include <QStringRef>
+#include <QVariant>
 
 namespace OpenOrienteering {
 
@@ -201,6 +202,10 @@ private:
 	 */
 	void consume(ObjectQuery&& other);
 	
+	//QVariant getObjectProperty(const Object* object, const StringOperands& tags) const;
+	bool getBooleanObjectProperty(const Object* object, const StringOperands& tags, bool& value) const;
+	bool isObjectProperty(const Object* object, const QString& tag_value) const;
+	
 	using SymbolOperand = const Symbol*;
 	
 	Operator op;
@@ -208,7 +213,7 @@ private:
 	union
 	{
 		LogicalOperands subqueries;
-		StringOperands     tags;
+		StringOperands  tags;
 		SymbolOperand   symbol;
 	};
 	
@@ -317,4 +322,4 @@ bool operator!=(const ObjectQuery::StringOperands& lhs, const ObjectQuery::Strin
 Q_DECLARE_METATYPE(OpenOrienteering::ObjectQuery::Operator)
 
 
-#endif
+#endif // OPENORIENTEERING_OBJECT_QUERY_H

--- a/src/core/objects/object_query.h
+++ b/src/core/objects/object_query.h
@@ -211,10 +211,7 @@ private:
 	 */
 	void consume(ObjectQuery&& other);
 	
-	//QVariant getObjectProperty(const Object* object, const StringOperands& tags) const;
 	bool getBooleanObjectProperty(const Object* object, const StringOperands& tags, bool& value) const;
-	//bool getDoubleObjectProperty(const Object* object, const StringOperands& tags, double& value) const;
-	bool isObjectProperty(const Object* object, const QString& tag_value) const;
 	bool compareObjectProperty(const Object* object, const StringOperands& tags, Operator op) const;
 	
 	bool IsLogicalOperator(Operator op) const { return op >= 1 && op <= 3; }

--- a/src/gui/map/map_find_feature.cpp
+++ b/src/gui/map/map_find_feature.cpp
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2017-2024 Kai Pastor
+ *    Copyright 2017-2020, 2024, 2025 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -103,11 +103,16 @@ void MapFindFeature::showDialog()
 		
 		tag_selector = new TagSelectWidget;
 		
+		auto find_all = new QPushButton(tr("Find &all"));
+		connect(find_all, &QPushButton::clicked, this, &MapFindFeature::findAll);
+		
 		auto find_next = new QPushButton(tr("&Find next"));
 		connect(find_next, &QPushButton::clicked, this, &MapFindFeature::findNext);
 		
-		auto find_all = new QPushButton(tr("Find &all"));
-		connect(find_all, &QPushButton::clicked, this, &MapFindFeature::findAll);
+		delete_find_next = new QPushButton(tr("Delete && Find next"));
+		connect(delete_find_next, &QPushButton::clicked, this, &MapFindFeature::deleteAndFindNext);
+		connect(controller.getMap(), &Map::objectSelectionChanged, this, &MapFindFeature::objectSelectionChanged);
+		objectSelectionChanged();
 		
 		auto tags_button = new QPushButton(tr("Query editor"));
 		tags_button->setCheckable(true);
@@ -117,7 +122,7 @@ void MapFindFeature::showDialog()
 		
 		auto button_box = new QDialogButtonBox(QDialogButtonBox::Close | QDialogButtonBox::Help);
 		connect(button_box, &QDialogButtonBox::rejected, &*find_dialog, &QDialog::hide);
-		connect(button_box->button(QDialogButtonBox::Help), &QPushButton::clicked, this, &MapFindFeature::showHelp);
+		connect(button_box, &QDialogButtonBox::helpRequested, this, &MapFindFeature::showHelp);
 		
 		editor_stack = new QStackedLayout();
 		editor_stack->addWidget(text_edit);
@@ -126,12 +131,13 @@ void MapFindFeature::showDialog()
 		connect(tags_button, &QAbstractButton::toggled, this, &MapFindFeature::tagSelectorToggled);
 		
 		auto layout = new QGridLayout;
-		layout->addLayout(editor_stack, 0, 0, 6, 1);
-		layout->addWidget(find_next, 0, 1, 1, 1);
-		layout->addWidget(find_all, 1, 1, 1, 1);
-		layout->addWidget(tags_button, 3, 1, 1, 1);
-		layout->addWidget(tag_selector_buttons, 5, 1, 1, 1);
-		layout->addWidget(button_box, 6, 0, 1, 2);
+		layout->addLayout(editor_stack, 0, 0, 7, 1);
+		layout->addWidget(find_all, 0, 1, 1, 1);
+		layout->addWidget(find_next, 1, 1, 1, 1);
+		layout->addWidget(delete_find_next, 2, 1, 1, 1);
+		layout->addWidget(tags_button, 4, 1, 1, 1);
+		layout->addWidget(tag_selector_buttons, 6, 1, 1, 1);
+		layout->addWidget(button_box, 7, 0, 1, 2);
 		
 		find_dialog->setLayout(layout);
 	}
@@ -140,7 +146,6 @@ void MapFindFeature::showDialog()
 	find_dialog->raise();
 	find_dialog->activateWindow();
 }
-
 
 
 ObjectQuery MapFindFeature::makeQuery() const
@@ -170,10 +175,14 @@ ObjectQuery MapFindFeature::makeQuery() const
 }
 
 
+// slot
 void MapFindFeature::findNext()
 {
 	auto map = controller.getMap();
 	auto first_object = map->getFirstSelectedObject();
+	// remember current selected object as start point in case next object found is deleted by 'Delete & Find Next'
+	if (first_object)
+		previous_object = first_object;
 	map->clearObjectSelection(false);
 	
 	Object* next_object = nullptr;
@@ -220,6 +229,21 @@ void MapFindFeature::findNext()
 }
 
 
+// slot
+void MapFindFeature::deleteAndFindNext()
+{
+	auto map = controller.getMap();
+	map->deleteSelectedObjects();
+	// restore start point for search in findNext() but only if the object still exists.
+	if (previous_object && map->getCurrentPart()->contains(previous_object))
+	{
+		map->addObjectToSelection(previous_object, false);
+	}
+	findNext();
+}
+
+
+// slot
 void MapFindFeature::findAll()
 {
 	auto map = controller.getMap();
@@ -244,12 +268,19 @@ void MapFindFeature::findAll()
 }
 
 
+// slot
+void MapFindFeature::objectSelectionChanged()
+{
+	auto map = controller.getMap();
+	delete_find_next->setEnabled(map->getNumSelectedObjects() == 1);
+}
 
+
+// slot
 void MapFindFeature::showHelp() const
 {
 	Util::showHelp(controller.getWindow(), "find_objects.html");
 }
-
 
 
 // slot

--- a/src/gui/map/map_find_feature.cpp
+++ b/src/gui/map/map_find_feature.cpp
@@ -35,7 +35,9 @@
 
 #include "core/map.h"
 #include "core/map_part.h"
+#include "core/objects/object.h"
 #include "core/objects/object_query.h"
+#include "core/symbols/symbol.h"
 #include "gui/main_window.h"
 #include "gui/util_gui.h"
 #include "gui/map/map_editor.h"
@@ -202,9 +204,11 @@ void MapFindFeature::findNext()
 				if (object == first_object)
 					first_object = nullptr;
 			}
-			else if (query(object))
+			else
 			{
-				next_object = object;
+				const auto* object_symbol = object->getSymbol();
+				if (!object_symbol->isProtected() && !object_symbol->isHidden() && query(object))
+					next_object = object;
 			}
 		}
 	};
@@ -255,10 +259,13 @@ void MapFindFeature::findAll()
 		controller.getWindow()->showStatusBarMessage(OpenOrienteering::TagSelectWidget::tr("Invalid query"), 2000);
 		return;
 	}
-	
+	auto search = [&query](const Object* object) {
+		const auto* object_symbol = object->getSymbol();
+		return !object_symbol->isProtected() && !object_symbol->isHidden() && query(object);
+	};
 	map->getCurrentPart()->applyOnMatchingObjects([map](Object* object) {
 		map->addObjectToSelection(object, false);
-	}, std::cref(query));
+	}, search);
 	map->emitSelectionChanged();
 	map->ensureVisibilityOfSelectedObjects(Map::FullVisibility);
 	controller.getWindow()->showStatusBarMessage(OpenOrienteering::TagSelectWidget::tr("%n object(s) selected", nullptr, map->getNumSelectedObjects()), 2000);

--- a/src/gui/map/map_find_feature.cpp
+++ b/src/gui/map/map_find_feature.cpp
@@ -1,5 +1,6 @@
 /*
  *    Copyright 2017-2020, 2024, 2025 Kai Pastor
+ *    Copyright 2025 Matthias Kühlewein
  *
  *    This file is part of OpenOrienteering.
  *
@@ -24,13 +25,16 @@
 
 #include <QAction>
 #include <QAbstractButton>
+#include <QContextMenuEvent>
 #include <QDialog>
 #include <QDialogButtonBox>
 #include <QGridLayout>
 #include <QKeySequence>  // IWYU pragma: keep
+#include <QMenu>
+#include <QPoint>
 #include <QPushButton>
 #include <QStackedLayout>
-#include <QTextEdit>
+#include <QVariant>
 #include <QWidget>
 
 #include "core/map.h"
@@ -46,7 +50,7 @@
 
 namespace OpenOrienteering {
 
-class Object;
+//class Object;
 
 MapFindFeature::MapFindFeature(MapEditorController& controller)
 : QObject{nullptr}
@@ -100,7 +104,7 @@ void MapFindFeature::showDialog()
 		find_dialog = new QDialog(window);
 		find_dialog->setWindowTitle(tr("Find objects"));
 		
-		text_edit = new QTextEdit;
+		text_edit = new MapFindTextEdit;
 		text_edit->setLineWrapMode(QTextEdit::WidgetWidth);
 		
 		tag_selector = new TagSelectWidget;
@@ -303,5 +307,37 @@ void MapFindFeature::tagSelectorToggled(bool active)
 	}
 }
 
+
+// slot
+void MapFindTextEdit::insertKeyword(QAction* action)
+{
+	const auto keyword = action->data().toString();
+	insertPlainText(keyword);
+}
+
+// override
+void MapFindTextEdit::contextMenuEvent(QContextMenuEvent* event)
+{
+	QMenu* menu = createStandardContextMenu(event->globalPos());
+	menu->addSeparator();
+	auto* insert_menu = new QMenu(tr("Insert keyword..."), menu);
+	insert_menu->menuAction()->setMenuRole(QAction::NoRole);
+	auto* keyword_actions_group = new QActionGroup(this);
+	
+	auto keywords = Object::getObjectProperties();
+	keywords.insert(keywords.end(), {QLatin1String("SYMBOL"), QLatin1String("AND"), QLatin1String("OR"), QLatin1String("NOT")});
+	for (auto& keyword : keywords)
+	{
+		auto* action = new QAction(keyword, this);
+		action->setData(QVariant(keyword));
+		keyword_actions_group->addAction(action);
+		insert_menu->addAction(action);
+	}
+	menu->addMenu(insert_menu);
+	connect(keyword_actions_group, &QActionGroup::triggered, this, &MapFindTextEdit::insertKeyword);
+	
+	menu->exec(event->globalPos());
+	delete menu;
+}
 
 }  // namespace OpenOrienteering

--- a/src/gui/map/map_find_feature.cpp
+++ b/src/gui/map/map_find_feature.cpp
@@ -25,6 +25,7 @@
 
 #include <QAction>
 #include <QAbstractButton>
+#include <QCheckBox>
 #include <QContextMenuEvent>
 #include <QDialog>
 #include <QDialogButtonBox>
@@ -120,6 +121,9 @@ void MapFindFeature::showDialog()
 		connect(controller.getMap(), &Map::objectSelectionChanged, this, &MapFindFeature::objectSelectionChanged);
 		objectSelectionChanged();
 		
+		center_view = new QCheckBox(tr("Center view"));
+		connect(center_view, &QCheckBox::stateChanged, this, &MapFindFeature::centerView);
+		
 		auto tags_button = new QPushButton(tr("Query editor"));
 		tags_button->setCheckable(true);
 		
@@ -141,9 +145,10 @@ void MapFindFeature::showDialog()
 		layout->addWidget(find_all, 0, 1, 1, 1);
 		layout->addWidget(find_next, 1, 1, 1, 1);
 		layout->addWidget(delete_find_next, 2, 1, 1, 1);
-		layout->addWidget(tags_button, 4, 1, 1, 1);
-		layout->addWidget(tag_selector_buttons, 6, 1, 1, 1);
-		layout->addWidget(button_box, 7, 0, 1, 2);
+		layout->addWidget(center_view, 3, 1, 1, 1);
+		layout->addWidget(tags_button, 5, 1, 1, 1);
+		layout->addWidget(tag_selector_buttons, 7, 1, 1, 1);
+		layout->addWidget(button_box, 8, 0, 1, 2);
 		
 		find_dialog->setLayout(layout);
 	}
@@ -230,7 +235,10 @@ void MapFindFeature::findNext()
 	if (next_object)
 		map->addObjectToSelection(next_object, false);
 	map->emitSelectionChanged();
-	map->ensureVisibilityOfSelectedObjects(Map::FullVisibility);
+	if (center_view->isChecked())
+		map->ensureVisibilityOfSelectedObjects(Map::CenterFullVisibility);
+	else
+		map->ensureVisibilityOfSelectedObjects(Map::FullVisibility);
 	
 	if (!map->selectedObjects().empty())
 		controller.setEditTool();
@@ -271,7 +279,10 @@ void MapFindFeature::findAll()
 		map->addObjectToSelection(object, false);
 	}, search);
 	map->emitSelectionChanged();
-	map->ensureVisibilityOfSelectedObjects(Map::FullVisibility);
+	if (center_view->isChecked())
+		map->ensureVisibilityOfSelectedObjects(Map::CenterFullVisibility);
+	else
+		map->ensureVisibilityOfSelectedObjects(Map::FullVisibility);
 	controller.getWindow()->showStatusBarMessage(OpenOrienteering::TagSelectWidget::tr("%n object(s) selected", nullptr, map->getNumSelectedObjects()), 2000);
 	
 	if (!map->selectedObjects().empty())
@@ -284,6 +295,18 @@ void MapFindFeature::objectSelectionChanged()
 {
 	auto map = controller.getMap();
 	delete_find_next->setEnabled(map->getNumSelectedObjects() == 1);
+}
+
+
+// slot
+void MapFindFeature::centerView()
+{
+	if (center_view->isChecked())
+	{
+		auto map = controller.getMap();
+		if (map->getNumSelectedObjects())
+			map->ensureVisibilityOfSelectedObjects(Map::CenterFullVisibility);
+	}
 }
 
 

--- a/src/gui/map/map_find_feature.h
+++ b/src/gui/map/map_find_feature.h
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2017 Kai Pastor
+ *    Copyright 2017-2019, 2025 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -27,6 +27,7 @@
 
 class QAction;
 class QDialog;
+class QPushButton;
 class QStackedLayout;
 class QTextEdit;
 class QWidget;
@@ -34,6 +35,7 @@ class QWidget;
 namespace OpenOrienteering {
 
 class MapEditorController;
+class Object;
 class ObjectQuery;
 class TagSelectWidget;
 
@@ -56,22 +58,28 @@ public:
 	
 	void setEnabled(bool enabled);
 	
-	QAction* showDialogAction() { return show_action; }
+	QAction* showDialogAction() const { return show_action; }
 	
-	QAction* findNextAction() { return find_next_action; }
+	QAction* findNextAction() const { return find_next_action; }
+	
+private slots:
+	void findNext();
+	
+	void deleteAndFindNext();
+	
+	void findAll();
+	
+	void objectSelectionChanged();
+	
+	void showHelp() const;
+	
+	void tagSelectorToggled(bool active);
 	
 private:
 	void showDialog();
 	
 	ObjectQuery makeQuery() const;
 	
-	void findNext();
-	
-	void findAll();
-	
-	void showHelp() const;
-	
-	void tagSelectorToggled(bool active);
 	
 	MapEditorController& controller;
 	QPointer<QDialog> find_dialog;           // child of controller's window
@@ -79,8 +87,11 @@ private:
 	QTextEdit* text_edit = nullptr;          // child of find_dialog
 	TagSelectWidget* tag_selector = nullptr; // child of find_dialog
 	QWidget* tag_selector_buttons = nullptr; // child of find_dialog
+	QPushButton* delete_find_next = nullptr; // child of find_dialog
 	QAction* show_action = nullptr;          // child of this
 	QAction* find_next_action = nullptr;     // child of this
+	
+	Object* previous_object = nullptr;
 	
 	Q_DISABLE_COPY(MapFindFeature)
 };
@@ -88,4 +99,4 @@ private:
 
 }  // namespace OpenOrienteering
 
-#endif
+#endif // OPENORIENTEERING_MAP_FIND_FEATURE_H

--- a/src/gui/map/map_find_feature.h
+++ b/src/gui/map/map_find_feature.h
@@ -24,12 +24,13 @@
 #include <QObject>
 #include <QPointer>
 #include <QString>
+#include <QTextEdit>
 
 class QAction;
+class QContextMenuEvent;
 class QDialog;
 class QPushButton;
 class QStackedLayout;
-class QTextEdit;
 class QWidget;
 
 namespace OpenOrienteering {
@@ -38,6 +39,22 @@ class MapEditorController;
 class Object;
 class ObjectQuery;
 class TagSelectWidget;
+
+
+/**
+ * The context menu (right click) is extended by the possibility to insert
+ * one of the keywords (e.g., SYMBOL, AND...)
+ */
+class MapFindTextEdit : public QTextEdit
+{
+	Q_OBJECT
+	
+private:
+	void contextMenuEvent(QContextMenuEvent* event) override;
+	
+private slots:
+	void insertKeyword(QAction* action);
+};
 
 
 /**
@@ -84,7 +101,7 @@ private:
 	MapEditorController& controller;
 	QPointer<QDialog> find_dialog;           // child of controller's window
 	QStackedLayout* editor_stack = nullptr;  // child of find_dialog
-	QTextEdit* text_edit = nullptr;          // child of find_dialog
+	MapFindTextEdit* text_edit = nullptr;    // child of find_dialog
 	TagSelectWidget* tag_selector = nullptr; // child of find_dialog
 	QWidget* tag_selector_buttons = nullptr; // child of find_dialog
 	QPushButton* delete_find_next = nullptr; // child of find_dialog
@@ -95,7 +112,6 @@ private:
 	
 	Q_DISABLE_COPY(MapFindFeature)
 };
-
 
 }  // namespace OpenOrienteering
 

--- a/src/gui/map/map_find_feature.h
+++ b/src/gui/map/map_find_feature.h
@@ -1,5 +1,6 @@
 /*
  *    Copyright 2017-2019, 2025 Kai Pastor
+ *    Copyright 2025 Matthias Kühlewein
  *
  *    This file is part of OpenOrienteering.
  *
@@ -27,6 +28,7 @@
 #include <QTextEdit>
 
 class QAction;
+class QCheckBox;
 class QContextMenuEvent;
 class QDialog;
 class QPushButton;
@@ -42,8 +44,8 @@ class TagSelectWidget;
 
 
 /**
- * The context menu (right click) is extended by the possibility to insert
- * one of the keywords (e.g., SYMBOL, AND...)
+ * The context menu (right click) is extended by the possibility
+ * to select and insert one of the keywords (e.g., SYMBOL, AND...)
  */
 class MapFindTextEdit : public QTextEdit
 {
@@ -88,6 +90,8 @@ private slots:
 	
 	void objectSelectionChanged();
 	
+	void centerView();
+	
 	void showHelp() const;
 	
 	void tagSelectorToggled(bool active);
@@ -105,6 +109,7 @@ private:
 	TagSelectWidget* tag_selector = nullptr; // child of find_dialog
 	QWidget* tag_selector_buttons = nullptr; // child of find_dialog
 	QPushButton* delete_find_next = nullptr; // child of find_dialog
+	QCheckBox* center_view = nullptr;        // child of find_dialog
 	QAction* show_action = nullptr;          // child of this
 	QAction* find_next_action = nullptr;     // child of this
 	

--- a/src/gui/map/map_widget.cpp
+++ b/src/gui/map/map_widget.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012-2014 Thomas Schöps
- *    Copyright 2013-2020 Kai Pastor
+ *    Copyright 2013-2020, 2025 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -426,7 +426,7 @@ void MapWidget::moveMap(int steps_x, int steps_y)
 	}
 }
 
-void MapWidget::ensureVisibilityOfRect(QRectF map_rect, ZoomOption zoom_option)
+void MapWidget::ensureVisibilityOfRect(QRectF map_rect, ZoomOption zoom_option, bool center_view)
 {
 	// Amount in pixels that is scrolled "too much" if the rect is not completely visible
 	// TODO: change to absolute size using dpi value
@@ -436,7 +436,11 @@ void MapWidget::ensureVisibilityOfRect(QRectF map_rect, ZoomOption zoom_option)
 	// TODO: this method assumes that the viewport is not rotated.
 	
 	if (rect().contains(viewport_rect.topLeft()) && rect().contains(viewport_rect.bottomRight()))
+	{
+		if (center_view)
+			view->setCenter(MapCoord{ map_rect.center() });
 		return;
+	}
 	
 	auto offset = MapCoordF{ 0, 0 };
 	
@@ -451,7 +455,12 @@ void MapWidget::ensureVisibilityOfRect(QRectF map_rect, ZoomOption zoom_option)
 		offset.ry() = view->pixelToLength(viewport_rect.bottom() - height() + pixel_border) / 1000.0;
 	
 	if (!qIsNull(offset.lengthSquared()))
-		view->setCenter(view->center() + offset);
+	{
+		if (center_view)
+			view->setCenter(MapCoord{ map_rect.center() });
+		else
+			view->setCenter(view->center() + offset);
+	}
 	
 	// If the rect is still not completely in view, we have to zoom out
 	viewport_rect = mapToViewport(map_rect).toAlignedRect();

--- a/src/gui/map/map_widget.h
+++ b/src/gui/map/map_widget.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012-2014 Thomas Schöps
- *    Copyright 2013-2020 Kai Pastor
+ *    Copyright 2013-2020, 2025 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -214,7 +214,7 @@ public:
 	/**
 	 * Adjusts the viewport so the given rect is inside the view.
 	 */
-	void ensureVisibilityOfRect(QRectF map_rect, ZoomOption zoom_option);  // clazy:exclude=function-args-by-ref
+	void ensureVisibilityOfRect(QRectF map_rect, ZoomOption zoom_option, bool center_view = false);  // clazy:exclude=function-args-by-ref
 	
 	/**
 	 * Sets the view so the rect is centered and zooomed to fill the widget.
@@ -584,4 +584,4 @@ MapWidget::CoordsType MapWidget::getCoordsDisplay() const
 
 }  // namespace OpenOrienteering
 
-#endif
+#endif // OPENORIENTEERING_MAP_WIDGET_H


### PR DESCRIPTION
Search for dynamic object properties (see #2341), e.g.,:
- object violates minimum area or line length constraints
- object area size / object line length is smaller/greater than a specific value
- object has no symbol

The mechanism to find objects is extended by the possibility to delete a selected object and search for the next matching object.
Optionally center the view to the found object(s).
The text editor allows to select and insert keywords on right click.

Note that the keywords to search for dynamic object properties are preliminary.