### PR TITLE
MapEditorController: Block graphical export while editing

### DIFF
--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2021, 2024 Kai Pastor
+ *    Copyright 2012-2021, 2024, 2025 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -1844,6 +1844,14 @@ void MapEditorController::exportVector()
 void MapEditorController::printClicked(int task)
 {
 #ifdef QT_PRINTSUPPORT_LIB
+	if (editing_in_progress)
+	{
+		QMessageBox::warning(window,
+		                     tr("Editing in progress"),
+		                     tr("The map is currently being edited. "
+		                        "Please finish the edit operation first.") );
+		return;
+	}
 	if (!print_dock_widget)
 	{
 		print_dock_widget = new EditorDockWidget(QString{}, nullptr, this, window);


### PR DESCRIPTION
If the Clip/Erase Area tool was activated and then interrupted by a graphical export (e.g., printing, PDF export), Mapper crashed after closing the graphical export dialog.
Show a warning that the editing operation needs to be finished first and block the graphical export.

Closes GH-2435 (Crash when interrupting Clip/Erase Area tool by graphical export).