### PR TITLE
Split lines and ways inplace

### DIFF
--- a/src/tools/cut_tool.cpp
+++ b/src/tools/cut_tool.cpp
@@ -739,15 +739,16 @@ void CutTool::replaceObject(Object* object, const std::vector<PathObject*>& repl
 	auto map = this->map();
 	auto map_part = map->getCurrentPart();
 	
+	int object_index = map_part->findObjectIndex(object);
 	auto add_step = new AddObjectsUndoStep(map);
-	add_step->addObject(map_part->findObjectIndex(object), object);
+	add_step->addObject(object_index, object);
 	map->removeObjectFromSelection(object, false);
 	map->releaseObject(object);
 	
 	auto delete_step = new DeleteObjectsUndoStep(map);
 	for (auto new_object : replacement)
 	{
-		map->addObject(new_object);
+		map_part->addObject(new_object, object_index++);
 		map->addObjectToSelection(new_object, false);
 		delete_step->addObject(map_part->findObjectIndex(new_object));
 	}


### PR DESCRIPTION
When a line or a polygon is split this is done inplace.

This should improve version controllability.

```diff
         <parts count="1" current="0">
             <part name="default part">
-                <objects count="5">
+                <objects count="6">
                     <object type="1" symbol="58">
-                        <coords count="39">
+                        <coords count="10">
                             <coord x="-70638" y="36180"/>
                             <coord x="-61531" y="3938"/>
                             <coord x="-51194" y="34211"/>
                             <coord x="-38641" y="-11322"/>
                             <coord x="-23136" y="20428"/>
                             <coord x="-6891" y="-39626"/>
                             <coord x="5169" y="246"/>
                             <coord x="15752" y="18952"/>
                             <coord x="29535" y="46517"/>
+                            <coord x="54886" y="18952" flags="16"/>
+                        </coords>
+                        <pattern rotation="0">
+                            <coord x="0" y="0"/>
+                        </pattern>
+                    </object>
+                    <object type="1" symbol="58">
+                        <coords count="30">
                             <coord x="54886" y="18952"/>
                             <coord x="49225" y="-9599" flags="1"/>
                             <coord x="45680" y="-23780"/>
                             <coord x="41213" y="-30980"/>
                             <coord x="35196" y="-44302" flags="1"/>
                             <coord x="29646" y="-56591"/>
                             <coord x="24477" y="-62413"/>
                             <coord x="17721" y="-74083" flags="1"/>
                             <coord x="12151" y="-83704"/>
                             <coord x="3514" y="-86916"/>
                             <coord x="2215" y="-97957"/>
                             <coord x="36426" y="-99680"/>
                             <coord x="60054" y="-77037"/>
                             <coord x="63746" y="-41595" flags="1"/>
                             <coord x="64511" y="-31646"/>
                             <coord x="66117" y="-26188"/>
                             <coord x="66946" y="-16244" flags="1"/>
                             <coord x="67744" y="-6666"/>
                             <coord x="66946" y="-1244"/>
                             <coord x="66946" y="8368" flags="1"/>
                             <coord x="66946" y="20989"/>
                             <coord x="64731" y="27989"/>
                             <coord x="64731" y="40610" flags="1"/>
                             <coord x="64731" y="53983"/>
                             <coord x="70672" y="63695"/>
                             <coord x="63254" y="74822"/>
                             <coord x="27566" y="88112"/>
                             <coord x="-7384" y="95742"/>
                             <coord x="-41595" y="98203"/>
-                            <coord x="-2285" y="52800"/>
+                            <coord x="-2285" y="52800" flags="16"/>
                         </coords>
                         <pattern rotation="0">
                             <coord x="0" y="0"/>
```