### PR TITLE
MapCoordF: Declare copy assignment operator

### DIFF
--- a/src/core/map_coord.h
+++ b/src/core/map_coord.h
@@ -547,6 +547,9 @@ public:
 	
 	
 	/** Assignment operator. */
+	constexpr MapCoordF& operator= (const MapCoordF& point) noexcept = default;
+	
+	/** Assignment operator. */
 	MapCoordF& operator= (const QPointF& point) noexcept;
 	
 	


### PR DESCRIPTION
Get rid of warnings about deprecated language pattern.