### PR TITLE
CombinedSymbol: Fix nullptr dereferencing

### DIFF
--- a/src/core/symbols/combined_symbol.cpp
+++ b/src/core/symbols/combined_symbol.cpp
@@ -85,7 +85,7 @@ CombinedSymbol* CombinedSymbol::duplicate() const
 
 bool CombinedSymbol::validate() const
 {
-	return std::all_of(begin(parts), end(parts), [](auto& symbol) { return symbol->validate(); });
+	return std::all_of(begin(parts), end(parts), [](auto& symbol) { return !symbol || symbol->validate(); });
 }
 
 


### PR DESCRIPTION
Add check for empty subsymbols when iterating over combined symbols.