### PR TITLE
PaintOnTemplateFeature: Use QImageWriter

### DIFF
--- a/src/templates/paint_on_template_feature.cpp
+++ b/src/templates/paint_on_template_feature.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2020 Kai Pastor
+ *    Copyright 2012-2020, 2025 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -37,6 +37,7 @@
 #include <QFontMetrics>
 #include <QIcon>
 #include <QImage>
+#include <QImageWriter>
 #include <QLatin1Char>
 #include <QLatin1String>
 #include <QList>
@@ -332,12 +333,13 @@ Template* PaintOnTemplateFeature::setupTemplate() const
 	}
 	else
 	{
-		auto image = makeImage(filename);
-		if (!image.save(image_file_path))
+		const auto image = makeImage(filename);
+		QImageWriter writer(image_file_path);
+		if (!writer.write(image))
 		{
 			showMessage(window,
 			            OpenOrienteering::MapEditorController::tr("Cannot save file\n%1:\n%2")
-			            .arg(filename, QString{}));
+			            .arg(filename, writer.errorString()));
 			return nullptr;
 		}
 		remove_file = true;


### PR DESCRIPTION
The 'save' method of QImage does not provide an error description, therefore use QImageWriter instead.