### PR TITLE
XMLFileImporter: Fix print area readjustment

### DIFF
--- a/src/fileformats/xml_file_format.cpp
+++ b/src/fileformats/xml_file_format.cpp
@@ -338,7 +338,6 @@ void XMLFileExporter::exportColors()
 		{
 			XmlElementWriter spotcolors_element(xml, literal::spotcolors);
 			spotcolors_element.writeAttribute(literal::knockout, color->getKnockout());
-			SpotColorComponent component;
 			switch (color->getSpotColorMethod())
 			{
 				case MapColor::SpotColor:
@@ -582,7 +581,7 @@ bool XMLFileImporter::importImplementation()
 		
 		// Verify the adjusted print area, and readjust if necessary
 		if (print_area.top() <= -1000000.0 || print_area.bottom() > 1000000.0)
-			print_area.moveTop(-print_area.width() / 2);
+			print_area.moveTop(-print_area.height() / 2);
 		if (print_area.left() <= -1000000.0 || print_area.right() > 1000000.0)
 			print_area.moveLeft(-print_area.width() / 2);
 		

--- a/test/file_format_t.cpp
+++ b/test/file_format_t.cpp
@@ -820,9 +820,9 @@ void FileFormatTest::issue_513_high_coordinates()
 	{
 		auto const* part = map.getPart(0);
 		auto extent = part->calculateExtent(true);
-		QVERIFY2(extent.top()    <  1000000.0, "extent.top() outside printable range");
+		QVERIFY2(extent.top()    > -1000000.0, "extent.top() outside printable range");
 		QVERIFY2(extent.left()   > -1000000.0, "extent.left() outside printable range");
-		QVERIFY2(extent.bottom() > -1000000.0, "extent.bottom() outside printable range");
+		QVERIFY2(extent.bottom() <  1000000.0, "extent.bottom() outside printable range");
 		QVERIFY2(extent.right()  <  1000000.0, "extent.right() outside printable range");
 		
 		QCOMPARE(part->getNumObjects(), 2);
@@ -834,9 +834,9 @@ void FileFormatTest::issue_513_high_coordinates()
 	}
 	
 	auto print_area = map.printerConfig().print_area;
-	QVERIFY2(print_area.top()    <  1000000.0, "print_area.top() outside printable range");
+	QVERIFY2(print_area.top()    > -1000000.0, "print_area.top() outside printable range");
 	QVERIFY2(print_area.left()   > -1000000.0, "print_area.left() outside printable range");
-	QVERIFY2(print_area.bottom() > -1000000.0, "print_area.bottom() outside printable range");
+	QVERIFY2(print_area.bottom() <  1000000.0, "print_area.bottom() outside printable range");
 	QVERIFY2(print_area.right()  <  1000000.0, "print_area.right() outside printable range");
 }
 


### PR DESCRIPTION
Use print area's height for vertical adjustment of the print area.
Fix vertical map part and print area extent checks in test.
Remove an unused object instantiation in XMLFileExporter.