### PR TITLE
Fix: Flatten OGR curve geometries (CurvePolygon) to polygons before import

### DIFF
--- a/src/gdal/ogr_file_format.cpp
+++ b/src/gdal/ogr_file_format.cpp
@@ -1059,7 +1059,16 @@ void OgrFileImport::importLayer(MapPart* map_part, OGRLayerH layer)
 			++empty_geometries;
 			continue;
 		}
-		
+				
+		if (OGR_G_HasCurveGeometry(geometry, 1)) {
+			OGRGeometryH linear_geom = OGR_G_GetLinearGeometry(geometry, 0, nullptr);
+			if (linear_geom) {
+				OGR_F_SetGeometryDirectly(feature.get(), linear_geom);
+				geometry = linear_geom;
+			}
+		}
+
+		OGR_G_FlattenTo2D(geometry);
 		importFeature(map_part, feature_definition, feature.get(), geometry, clipping.get());
 	}
 }


### PR DESCRIPTION
Hello,

This PR fixes an issue where geometries of type `CurvePolygon` ("polygonZ" in the attached picture, sometimes used in gpkg data, e.g., Czech Cadastral maps) were ignored or imported as empty geometries by the OGR importer.
![Not_Loaded](https://github.com/user-attachments/assets/32e12466-dd11-4692-9b3c-46cfd936c83f)

Changes:
- Added a check for `OGR_G_HasCurveGeometry`.
- If a curve geometry is detected, it is converted to a linear approximation using `OGR_G_GetLinearGeometry` before processing.

This ensures that these complex polygon types are correctly imported as standard polygons.