### PR TITLE
MapTest: Fix QRegularExpression syntax error

### DIFF
--- a/test/map_t.cpp
+++ b/test/map_t.cpp
@@ -130,10 +130,10 @@ void MapTest::printerConfigTest()
 
 void MapTest::specialColorsTest()
 {
-	QVERIFY(Map::getCoveringRed() != nullptr);
+	QVERIFY(Map::getCoveringWhite() != nullptr);
 	QCOMPARE(Map::getCoveringWhite()->getPriority(), static_cast<int>(MapColor::CoveringWhite));
 	
-	QVERIFY(Map::getCoveringWhite() != nullptr);
+	QVERIFY(Map::getCoveringRed() != nullptr);
 	QCOMPARE(Map::getCoveringRed()->getPriority(), static_cast<int>(MapColor::CoveringRed));
 	
 	QVERIFY(Map::getUndefinedColor() != nullptr);
@@ -337,8 +337,8 @@ void MapTest::crtFileTest()
 	out_stream.flush();
 	out_buffer.close();
 	const auto result = QString::fromLatin1(out_buffer.buffer());
-	QVERIFY(result.contains(QRegularExpression(QLatin1String("^101 *104$", QRegularExpression::MultilineOption))));
-	QVERIFY(result.contains(QRegularExpression(QLatin1String("102 *105_text$", QRegularExpression::MultilineOption))));
+	QVERIFY(result.contains(QRegularExpression(QLatin1String("^101 *104$"), QRegularExpression::MultilineOption)));
+	QVERIFY(result.contains(QRegularExpression(QLatin1String("102 *105_text$"), QRegularExpression::MultilineOption)));
 	QVERIFY(!result.contains(QLatin1String("123456")));
 	QVERIFY(!result.contains(QLatin1String("106")));
 }


### PR DESCRIPTION
A misplaced closing bracket caused `QRegularExpression::MultilineOption` (0x0004) to pass as a string length argument.
This limited the regular expression string to 4 bytes upon creation, resulting in truncated expressions like "^101" or "102 ".
The bug went unnoticed because the truncated patterns still passed the existing tests without compilation errors.