### PR TITLE
Discard `view`, `undo` and `redo` when writing `.xmap`

### DIFF
--- a/src/fileformats/xml_file_format.cpp
+++ b/src/fileformats/xml_file_format.cpp
@@ -279,14 +279,18 @@ bool XMLFileExporter::exportImplementation()
 		exportMapParts();
 		writeLineBreak(xml);
 		exportTemplates();
-		writeLineBreak(xml);
-		exportView();
-		writeLineBreak(xml);
-		exportPrint();
+		if (!path.endsWith(QLatin1String(".xmap")))
+		{
+			writeLineBreak(xml);
+			exportView();
+			writeLineBreak(xml);
+			exportPrint();
+		}
 		delete barrier;
 		writeLineBreak(xml);
 
-		if (Settings::getInstance().getSetting(Settings::General_SaveUndoRedo).toBool()
+		if (!path.endsWith(QLatin1String(".xmap"))
+		    && Settings::getInstance().getSetting(Settings::General_SaveUndoRedo).toBool()
 		    && (map->undoManager().canUndo() || map->undoManager().canRedo()) )
 		{
 			{


### PR DESCRIPTION
Hopefully improves on #1290

Since the `.xmap` formap is designed to be version control friendly this removes another not map information that is changing on every save.

Implementationwise, this is the short form. If we plan on doing more changes to the xmap format. Then we should consider adding a new option in the exporter to make the path.endswith(xmap) more readable.