### PR TITLE
Template: Search recursively for missing templates

### DIFF
--- a/src/fileformats/file_import_export.cpp
+++ b/src/fileformats/file_import_export.cpp
@@ -227,6 +227,13 @@ void Importer::validate()
 			                "Template \"%1\" has been loaded from the map's directory instead of"
 			                " the relative location to the map file where it was previously.")
 			            .arg(temp->getTemplateFilename()) + QLatin1Char('\n') );
+			break;
+		case Template::FoundInMapSubDir:
+			error_string.append(
+			            ::OpenOrienteering::Importer::tr(
+			                "Template \"%1\" has been loaded from a map subdirectory instead of"
+			                " the relative location to the map file where it was previously.")
+			            .arg(temp->getTemplateFilename()) + QLatin1Char('\n') );
 		default:
 			;
 		}

--- a/src/templates/template.cpp
+++ b/src/templates/template.cpp
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2013-2020 Kai Pastor
+ *    Copyright 2013-2020, 2026 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -37,6 +37,7 @@
 #include <QColor>
 #include <QCoreApplication>
 #include <QDir>
+#include <QDirIterator>
 #include <QFileInfo>
 #include <QLatin1Char>
 #include <QLatin1String>
@@ -630,6 +631,22 @@ Template::LookupResult Template::tryToFindTemplateFile(const QString& map_path)
 			setTemplateFileInfo(abs_path_info);
 			set_state(Unloaded);
 			return FoundInMapDir;
+		}
+	}
+	
+	// 4. Search subdirectories of the map directory for the filename
+	if (!filename.isEmpty() && !map_path.isEmpty())
+	{
+		QDirIterator it(dir(map_path).absolutePath(), QDir::Dirs | QDir::NoDotAndDotDot, QDirIterator::Subdirectories);
+		while (it.hasNext())
+		{
+			auto const sub_path_info = QFileInfo(QDir(it.next()).absoluteFilePath(filename));
+			if (sub_path_info.isFile())
+			{
+				setTemplateFileInfo(sub_path_info);
+				set_state(Unloaded);
+				return FoundInMapSubDir;
+			}
 		}
 	}
 	

--- a/src/templates/template.h
+++ b/src/templates/template.h
@@ -1,6 +1,6 @@
 /*
  *    Copyright 2012, 2013 Thomas Schöps
- *    Copyright 2012-2020 Kai Pastor
+ *    Copyright 2012-2020, 2026 Kai Pastor
  *
  *    This file is part of OpenOrienteering.
  *
@@ -133,10 +133,11 @@ public:
 	 */
 	enum LookupResult
 	{
-		NotFound       = 0,  ///< File not found at all.
-		FoundInMapDir  = 1,  ///< File name found in the map's directory.
-		FoundByRelPath = 2,  ///< File found by relative path from the map's directory.
-		FoundByAbsPath = 3,  ///< File found by absolute path.
+		NotFound         = 0,  ///< File not found at all.
+		FoundInMapDir    = 1,  ///< File name found in the map's directory.
+		FoundByRelPath   = 2,  ///< File found by relative path from the map's directory.
+		FoundByAbsPath   = 3,  ///< File found by absolute path.
+		FoundInMapSubDir = 4,  ///< File name found in a subdirectory of the map's directory.
 	};
 
 	/**
@@ -811,4 +812,4 @@ protected:
 Q_DECLARE_OPERATORS_FOR_FLAGS(OpenOrienteering::Template::ScribbleOptions)
 
 
-#endif
+#endif // OPENORIENTEERING_TEMPLATE_H


### PR DESCRIPTION
If templates are no longer found at their previous locations,
Mapper searches alternative locations, including the map directory.
Extend this search to recursively include its subdirectories.