### PR TITLE
Unify checkbox initialization for non-georeferenced templates

### DIFF
--- a/src/core/map.cpp
+++ b/src/core/map.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012-2014 Thomas Schöps
- *    Copyright 2013-2020, 2024, 2025 Kai Pastor
+ *    Copyright 2013-2020, 2024-2026 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -2031,6 +2031,12 @@ void Map::loadTemplateFilesAsync(MapView& view, std::function<void(const QString
 			return;
 		}
 	}
+}
+
+bool Map::hasNonGeoreferencedTemplate() const
+{
+	return std::any_of(begin(templates), end(templates), [](const auto& temp) { return !temp->isTemplateGeoreferenced(); })
+	       || std::any_of(begin(closed_templates), end(closed_templates), [](const auto& temp) { return !temp->isTemplateGeoreferenced(); });
 }
 
 

--- a/src/core/map.h
+++ b/src/core/map.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012-2014 Thomas Schöps
- *    Copyright 2013-2020, 2024 Kai Pastor
+ *    Copyright 2013-2020, 2024-2026 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -787,6 +787,10 @@ public:
 	 */
 	void loadTemplateFilesAsync(MapView& view, std::function<void(const QString&)> listener);
 	
+	/**
+	 * Returns if there is at least one non-georeferenced template (either open or closed)
+	 */
+	bool hasNonGeoreferencedTemplate() const;
 	
 	// Undo & Redo
 	
@@ -1491,8 +1495,8 @@ signals:
 	
 	
 	/** Emitted when the set of selected objects changes. Also emitted when the
-	 *  symbol of a selected object changes (which is similar to selecting another
-	 *  object). */
+	 *  symbol of a selected object changes (which is similar to selecting another object).
+	 */
 	void objectSelectionChanged();
 	
 	/**
@@ -1563,11 +1567,11 @@ private:
 		
 		/** Merges another MapColorSet into this set, trying to maintain
 		 *  the relative order of colors.
-		 *  If a filter is given, imports only the colors for  which
+		 *  If a filter is given, imports only the colors for which
 		 *  filter[color_index] is true, or which are spot colors referenced
 		 *  by the selected colors.
 		 *  If a map is given, this color set is modified through the map's
-		 *  color accessor methods so that other object become aware of the
+		 *  color accessor methods so that other objects become aware of the
 		 *  changes.
 		 *  @return a mapping from the imported color pointer in the other set
 		 *          to color pointers in this set.

--- a/src/gui/map/map_dialog_scale.cpp
+++ b/src/gui/map/map_dialog_scale.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2019-2020 Kai Pastor
+ *    Copyright 2019-2020, 2026 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -21,9 +21,12 @@
 
 #include "map_dialog_scale.h"
 
-#include <QDoubleSpinBox>
+#include <Qt>
+#include <QAbstractButton>
+#include <QAbstractSpinBox>
 #include <QCheckBox>
 #include <QDialogButtonBox>
+#include <QDoubleSpinBox>
 #include <QFormLayout>
 #include <QLabel>
 #include <QRadioButton>
@@ -32,13 +35,15 @@
 
 #include "core/georeferencing.h"
 #include "core/map.h"
-#include "templates/template.h"
+#include "core/map_coord.h"
 #include "gui/util_gui.h"
 
 
 namespace OpenOrienteering {
 
-ScaleMapDialog::ScaleMapDialog(QWidget* parent, Map* map) : QDialog(parent, Qt::WindowSystemMenuHint | Qt::WindowTitleHint), map(map)
+ScaleMapDialog::ScaleMapDialog(QWidget* parent, Map* map)
+: QDialog(parent, Qt::WindowSystemMenuHint | Qt::WindowTitleHint)
+, map(map)
 {
 	setWindowTitle(tr("Change map scale"));
 	
@@ -102,12 +107,7 @@ ScaleMapDialog::ScaleMapDialog(QWidget* parent, Map* map) : QDialog(parent, Qt::
 	layout->addRow(adjust_georeferencing_check);
 	
 	adjust_templates_check = new QCheckBox(tr("Scale non-georeferenced templates"));
-	bool have_non_georeferenced_template = false;
-	for (int i = 0; i < map->getNumTemplates() && !have_non_georeferenced_template; ++i)
-		have_non_georeferenced_template = !map->getTemplate(i)->isTemplateGeoreferenced();
-	for (int i = 0; i < map->getNumClosedTemplates() && !have_non_georeferenced_template; ++i)
-		have_non_georeferenced_template = !map->getClosedTemplate(i)->isTemplateGeoreferenced();
-	if (have_non_georeferenced_template)
+	if (map->hasNonGeoreferencedTemplate())
 		adjust_templates_check->setChecked(true);
 	else
 		adjust_templates_check->setEnabled(false);

--- a/src/gui/map/rotate_map_dialog.cpp
+++ b/src/gui/map/rotate_map_dialog.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2020 Kai Pastor
+ *    Copyright 2020, 2026 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -21,17 +21,15 @@
 
 #include "rotate_map_dialog.h"
 
-#include <Qt>
 #include <QtMath>
 #include <QAbstractButton>
 #include <QCheckBox>
 #include <QDialogButtonBox>
 #include <QDoubleSpinBox>
 #include <QFormLayout>
-#include <QVBoxLayout>
 #include <QLabel>
 #include <QRadioButton>
-#include <QSpacerItem>
+#include <QVBoxLayout>
 
 #include "core/georeferencing.h"
 #include "core/map.h"
@@ -97,7 +95,10 @@ RotateMapDialog::RotateMapDialog(const Map& map, QWidget* parent, Qt::WindowFlag
 	layout->addRow(adjust_declination_check);
 	
 	adjust_templates_check = new QCheckBox(tr("Rotate non-georeferenced templates"));
-	adjust_templates_check->setChecked(true);
+	if (map.hasNonGeoreferencedTemplate())
+		adjust_templates_check->setChecked(true);
+	else
+		adjust_templates_check->setEnabled(false);
 	layout->addRow(adjust_templates_check);
 	
 	

--- a/src/gui/map/stretch_map_dialog.cpp
+++ b/src/gui/map/stretch_map_dialog.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2019, 2020 Kai Pastor
+ *    Copyright 2019-2020, 2026 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -21,7 +21,6 @@
 
 #include "stretch_map_dialog.h"
 
-#include <Qt>
 #include <QAbstractButton>
 #include <QCheckBox>
 #include <QDialogButtonBox>
@@ -29,7 +28,6 @@
 #include <QFormLayout>
 #include <QLabel>
 #include <QRadioButton>
-#include <QSpacerItem>
 #include <QVBoxLayout>
 
 #include "core/georeferencing.h"
@@ -89,7 +87,10 @@ StretchMapDialog::StretchMapDialog(const Map& map, double stretch_factor, QWidge
 	layout->addRow(adjust_georeferencing_check);
 	
 	adjust_templates_check = new QCheckBox(tr("Scale non-georeferenced templates"));
-	adjust_templates_check->setChecked(true);
+	if (map.hasNonGeoreferencedTemplate())
+		adjust_templates_check->setChecked(true);
+	else
+		adjust_templates_check->setEnabled(false);
 	layout->addRow(adjust_templates_check);
 	
 	


### PR DESCRIPTION
Ensure the checkbox is disabled in the "Rotate map" and "Change scale factor" dialogs when no applicable templates are present, matching the existing behavior of the "Change map scale" dialog.

Current behaviour for a map without templates:
![InitCheckboxesNonGeorefTemplates](https://github.com/user-attachments/assets/9f7328d0-68b2-4af3-a81f-b11b64bd41cf)
