### PR TITLE
OgrFileExport: Fix GeoJSON export

### DIFF
--- a/src/gdal/ogr_file_format.cpp
+++ b/src/gdal/ogr_file_format.cpp
@@ -2188,6 +2188,7 @@ void OgrFileExport::setupQuirks(GDALDriverH po_driver)
 	    { "DGNv8",         GeorefOptional },
 	    { "DWG",           GeorefOptional },
 	    { "DXF",           OgrQuirks() | GeorefOptional | SingleLayer | UseLayerField },
+	    { "GeoJSON",       SingleLayer },
 	    { "Geomedia",      GeorefOptional },
 	    { "GPX",           NeedsWgs84 },
 	    { "INGRES",        GeorefOptional },


### PR DESCRIPTION
The GeoJSON driver doesn't support multilayer creation. Add quirk to enforce single layer export.

Closes GH-2314 (GeoJSON export failing - driver quirk).