### PR TITLE
EditLineTool: Fix vertical bar in status text

### DIFF
--- a/src/tools/edit_line_tool.cpp
+++ b/src/tools/edit_line_tool.cpp
@@ -524,7 +524,7 @@ void EditLineTool::updateStatusText()
 			text += tr("<b>%1</b>: Free movement. ").arg(ModifierKey::control());
 		if (!(active_modifiers & Qt::ShiftModifier))
 			text += ::OpenOrienteering::EditTool::tr("<b>%1</b>: Snap to existing objects. ").arg(ModifierKey::shift());
-		else
+		if (text.endsWith(QLatin1String("| ")))
 			text.chop(2); // Remove "| "
 	}
 	else


### PR DESCRIPTION
Only remove the trailing vertical bar from the status text if it exists.
Otherwise the last two chars from "<b>%1</b>: Free movement. " or any translation are chopped.
Visible by using the "Edit lines" tool and pressing the Shift key.