### PR TITLE
doc: update building instructions for macos

### DIFF
--- a/3rd-party/clipper/CMakeLists.txt
+++ b/3rd-party/clipper/CMakeLists.txt
@@ -19,7 +19,7 @@
 
 project(Clipper)
 
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.7.0)
 
 # Configuration options
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -94,7 +94,7 @@ Now you may start the build process by running
 make
 ```
 
-## Compiling for macos (without OpenOrienteering superbuild)
+## Compiling for macOS (with brew instead of OpenOrienteering superbuild)
 
 `brew` installs `cmake` 4.x but the project requires an older version 3. A legacy
 version of `cmake` can be downloaded at https://cmake.org/download/#text=Legacy%20Release then located at

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,9 +6,9 @@ The general build process prerequisites are:
  - A supported platform: 
    - Linux. Ubuntu 18.04 is known to work.
      Linux is also used to cross-compile for Android.
-   - macOS: 10.13 is known to work.
+   - macOS: 10.13 is known to work, so is 26.3 (Tahoe).
    - Windows: MSYS2 (MinGW subsystem).
- - CMake >= 3.7.
+ - CMake >= 3.7, < 4.0.
    CMake is available from https://cmake.org/.
  - A supported C++ compiler toolchain. C++14 is mandatory.
 
@@ -17,7 +17,7 @@ components. Direct dependencies are:
  - Qt >=5.5
    https://www.qt.io/download-open-source/
  - Clipper library (aka libpolyclipping) >= 6.1.3a
-   http://www.angusj.com/delphi/clipper.php
+   http://www.angusj.com/delphi/
  - PROJ Cartographic Projections Library >= 4.9
    https://proj4.org/
  - GDAL Geospatial Data Abstraction Library >= 2
@@ -77,11 +77,11 @@ zlib1g-dev
 ```
 
 When not using Qt Creator, open a terminal, and create a build directory, e.g.
-as subdirectory build in the source directory, and change to that directory.
+as subdirectory build in the project's root directory, and change to that directory.
 From the build directory, configure and build like this:
 
 ```
-cmake PATH/TO/SOURCE_DIR
+cmake PATH/TO/MAPPER_ROOT_DIR
 ```
 
 When building on openSUSE, you may want to add -DMapper_BUILD_CLIPPER=1. This
@@ -94,6 +94,39 @@ Now you may start the build process by running
 make
 ```
 
+## Compiling for macos (without OpenOrienteering superbuild)
+
+`brew` installs `cmake` 4.x but the project requires an older version 3. A legacy
+version of `cmake` can be downloaded at https://cmake.org/download/#text=Legacy%20Release then located at
+`/Applications/CMake.app/Contents/bin/cmake`.
+
+The remaining packages can be installed with `brew`:
+
+```
+brew install clipper2 proj gdal zlib qt@5
+```
+
+Installed version at the writing of this section where
+
+```
+» brew list --versions clipper2 proj gdal zlib qt@5
+clipper2 2.0.1
+gdal 3.13.0
+proj 9.8.1
+qt@5 5.15.18
+zlib 1.3.2
+```
+
+For the build it might be necessary to pass `-DCMAKE_PREFIX_PATH="$(brew --prefix qt@5)` to `cmake`:
+
+```
+mkdir build
+cd build
+cmake3 .. -DCMAKE_PREFIX_PATH="$(brew --prefix qt@5)"
+make
+```
+
+The built application can then be opened with `open src/Mapper.app`
 
 ## Compiling for Windows (without OpenOrienteering superbuild)
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,7 +8,7 @@ The general build process prerequisites are:
      Linux is also used to cross-compile for Android.
    - macOS: 10.13 is known to work, so is 26.3 (Tahoe).
    - Windows: MSYS2 (MinGW subsystem).
- - CMake >= 3.7, < 4.0.
+ - CMake >= 3.7.
    CMake is available from https://cmake.org/.
  - A supported C++ compiler toolchain. C++14 is mandatory.
 
@@ -77,11 +77,11 @@ zlib1g-dev
 ```
 
 When not using Qt Creator, open a terminal, and create a build directory, e.g.
-as subdirectory build in the project's root directory, and change to that directory.
+as subdirectory `build` in the source directory, and change to that directory.
 From the build directory, configure and build like this:
 
 ```
-cmake PATH/TO/MAPPER_ROOT_DIR
+cmake PATH/TO/SOURCE_DIR
 ```
 
 When building on openSUSE, you may want to add -DMapper_BUILD_CLIPPER=1. This
@@ -96,11 +96,8 @@ make
 
 ## Compiling for macOS (with brew instead of OpenOrienteering superbuild)
 
-`brew` installs `cmake` 4.x but the project requires an older version 3. A legacy
-version of `cmake` can be downloaded at https://cmake.org/download/#text=Legacy%20Release then located at
-`/Applications/CMake.app/Contents/bin/cmake`.
 
-The remaining packages can be installed with `brew`:
+The packages can be installed with `brew`:
 
 ```
 brew install clipper2 proj gdal zlib qt@5
@@ -120,13 +117,8 @@ zlib 1.3.2
 For the build it might be necessary to pass `-DCMAKE_PREFIX_PATH="$(brew --prefix qt@5)` to `cmake`:
 
 ```
-mkdir build
-cd build
-cmake3 .. -DCMAKE_PREFIX_PATH="$(brew --prefix qt@5)"
-make
+cmake .. -DCMAKE_PREFIX_PATH="$(brew --prefix qt@5)"
 ```
-
-The built application can then be opened with `open src/Mapper.app`
 
 ## Compiling for Windows (without OpenOrienteering superbuild)
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -97,7 +97,7 @@ make
 ## Compiling for macOS (with brew instead of OpenOrienteering superbuild)
 
 
-The packages can be installed with `brew`:
+The packages can be installed with `brew` (https://brew.sh):
 
 ```
 brew install clipper2 proj gdal zlib qt@5


### PR DESCRIPTION
- Add instruction for building on macOS
- Fix: minimum `cmake` version below 3.5 leads to error with `cmake` 4+
- Update stale link for `clipper` library
