### PR TITLE
Misc test fixes

### DIFF
--- a/test/duplicate_equals_t.cpp
+++ b/test/duplicate_equals_t.cpp
@@ -60,7 +60,7 @@ void testDecoupling(const AreaSymbol& a, const AreaSymbol& b)
 	{
 		auto& pattern_a = a.getFillPattern(i);
 		auto& pattern_b = b.getFillPattern(i);
-		QVERIFY(&a != &b);
+		QVERIFY(&pattern_a != &pattern_b);
 		switch (pattern_a.type)
 		{
 		case AreaSymbol::FillPattern::LinePattern:

--- a/test/file_format_t.cpp
+++ b/test/file_format_t.cpp
@@ -169,7 +169,7 @@ namespace
 		} \
 		else \
 		{ \
-			auto const diff = qstrlen(#b) - qstrlen(#a); \
+			int const diff = qstrlen(#b) - qstrlen(#a); \
 			auto const fill_a = QString().fill(QChar::Space, +diff); \
 			auto const fill_b = QString().fill(QChar::Space, -diff); \
 			QFAIL(QString::fromLatin1( \

--- a/test/path_object_t.cpp
+++ b/test/path_object_t.cpp
@@ -909,7 +909,7 @@ void PathObjectTest::calcIntersectionsTest()
 		parallel3.addCoordinate(MapCoord(30, -10));
 		
 		PathObject::Intersections intersections_parallel_se;
-		intersections_parallel.reserve(2);
+		intersections_parallel_se.reserve(2);
 		
 		intersection.coord = MapCoordF(20, 0);
 		intersection.length = 10;


### PR DESCRIPTION
DuplicateEqualsTest: Fix comparison of area symbols

PathObjectTest: Fix copy and paste error

FileFormatTest: Fix variable type deduction:
Fix type deduction where subtracting two unsigned functions resulted in an unsigned auto variable, ignoring negative results.
This underflow had no negative side effects because QString::fill() expects a signed parameter, implicitly converting values near UINT_MAX back to the correct negative numbers.