### PR TITLE
TemplateListWidget: Consider cancellation of template georeferencing

### DIFF
--- a/src/gui/widgets/template_list_widget.cpp
+++ b/src/gui/widgets/template_list_widget.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2020 Kai Pastor
+ *    Copyright 2012-2020, 2025 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -964,8 +964,12 @@ void TemplateListWidget::changeGeorefClicked()
 	auto* templ = currentTemplate();
 	if (templ && templ->canChangeTemplateGeoreferenced())
 	{
-		auto new_value = !templ->isTemplateGeoreferenced();
-		if (new_value)
+		if (!templ->trySetTemplateGeoreferenced(!templ->isTemplateGeoreferenced(), this))
+		{
+			QMessageBox::warning(this, tr("Error"), tr("Cannot change the georeferencing state."));
+		}
+		georef_action->setChecked(templ->isTemplateGeoreferenced());
+		if (templ->isTemplateGeoreferenced())
 		{
 			// Properly tear down positioning activities
 			if (move_by_hand_action->isChecked())
@@ -974,11 +978,6 @@ void TemplateListWidget::changeGeorefClicked()
 				adjust_button->click();
 			if (position_action->isChecked())
 				position_action->trigger();
-		}
-		if (!templ->trySetTemplateGeoreferenced(new_value, this))
-		{
-			QMessageBox::warning(this, tr("Error"), tr("Cannot change the georeferencing state."));
-			georef_action->setChecked(templ->isTemplateGeoreferenced());
 		}
 	}
 }


### PR DESCRIPTION
If the user activates georeferencing for a template where georeferencing was switched off, a dialog will show up to select the coordinate reference system. If the dialog was cancelled the 'Georeferenced' checkmark would be set and 'Positioning' would be discarded as if coordinate reference system selection succeeded.