### PR TITLE
Display keyboard shortcuts in the map editor toolbar

### DIFF
--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -1430,8 +1430,12 @@ void MapEditorController::createMenuAndToolbars()
 			if (action && !action->isSeparator() && !action->shortcut().isEmpty())
 			{
 				auto label = action->text();
-				label.remove(QLatin1Char('&'));
-				action->setToolTip(label + QStringLiteral(" (") + action->shortcut().toString() + QStringLiteral(")"));
+				// Remove unescaped '&', cf. qt_strippedText in qtbase/src/widgets/kernel/qaction.cpp
+				for (int i = 0; i < label.size(); ++i) {
+					if (label.at(i) == QLatin1Char('&'))
+						label.remove(i, 1);
+				}
+				action->setToolTip(tr("%1 (%2)").arg(label, action->shortcut().toString()));
 			}
 		}
 	}

--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -1421,6 +1421,20 @@ void MapEditorController::createMenuAndToolbars()
 	context_menu->addAction(switch_dashes_act);
 	context_menu->addAction(connect_paths_act);
 	context_menu->addAction(copy_coords_act);
+	
+	// Show keyboard shortcuts in toolbar tooltips
+	for (auto* toolbar : {main_toolbar, toolbar_view, toolbar_mapparts, toolbar_drawing, toolbar_editing, toolbar_advanced_editing})
+	{
+		for (auto* action : toolbar->actions())
+		{
+			if (action && !action->isSeparator() && !action->shortcut().isEmpty())
+			{
+				auto label = action->text();
+				label.remove(QLatin1Char('&'));
+				action->setToolTip(label + QStringLiteral(" (") + action->shortcut().toString() + QStringLiteral(")"));
+			}
+		}
+	}
 }
 
 void MapEditorController::createMobileGUI()


### PR DESCRIPTION
I am really missing getting the hotkeys displayed in OOMapper.
This is probably a problem that most maintainers here don't have, but when you start using this software you don't know all the hotkeys by heart.
Looking them up all the time is annoying and in the beginning most users probably don't know that they exist.
Displaying them whenever hovering over the icons really helps learning them.

Unfortutnately I am too stupid to actually take a screenshot of it, but it displays:

- Edit objects (E)
- Edit lines (L)
- Set point objects (S)
- and so on

AI was used during programming. I tried my best and I hope it is not complete garbage.

Edit:
<img width="351" height="255" alt="image" src="https://github.com/user-attachments/assets/28ebbcc7-5abc-4d80-a198-f1e16f9d7ece" />
