### PR TITLE
PointSymbolEditorWidget: Hide oriented-to-north for area symbol patterns

### DIFF
--- a/src/gui/symbols/area_symbol_settings.cpp
+++ b/src/gui/symbols/area_symbol_settings.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2010, 2025 Kai Pastor
+ *    Copyright 2012-2020, 2025 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *

--- a/src/gui/symbols/area_symbol_settings.cpp
+++ b/src/gui/symbols/area_symbol_settings.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2017 Kai Pastor
+ *    Copyright 2012-2010, 2025 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -321,7 +321,7 @@ void AreaSymbolSettings::loadPatterns()
 		pattern_list->addItem(pattern.name);
 		if (pattern.type == AreaSymbol::FillPattern::PointPattern)
 		{
-			auto editor = new PointSymbolEditorWidget(controller, pattern.point, 16);
+			auto editor = new PointSymbolEditorWidget(controller, pattern.point, PointSymbolEditorWidget::AreaSymbolElement, 16);
 			connect(editor, &PointSymbolEditorWidget::symbolEdited, this, &SymbolPropertiesWidget::propertiesModified );
 			addPropertiesGroup(pattern.name, editor);
 		}
@@ -451,7 +451,7 @@ void AreaSymbolSettings::addPattern(AreaSymbol::FillPattern::Type type)
 	{
 		active_pattern->point = new PointSymbol();
 		active_pattern->point->setRotatable(true);
-		auto editor = new PointSymbolEditorWidget(controller, active_pattern->point, 16);
+		auto editor = new PointSymbolEditorWidget(controller, active_pattern->point, PointSymbolEditorWidget::AreaSymbolElement, 16);
 		connect(editor, &PointSymbolEditorWidget::symbolEdited, this, &SymbolPropertiesWidget::propertiesModified );
 		if (pattern_list->currentRow() == int(symbol->patterns.size()) - 1)
 		{

--- a/src/gui/symbols/line_symbol_settings.cpp
+++ b/src/gui/symbols/line_symbol_settings.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2019, 2024 Kai Pastor
+ *    Copyright 2012-2019, 2024, 2025 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -327,7 +327,7 @@ LineSymbolSettings::LineSymbolSettings(LineSymbol* symbol, SymbolSettingDialog* 
 	symbol->ensurePointSymbols(tr("Start symbol"), tr("Mid symbol"), tr("End symbol"), tr("Dash symbol"));
 	for (auto point_symbol : { symbol->getStartSymbol(), symbol->getMidSymbol(), symbol->getEndSymbol(), symbol->getDashSymbol() })
 	{
-		point_symbol_editor = new PointSymbolEditorWidget(controller, point_symbol, 16);
+		point_symbol_editor = new PointSymbolEditorWidget(controller, point_symbol, PointSymbolEditorWidget::LineSymbolElement, 16);
 		addPropertiesGroup(point_symbol->getName(), point_symbol_editor);
 		connect(point_symbol_editor, &PointSymbolEditorWidget::symbolEdited, this, &LineSymbolSettings::pointSymbolEdited);
 	}
@@ -818,7 +818,7 @@ void LineSymbolSettings::reset(Symbol* symbol)
 	this->symbol->ensurePointSymbols(tr("Start symbol"), tr("Mid symbol"), tr("End symbol"), tr("Dash symbol"));
 	for (auto point_symbol : { this->symbol->getStartSymbol(), this->symbol->getMidSymbol(), this->symbol->getEndSymbol(), this->symbol->getDashSymbol() })
 	{
-		point_symbol_editor = new PointSymbolEditorWidget(controller, point_symbol, 16);
+		point_symbol_editor = new PointSymbolEditorWidget(controller, point_symbol, PointSymbolEditorWidget::LineSymbolElement, 16);
 		connect(point_symbol_editor, &PointSymbolEditorWidget::symbolEdited, this, &LineSymbolSettings::pointSymbolEdited);
 		
 		int index = indexOfPropertiesGroup(point_symbol->getName()); // existing symbol editor

--- a/src/gui/symbols/point_symbol_editor_widget.cpp
+++ b/src/gui/symbols/point_symbol_editor_widget.cpp
@@ -24,9 +24,9 @@
 #include <algorithm>
 #include <limits>
 // IWYU pragma: no_include <memory>
+// IWYU pragma: no_include <vector>
 
 #include <Qt>
-#include <QAbstractButton>
 #include <QAbstractItemView>
 #include <QCheckBox>
 #include <QComboBox>
@@ -83,11 +83,10 @@ PointSymbolEditorWidget::PointSymbolEditorWidget(MapEditorController* controller
 , symbol(symbol)
 , object_origin_coord(0, offset_y)
 , offset_y(offset_y)
+, map(controller->getMap())
 , controller(controller)
 , permanent_preview(role == PrimarySymbol)
 {
-	map = controller->getMap();
-	
 	if (permanent_preview)
 	{
 		midpoint_object = new PointObject(symbol);

--- a/src/gui/symbols/point_symbol_editor_widget.cpp
+++ b/src/gui/symbols/point_symbol_editor_widget.cpp
@@ -97,6 +97,7 @@ PointSymbolEditorWidget::PointSymbolEditorWidget(MapEditorController* controller
 	
 	oriented_to_north = new QCheckBox(tr("Always oriented to north (not rotatable)"));
 	oriented_to_north->setChecked(!symbol->isRotatable());
+	oriented_to_north->setVisible(role != AreaSymbolElement);
 	
 	auto* elements_label = Util::Headline::create(tr("Elements"));
 	element_list = new QListWidget();

--- a/src/gui/symbols/point_symbol_editor_widget.cpp
+++ b/src/gui/symbols/point_symbol_editor_widget.cpp
@@ -78,13 +78,13 @@
 
 namespace OpenOrienteering {
 
-PointSymbolEditorWidget::PointSymbolEditorWidget(MapEditorController* controller, PointSymbol* symbol, qreal offset_y, bool permanent_preview, QWidget* parent)
+PointSymbolEditorWidget::PointSymbolEditorWidget(MapEditorController* controller, PointSymbol* symbol, SymbolRole role, qreal offset_y, QWidget* parent)
 : QWidget(parent)
 , symbol(symbol)
 , object_origin_coord(0, offset_y)
 , offset_y(offset_y)
 , controller(controller)
-, permanent_preview(permanent_preview)
+, permanent_preview(role == PrimarySymbol)
 {
 	map = controller->getMap();
 	

--- a/src/gui/symbols/point_symbol_editor_widget.h
+++ b/src/gui/symbols/point_symbol_editor_widget.h
@@ -62,13 +62,21 @@ class PointSymbolEditorWidget : public QWidget
 Q_OBJECT
 friend class PointSymbolEditorActivity;
 public:
+    /** Describes the role of the symbol to be edited. */
+    enum SymbolRole {
+		PrimarySymbol,      ///< A primary point symbol
+		AreaSymbolElement,  ///< A symbol used in an area symbol fill pattern
+		LineSymbolElement,  ///< A symbol used for decorating a line symbol
+	};
+	
 	/** Construct a new widget.
 	 * @param controller The controller of the preview map
 	 * @param symbol The point symbol to be edited
+	 * @param role The role of the symbol to be edited
 	 * @param offset_y The vertical offset of the point symbol preview/editor from the origin
-	 * @param permanent_preview A flag indicating whether the preview shall be visible even if the editor is not visible
+	 * @param parent Standard QWidget parentship
 	 */
-	PointSymbolEditorWidget(MapEditorController* controller, PointSymbol* symbol, qreal offset_y = 0, bool permanent_preview = false, QWidget* parent = 0);
+	PointSymbolEditorWidget(MapEditorController* controller, PointSymbol* symbol, SymbolRole role = PrimarySymbol, qreal offset_y = 0, QWidget* parent = nullptr);
 	
 	~PointSymbolEditorWidget() override;
 	

--- a/src/gui/symbols/point_symbol_settings.cpp
+++ b/src/gui/symbols/point_symbol_settings.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2017 Kai Pastor
+ *    Copyright 2012-2018, 2025 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -49,7 +49,7 @@ PointSymbolSettings::PointSymbolSettings(PointSymbol* symbol, SymbolSettingDialo
 : SymbolPropertiesWidget(symbol, dialog), 
   symbol(symbol)
 {
-	symbol_editor = new PointSymbolEditorWidget(dialog->getPreviewController(), symbol, 0, true);
+	symbol_editor = new PointSymbolEditorWidget(dialog->getPreviewController(), symbol);
 	connect(symbol_editor, &PointSymbolEditorWidget::symbolEdited, this, &SymbolPropertiesWidget::propertiesModified );
 	
 	layout = new QVBoxLayout();
@@ -81,7 +81,7 @@ void PointSymbolSettings::reset(Symbol* symbol)
 	layout->removeWidget(symbol_editor);
 	delete(symbol_editor);
 	
-	symbol_editor = new PointSymbolEditorWidget(dialog->getPreviewController(), this->symbol, 0, true);
+	symbol_editor = new PointSymbolEditorWidget(dialog->getPreviewController(), this->symbol);
 	connect(symbol_editor, &PointSymbolEditorWidget::symbolEdited, this, &SymbolPropertiesWidget::propertiesModified );
 	layout->addWidget(symbol_editor);
 }


### PR DESCRIPTION
Complements #2378. 

The point symbol editor widget is used for pattern fills in area symbols. It featured the "Always oriented to north (not rotatable)" checkbox, but this checkbox didn't have an effect in that use case. This PR hides the checkbox. This should reduce confusion, in particular with the same checkbox added to the area symbol itself in #2378.

NB: The checkbox has an effect for line symbol decorators. I wouldn't say it is intented, but I don't want to change this now.