### PR TITLE
TemplateListWidget: Fix cancelling map import

### DIFF
--- a/src/gui/widgets/template_list_widget.cpp
+++ b/src/gui/widgets/template_list_widget.cpp
@@ -861,7 +861,6 @@ void TemplateListWidget::importClicked()
 		prototype->getTransform(transform);
 	
 	Map template_map;
-	bool ok = true;
 	if (qstrcmp(prototype->getTemplateType(), "OgrTemplate") == 0)
 	{
 		template_map.importMap(*prototype->templateMap(), Map::MinimalObjectImport);
@@ -908,12 +907,13 @@ void TemplateListWidget::importClicked()
 			scale_options.append(tr("Scale by current template scaling (%1 %)").arg(locale().toString(current_scale * 100.0, 'f', 1)));
 		if (!scale_options.isEmpty())
 		{
+			bool ok;
 			scale_options.prepend(tr("Don't scale"));
 			QString option = QInputDialog::getItem( window(),
 			  tr("Template import"),
 			  tr("How shall the symbols of the imported template map be scaled?"),
 			  scale_options, 0, false, &ok );
-			if (option.isEmpty())
+			if (!ok || option.isEmpty())
 				return;
 			else if (option == scale_options[0])
 				Q_ASSERT(scale == 1.0);
@@ -923,7 +923,7 @@ void TemplateListWidget::importClicked()
 				scale = current_scale;
 		}
 		
-		if (ok && scale != 1.0)
+		if (scale != 1.0)
 				template_map.scaleAllSymbols(scale);
 	}
 	else


### PR DESCRIPTION
The import of a map that was loaded as a template before may invoke a dialog to select scaling options.
The Cancel button however did not cancel the import as expected (since `option.isEmpty()` is not possible to become true as editing is disabled (but it's ok to keep it)).