### PR TITLE
PieMenu: Ensure popup menu stays within viewport

### DIFF
--- a/src/gui/widgets/pie_menu.cpp
+++ b/src/gui/widgets/pie_menu.cpp
@@ -175,7 +175,7 @@ void PieMenu::popup(const QPoint& pos)
 	else if (cursor_pos.y() < total_radius)
 		cursor_pos.setY(total_radius);
 	
-	setGeometry(pos.x() - total_radius, pos.y() - total_radius, 2 * total_radius, 2 * total_radius);
+	setGeometry(cursor_pos.x() - total_radius, cursor_pos.y() - total_radius, 2 * total_radius, 2 * total_radius);
 	
 	clicked = false;
 	active_action = nullptr;

--- a/src/gui/widgets/pie_menu.cpp
+++ b/src/gui/widgets/pie_menu.cpp
@@ -162,7 +162,7 @@ void PieMenu::popup(const QPoint& pos)
 {
 	updateCachedState(); // We need the current total_radius.
 	
-	QPoint cursor_pos = QCursor::pos();
+	QPoint cursor_pos = pos;
 	QRect screen_rect = qApp->desktop()->availableGeometry(cursor_pos);
 	
 	if (cursor_pos.x() > screen_rect.right() - total_radius)


### PR DESCRIPTION
The popup pie menu would be clipped when overflowing the screen edges. To avoid clipping, use the existing dead code to shift position.
<img width="94" height="223" alt="pie_menu_clipped" src="https://github.com/user-attachments/assets/1fc1cfb5-e74f-4c9c-ad73-f6ffe64e6abe" />
