### PR TITLE
UndoManager: Fix removal of oldest redo steps

### DIFF
--- a/src/undo/undo_manager.cpp
+++ b/src/undo/undo_manager.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2014-2018 Kai Pastor
+ *    Copyright 2014-2019, 2026 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -41,8 +41,6 @@
 
 namespace OpenOrienteering {
 
-Q_STATIC_ASSERT(UndoManager::max_undo_steps < static_cast<unsigned int>(std::numeric_limits<int>::max()));
-
 
 // ### UndoManager::State ###
 
@@ -62,10 +60,13 @@ UndoManager::State::State(UndoManager const *manager)
 UndoManager::UndoManager(Map* map)
 : QObject()
 , map(map)
+, max_undo_steps(128)
 , current_index(0)
 , clean_state_index(-1)
 , loaded_state_index(-1)
 {
+	Q_ASSERT(max_undo_steps < static_cast<unsigned int>(std::numeric_limits<int>::max()));
+	
 	undo_steps.reserve(max_undo_steps + 1);  // +1 is for push before trim
 	if (map)
 	{
@@ -444,8 +445,7 @@ void UndoManager::loadUndo(QXmlStreamReader& xml, SymbolDictionary& symbol_dict)
 	
 	clear();
 	UndoManager::State old_state(this);
-	using std::swap;
-	swap(undo_steps, loaded_steps);
+	std::swap(undo_steps, loaded_steps);
 	current_index = int(undo_steps.size());
 	setLoaded();
 	setClean();
@@ -472,7 +472,7 @@ void UndoManager::loadRedo(QXmlStreamReader& xml, SymbolDictionary& symbol_dict)
 UndoManager::StepList UndoManager::loadSteps(QXmlStreamReader& xml, SymbolDictionary& symbol_dict) const
 {
 	StepList steps;
-	steps.reserve(max_undo_steps + 1);
+	steps.reserve(max_undo_steps);
 	while (xml.readNextStartElement())
 	{
 		if (xml.name() == QLatin1String("step"))

--- a/src/undo/undo_manager.cpp
+++ b/src/undo/undo_manager.cpp
@@ -460,7 +460,7 @@ void UndoManager::loadRedo(QXmlStreamReader& xml, SymbolDictionary& symbol_dict)
 	auto loaded_steps = loadSteps(xml, symbol_dict);
 	auto capacity = max_undo_steps - undo_steps.size();
 	if (loaded_steps.size() > capacity)
-		loaded_steps.erase(begin(loaded_steps) + StepList::difference_type(loaded_steps.size() - capacity), end(loaded_steps));
+		loaded_steps.erase(begin(loaded_steps), begin(loaded_steps) + StepList::difference_type(loaded_steps.size() - capacity));
 		
 	clearRedoSteps();
 	UndoManager::State old_state(this);

--- a/src/undo/undo_manager.h
+++ b/src/undo/undo_manager.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2014, 2017, 2018 Kai Pastor
+ *    Copyright 2014, 2017-2019, 2026 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -36,11 +36,12 @@ class QWidget;
 class QXmlStreamReader;
 class QXmlStreamWriter;
 
+class UndoManagerTest;
+
 namespace OpenOrienteering {
 
 class Map;
 class UndoStep;
-
 
 /**
  * Manages the history of steps for undoing and redoing changes to a map.
@@ -50,6 +51,7 @@ class UndoStep;
  */
 class UndoManager : public QObject
 {
+friend class ::UndoManagerTest;
 Q_OBJECT
 public:
 	/**
@@ -176,7 +178,7 @@ public:
 	void saveUndo(QXmlStreamWriter& xml) const;
 	
 	/**
-	 * Saves the undo steps to the file in xml format.
+	 * Saves the redo steps to the file in xml format.
 	 */
 	void saveRedo(QXmlStreamWriter& xml) const;
 	
@@ -193,16 +195,6 @@ public:
 	 * Any existing redo steps will be deleted first, but undo steps are left untouched.
 	 */
 	void loadRedo(QXmlStreamReader& xml, SymbolDictionary& symbol_dict);
-	
-	
-	/**
-	 * The maximum number of steps kept for undo() and redo(), respectively.
-	 * 
-	 * This limits the amount of memory occupied by undo steps.
-	 * 
-	 * @todo Make this configurable (maybe by used memory instead of step count)
-	 */
-	static constexpr std::size_t max_undo_steps = 128;
 	
 signals:
 	/**
@@ -307,6 +299,15 @@ private:
 	Map* const map;
 	
 	/**
+	 * The maximum number of steps kept for undo() and redo(), respectively.
+	 * 
+	 * This limits the amount of memory occupied by undo steps.
+	 * 
+	 * @todo Make this configurable (maybe by used memory instead of step count)
+	 */
+	std::size_t max_undo_steps;
+	
+	/**
 	 * The index where push will place the next undo step.
 	 * 
 	 * The latest undo step (if any) is just before this index.
@@ -340,4 +341,4 @@ private:
 
 }  // namespace OpenOrienteering
 
-#endif
+#endif // OPENORIENTEERING_UNDO_MANAGER_H

--- a/test/undo_manager_t.cpp
+++ b/test/undo_manager_t.cpp
@@ -1,5 +1,6 @@
 /*
  *    Copyright 2014 Kai Pastor
+ *    Copyright 2026 Matthias Kühlewein
  *
  *    This file is part of OpenOrienteering.
  *
@@ -19,14 +20,52 @@
 
 #include "undo_manager_t.h"
 
-#include <QtTest>
+#include <algorithm>
+#include <initializer_list>
+#include <memory>
 
+#include <QtTest>
+#include <QBuffer>
+#include <QIODevice>
+
+#include "core/map.h"
+#include "core/objects/object.h"
+#include "core/symbols/point_symbol.h"
+#include "core/symbols/symbol.h"
+#include "fileformats/file_format.h"
+#include "fileformats/file_import_export.h"
+#include "fileformats/xml_file_format.h"
+#include "undo/object_undo.h"
 #include "undo/undo.h"
 #include "undo/undo_manager.h"
 
-namespace OpenOrienteering { class Map; }
 
 using namespace OpenOrienteering;
+
+namespace
+{
+	bool saveAndLoadMap(const Map& input, Map& out)
+	{
+		XMLFileFormat format;
+		auto exporter = format.makeExporter({}, &input, nullptr);
+		auto importer = format.makeImporter({}, &out, nullptr);
+		if (exporter && importer)
+		{
+			QBuffer buffer;
+			exporter->setDevice(&buffer);
+			importer->setDevice(&buffer);
+			if (buffer.open(QIODevice::ReadWrite)
+				&& exporter->doExport()
+				&& buffer.seek(0)
+				&& importer->doImport())
+			{
+				return true;  // success
+			}
+		}
+		out.reset();  // failure
+		return false;
+	}
+}
 
 
 // test
@@ -244,4 +283,158 @@ void UndoManagerTest::canRedoChanged(bool can_redo)
 }
 
 
-QTEST_GUILESS_MAIN(UndoManagerTest)
+// test
+void UndoManagerTest::testSaveAndLoad()
+{
+	Map map;
+	map.undoManager().max_undo_steps = 3;
+	
+	auto point_symbol = new PointSymbol();
+	point_symbol->setRotatable(true);
+	map.addSymbol(point_symbol, 0);
+	
+	auto addObject = [&point_symbol](Map* map, double rotation)
+	{
+		auto object = new PointObject(point_symbol);
+		object->setRotation(rotation);
+		auto undo_step = new DeleteObjectsUndoStep(map);
+		map->addObject(object);
+		undo_step->addObject(map->getCurrentPart()->findObjectIndex(object));
+		map->push(undo_step);
+	};
+	
+	for(double rotation : {1.0, 2.0, 3.0})
+	{
+		addObject(&map, rotation);
+	}
+	QCOMPARE(map.getNumObjects(), 3);
+	auto existsObject = [](const Map* map, double rotation) { 
+		return map->existsObject([rotation](auto const* o) {
+			return qFuzzyCompare(o->getRotation(), rotation);
+		});
+	};
+	QVERIFY(existsObject(&map, 1.0));
+	auto existsAllObjects = [&existsObject](const Map* map, std::initializer_list<double> members) {
+		return std::all_of(begin(members), end(members), [&existsObject, map](auto& member) {
+			return existsObject(map, member);
+		});
+	};
+	QVERIFY(existsAllObjects(&map, {1.0, 2.0, 3.0}));
+	QVERIFY(map.undoManager().canUndo());
+	QVERIFY(!map.undoManager().canRedo());
+	QCOMPARE(map.undoManager().undoStepCount(), 3);
+	
+	map.undoManager().undo();
+	QCOMPARE(map.getNumObjects(), 2);
+	QVERIFY(map.undoManager().canUndo());
+	QVERIFY(map.undoManager().canRedo());
+	QCOMPARE(map.undoManager().undoStepCount(), 2);
+	QCOMPARE(map.undoManager().redoStepCount(), 1);
+	
+	map.undoManager().redo();
+	QCOMPARE(map.getNumObjects(), 3);
+	QVERIFY(map.undoManager().canUndo());
+	QVERIFY(!map.undoManager().canRedo());
+	QCOMPARE(map.undoManager().undoStepCount(), 3);
+	
+	// add another object, causing the oldest undo step to be deleted
+	addObject(&map, 4.0);
+	while (map.undoManager().canUndo())
+	{
+		map.undoManager().undo();
+	}
+	QCOMPARE(map.getNumObjects(), 1);
+	QVERIFY(existsAllObjects(&map, {1.0}));
+	while (map.undoManager().canRedo())
+	{
+		map.undoManager().redo();
+	}
+	QCOMPARE(map.getNumObjects(), 4);
+	QVERIFY(existsAllObjects(&map, {1.0, 2.0, 3.0, 4.0}));
+	
+	// Normal save and load cycle with 3 undo steps and 0 redo steps
+	Map reloaded_map;
+	reloaded_map.undoManager().max_undo_steps = 3;
+	QVERIFY(saveAndLoadMap(map, reloaded_map));
+	QCOMPARE(reloaded_map.getNumObjects(), 4);
+	QVERIFY(existsAllObjects(&reloaded_map, {1.0, 2.0, 3.0, 4.0}));
+	reloaded_map.undoManager().loaded_state_index = 0;	// avoid message box "Undoing this step will go beyond the point..."
+	QVERIFY(reloaded_map.undoManager().canUndo());
+	QVERIFY(!reloaded_map.undoManager().canRedo());
+	QCOMPARE(reloaded_map.undoManager().undoStepCount(), 3);
+	
+	while (reloaded_map.undoManager().canUndo())
+	{
+		reloaded_map.undoManager().undo();
+	}
+	QCOMPARE(reloaded_map.getNumObjects(), 1);
+	QVERIFY(existsAllObjects(&reloaded_map, {1.0}));
+	
+	// Save and load cycle with 3 undo steps and 0 redo steps
+	// where number of undo steps in loaded map is larger than max. undo/redo steps,
+	// thus reducing the number of stored undo steps
+	Map reloaded_map2;
+	reloaded_map2.undoManager().max_undo_steps = 2;
+	QVERIFY(saveAndLoadMap(map, reloaded_map2));
+	QCOMPARE(reloaded_map2.getNumObjects(), 4);
+	QVERIFY(existsAllObjects(&reloaded_map2, {1.0, 2.0, 3.0, 4.0}));
+	reloaded_map2.undoManager().loaded_state_index = 0;	// avoid message box "Undoing this step will go beyond the point..."
+	QVERIFY(reloaded_map2.undoManager().canUndo());
+	QVERIFY(!reloaded_map2.undoManager().canRedo());
+	QCOMPARE(reloaded_map2.undoManager().undoStepCount(), 2);
+	
+	reloaded_map2.undoManager().undo();
+	QVERIFY(existsAllObjects(&reloaded_map2, {1.0, 2.0, 3.0}));
+	reloaded_map2.undoManager().undo();
+	QCOMPARE(reloaded_map2.getNumObjects(), 2);
+	QVERIFY(existsAllObjects(&reloaded_map2, {1.0, 2.0}));
+	
+	// now create source map with 0 undo steps and 3 redo steps
+	while (map.undoManager().canUndo())
+	{
+		map.undoManager().undo();
+	}
+	QCOMPARE(map.getNumObjects(), 1);
+	
+	// Normal save and load cycle with 0 undo steps and 3 redo steps
+	Map reloaded_map3;
+	reloaded_map3.undoManager().max_undo_steps = 3;
+	QVERIFY(saveAndLoadMap(map, reloaded_map3));
+	QCOMPARE(reloaded_map3.getNumObjects(), 1);
+	QVERIFY(existsAllObjects(&reloaded_map3, {1.0}));
+	QVERIFY(!reloaded_map3.undoManager().canUndo());
+	QVERIFY(reloaded_map3.undoManager().canRedo());
+	QCOMPARE(reloaded_map3.undoManager().redoStepCount(), 3);
+	reloaded_map3.undoManager().redo();
+	QVERIFY(existsAllObjects(&reloaded_map3, {1.0, 2.0}));
+	reloaded_map3.undoManager().redo();
+	QVERIFY(existsAllObjects(&reloaded_map3, {1.0, 2.0, 3.0}));
+	reloaded_map3.undoManager().redo();
+	QVERIFY(existsAllObjects(&reloaded_map3, {1.0, 2.0, 3.0, 4.0}));
+	
+	// Save and load cycle with 0 undo steps and 3 redo steps
+	// where number of redo steps in loaded map is larger than max. undo/redo steps,
+	// thus reducing the number of stored redo steps
+	Map reloaded_map4;
+	reloaded_map4.undoManager().max_undo_steps = 2;
+	QVERIFY(saveAndLoadMap(map, reloaded_map4));
+	QCOMPARE(reloaded_map4.getNumObjects(), 1);
+	QVERIFY(existsAllObjects(&reloaded_map4, {1.0}));
+	QVERIFY(!reloaded_map4.undoManager().canUndo());
+	QVERIFY(reloaded_map4.undoManager().canRedo());
+	QCOMPARE(reloaded_map4.undoManager().redoStepCount(), 2);
+	reloaded_map4.undoManager().redo();
+	QVERIFY(existsAllObjects(&reloaded_map4, {1.0, 2.0}));
+	reloaded_map4.undoManager().redo();
+	QVERIFY(existsAllObjects(&reloaded_map4, {1.0, 2.0, 3.0}));
+}
+
+/*
+ * We don't need a real GUI window.
+ */
+namespace {
+	auto const Q_DECL_UNUSED qpa_selected = qputenv("QT_QPA_PLATFORM", "offscreen");  // clazy:exclude=non-pod-global-static
+}
+
+
+QTEST_MAIN(UndoManagerTest)

--- a/test/undo_manager_t.h
+++ b/test/undo_manager_t.h
@@ -1,5 +1,6 @@
 /*
  *    Copyright 2014 Kai Pastor
+ *    Copyright 2026 Matthias Kühlewein
  *
  *    This file is part of OpenOrienteering.
  *
@@ -22,7 +23,6 @@
 
 #include <QObject>
 
-
 /**
  * @test Tests UndoManager.
  */
@@ -32,9 +32,15 @@ class UndoManagerTest : public QObject
 	
 private slots:
 	/**
-	 * Performs actions on an UndoManager and observes its behaviour.
+	 * Performs basic actions on an UndoManager and observes its behaviour.
 	 */
 	void testUndoRedo();
+	
+	/**
+	 * Performs roundtrip actions (saving and loading) and tests correct behavior
+	 * if number of loaded undo/redo steps exceeds the maximum number of undo steps.
+	 */
+	void testSaveAndLoad();
 	
 private:
 	bool clean_changed;


### PR DESCRIPTION
The map file stores redo steps in reversed order, which are then reinserted in reversed order. When the number of loaded steps exceeded the maximum undo/redo limit, then the newest redo steps were removed instead of the oldest ones.
Make max_undo_steps a class member and class UndoManagerTest a friend to allow testing with varying number of undo/redo steps.
Add test for saving and loading a map file with undo/redo steps to verify that these steps will be executed correctly after loading.
Test that limitation of undo/redo steps is done correctly if a map file is loaded that contains more steps than the maximum number of steps.