### PR TITLE
OcdFileExport: Zero angle on non-rotatable objects

### DIFF
--- a/src/fileformats/ocd_file_export.cpp
+++ b/src/fileformats/ocd_file_export.cpp
@@ -2511,10 +2511,11 @@ QByteArray OcdFileExport::exportPointObject(const PointObject* point, typename O
 {
 	OcdObject ocd_object = {};
 	ocd_object.type = 1;
-	auto const symbol_number_it = symbol_numbers.find(point->getSymbol());
+	auto const symbol = point->getSymbol()->asPoint();
+	auto const symbol_number_it = symbol_numbers.find(symbol);
 	decltype(entry.symbol) const symbol_number = symbol_number_it != symbol_numbers.end() ? symbol_number_it->second : -1;
 	ocd_object.symbol = entry.symbol = symbol_number;
-	ocd_object.angle = decltype(ocd_object.angle)(convertRotation(point->getRotation()));
+	ocd_object.angle = decltype(ocd_object.angle)(symbol->isRotatable() ? convertRotation(point->getRotation()) : 0);
 	return exportObjectCommon(point, ocd_object, entry);
 }
 
@@ -2622,7 +2623,7 @@ void OcdFileExport::exportPathObject(OcdFile<Format>& file, const PathObject* pa
 template< class OcdObject >
 QByteArray OcdFileExport::exportTextObject(const TextObject* text, typename OcdObject::IndexEntryType& entry)
 {
-	auto symbol = static_cast<const TextSymbol*>(text->getSymbol());
+	auto const symbol = text->getSymbol()->asText();
 	auto alignment = text->getHorizontalAlignment();
 	auto text_format = std::find_if(begin(text_format_mapping), end(text_format_mapping), [symbol, alignment](const auto& m) {
 		return m.symbol == symbol && m.alignment == alignment;
@@ -2637,7 +2638,7 @@ QByteArray OcdFileExport::exportTextObject(const TextObject* text, typename OcdO
 	OcdObject ocd_object = {};
 	ocd_object.type = text->hasSingleAnchor() ? 4 : 5;
 	ocd_object.symbol = entry.symbol = symbol_number;
-	ocd_object.angle = decltype(ocd_object.angle)(convertRotation(text->getRotation()));
+	ocd_object.angle = decltype(ocd_object.angle)(symbol->isRotatable() ? convertRotation(text->getRotation()) : 0);
 	return exportObjectCommon(text, ocd_object, entry);
 }
 


### PR DESCRIPTION
Text and point objects with non-rotatable symbol appear orientated to north in Mapper. When writing XML, Mapper skips the rotation attribute in `Object::save(QXmlStreamWriter&)`.

However, if a map is opened from OCD format, the north rotation lock is [silently removed from point symbols](https://github.com/OpenOrienteering/mapper/blob/064e6c943ee963277f1e930bda595723acd3e8c6/src/fileformats/ocd_file_import.cpp#L1906-L1913). The user may restore the rotation lock by either replacing the symbol set or a manual intervention. Then if the map is saved in OCD format, the symbol has north orientation (rotation lock) and the object has rotation angle set. If the map is reopened in Mapper, the cycle repeats - there is a rotated object with a point symbol, so Mapper removes the lock again.

The text symbols do not have the rotation lock removal logic in OCD import and [text appears rotated regardless of the lock setting](https://github.com/OpenOrienteering/mapper/blob/064e6c943ee963277f1e930bda595723acd3e8c6/src/core/renderables/renderable_implementation.cpp#L745). As a result, north oriented text is rendered as rotated and cannot be straightened by the _Rotate pattern_ tool. The _Rotate object_ tool, which is enabled for the object in question, creates funny effects.

This patch aligns the export logic in OCD export path with the XML counterpart.