### PR TITLE
Fix OCD text framing import/export

### DIFF
--- a/src/fileformats/ocd_file_export.cpp
+++ b/src/fileformats/ocd_file_export.cpp
@@ -1877,6 +1877,7 @@ QByteArray OcdFileExport::exportTextSymbol(const TextSymbol* text_symbol, quint3
 	setupTextSymbolExtra(text_symbol, ocd_symbol);
 	setupTextSymbolBasic(text_symbol, alignment, ocd_symbol.basic);
 	setupTextSymbolSpecial(text_symbol, ocd_symbol.special);
+	setupTextSymbolFraming(text_symbol, ocd_symbol.framing);
 	
 	auto header_size = int(sizeof(OcdTextSymbol));
 	ocd_symbol.base.size = decltype(ocd_symbol.base.size)(header_size);
@@ -1963,6 +1964,8 @@ void OcdFileExport::setupTextSymbolFraming(const TextSymbol* text_symbol, OcdTex
 	if (text_symbol->getFramingColor())
 	{
 		ocd_text_framing.color = convertColor(text_symbol->getFramingColor());
+		if (ocd_version >= 9)
+			ocd_text_framing.line_style_V9 = 4;		// Default value
 		switch (text_symbol->getFramingMode())
 		{
 		case TextSymbol::NoFraming:

--- a/src/fileformats/ocd_file_import.cpp
+++ b/src/fileformats/ocd_file_import.cpp
@@ -2355,7 +2355,13 @@ void OcdFileImport::setFraming(OcdFileImport::OcdImportedTextSymbol* symbol, con
 	case Ocd::FramingLine: // since V7
 		symbol->framing = true;
 		symbol->framing_mode = TextSymbol::LineFraming;
+		symbol->framing_color = convertColor(framing.color);
 		symbol->framing_line_half_width = convertLength(framing.line_width);
+		if (ocd_version >= 9)
+		{
+			if (framing.line_style_V9 != 0 && framing.line_style_V9 != 4)
+				addSymbolWarning(symbol, tr("Ignoring text framing line style."));
+		}
 		break;
 	case Ocd::FramingRectangle:
 	default:

--- a/src/fileformats/ocd_types_v8.h
+++ b/src/fileformats/ocd_types_v8.h
@@ -353,8 +353,8 @@ namespace Ocd
 		quint16 line_width;
 		quint16 font_weight;             /// TextSymbol only
 		quint16 italic;                  /// TextSymbol only
-		quint16 offset_x;
-		quint16 offset_y;
+		qint16 offset_x;
+		qint16 offset_y;
 	};
 
 	struct TextSymbolV8


### PR DESCRIPTION
Fix type of horizontal and vertical offsets for text symbol shadow framing to be signed.
Call already existing function to setup the text symbol framing attributes for OCD export.
Import color when importing a text symbol with line framing and issue warning for unsupported lines styles.

Closes GH-2418 (OCAD import and export of text framing is buggy).