### PR TITLE
CI: Roll windows images to 2022

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -341,7 +341,7 @@ jobs:
   displayName: Windows x32 (Release, MinGW)
   timeoutInMinutes: 90
   variables:
-    IMAGE_NAME: 'windows-2019'
+    IMAGE_NAME: 'windows-2022'
     SUPERBUILD_IMAGE_NAME: $(IMAGE_NAME)
     SUPERBUILD_INSTALL_DIR: 'C:/msys2'
     MINGW: mingw32
@@ -369,7 +369,7 @@ jobs:
   displayName: Windows x64 (Release, MinGW)
   timeoutInMinutes: 90
   variables:
-    IMAGE_NAME: 'windows-2019'
+    IMAGE_NAME: 'windows-2022'
     SUPERBUILD_IMAGE_NAME: $(IMAGE_NAME)
     SUPERBUILD_INSTALL_DIR: 'C:/msys2'
     MINGW: mingw64


### PR DESCRIPTION
Fixes GH-2367.

CI is already modified to use the artifacts from the update superbuild.