### PR TITLE
Add WMS/WMTS online background maps

### DIFF
--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -303,6 +303,41 @@ if(Mapper_PACKAGE_GDAL)
 	install(
 	  DIRECTORY "${GDAL_DATA_DIR}/"
 	  DESTINATION "${MAPPER_DATA_DESTINATION}/gdal")
+
+	# MinGW libcurl is normally built with a path to the build machine's CA
+	# bundle.  That absolute path is invalid after installing Mapper elsewhere.
+	# Ship a relocatable bundle so HTTPS works from a standalone Windows package.
+	if(WIN32)
+		set(Mapper_CA_BUNDLE_FILE "" CACHE FILEPATH
+		  "TLS CA bundle to include in standalone Windows packages")
+		mark_as_advanced(Mapper_CA_BUNDLE_FILE)
+		if(NOT Mapper_CA_BUNDLE_FILE)
+			get_filename_component(gdal_prefix "${GDAL_DATA_DIR}/../.." ABSOLUTE)
+			find_file(_mapper_ca_bundle
+			  NAMES ca-bundle.crt ca-certificates.crt tls-ca-bundle.pem
+			  HINTS
+			    "${gdal_prefix}/etc/ssl/certs"
+			    "${gdal_prefix}/etc/pki/ca-trust/extracted/pem"
+			    "$ENV{MINGW_PREFIX}/etc/ssl/certs"
+			    "$ENV{MINGW_PREFIX}/etc/pki/ca-trust/extracted/pem"
+			    "/etc/ssl/certs"
+			    "/etc/pki/ca-trust/extracted/pem"
+			)
+			if(_mapper_ca_bundle)
+				set(Mapper_CA_BUNDLE_FILE "${_mapper_ca_bundle}" CACHE FILEPATH
+				  "TLS CA bundle to include in standalone Windows packages" FORCE)
+			endif()
+		endif()
+		if(NOT EXISTS "${Mapper_CA_BUNDLE_FILE}")
+			message(SEND_ERROR
+			  "A TLS CA bundle is required when packaging GDAL for Windows. "
+			  "Set Mapper_CA_BUNDLE_FILE to a readable PEM bundle.")
+		endif()
+		install(
+		  FILES "${Mapper_CA_BUNDLE_FILE}"
+		  DESTINATION "${MAPPER_RUNTIME_DESTINATION}/certs"
+		  RENAME ca-bundle.crt)
+	endif()
 	foreach(item IN LISTS GDAL_LIBRARIES)
 		if(EXISTS "${item}")
 			get_filename_component(GDAL_LIBRARY_DIR "{item}" PATH)

--- a/src/core/map_view.cpp
+++ b/src/core/map_view.cpp
@@ -71,7 +71,11 @@ bool TemplateVisibility::hasAlpha() const
 // ### MapView ###
 
 const double MapView::zoom_in_limit = 512;
-const double MapView::zoom_out_limit = 1 / 16.0;
+// Regional and global georeferenced online templates can cover an area many
+// orders of magnitude larger than an orienteering map.  Keep the traditional
+// zoom-in limit, but allow the view to fit such a template without changing
+// the map scale or the template georeferencing.
+const double MapView::zoom_out_limit = 1 / 4096.0;
 
 
 MapView::MapView(QObject* parent, Map* map)

--- a/src/gdal/CMakeLists.txt
+++ b/src/gdal/CMakeLists.txt
@@ -24,6 +24,10 @@ set(CMAKE_AUTOMOC ON)
  
 # Extra header to be shown in the IDE or to be translated
 set(MAPPER_GDAL_HEADERS
+  gdal_ogc_catalog.h
+  gdal_ogc_connection.h
+  gdal_ogc_dialog.h
+  gdal_online_raster_template.h
   ogr_file_format_p.h
 )
 	
@@ -31,6 +35,10 @@ set(MAPPER_GDAL_SOURCES
   gdal_file.cpp
   gdal_image_reader.cpp
   gdal_manager.cpp
+  gdal_ogc_catalog.cpp
+  gdal_ogc_connection.cpp
+  gdal_ogc_dialog.cpp
+  gdal_online_raster_template.cpp
   gdal_settings_page.cpp
   gdal_template.cpp
   kmz_groundoverlay_export.cpp
@@ -55,6 +63,9 @@ target_include_directories(mapper-gdal SYSTEM PRIVATE ${GDAL_INCLUDE_DIRS})
 target_include_directories(mapper-gdal PRIVATE "${PROJECT_SOURCE_DIR}/src")
 
 target_link_libraries(mapper-gdal ${GDAL_LIBRARIES} Qt5::Core Qt5::Gui Qt5::Widgets Mapper_Common)
+if(WIN32)
+  target_link_libraries(mapper-gdal advapi32)
+endif()
 
 set_target_properties(mapper-gdal PROPERTIES PREFIX "")
 

--- a/src/gdal/gdal_ogc_catalog.cpp
+++ b/src/gdal/gdal_ogc_catalog.cpp
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2026 The OpenOrienteering developers
+ *
+ * This file is part of OpenOrienteering.
+ * OpenOrienteering is free software under GNU GPL version 3 or later.
+ */
+
+#include "gdal/gdal_ogc_catalog.h"
+
+#include <utility>
+
+#include <QByteArray>
+#include <QCoreApplication>
+#include <QRegularExpression>
+#include <QUrl>
+#include <QUrlQuery>
+
+#include <cpl_error.h>
+#include <cpl_string.h>
+#include <gdal.h>
+
+#include "gdal/gdal_manager.h"
+
+namespace OpenOrienteering {
+namespace {
+
+QString trCatalog(const char* source_text)
+{
+	return QCoreApplication::translate("OpenOrienteering::GdalOgcCatalog", source_text);
+}
+
+QString queryValueCaseInsensitive(const QUrlQuery& query, const QString& key)
+{
+	for (const auto& item : query.queryItems(QUrl::FullyDecoded))
+	{
+		if (item.first.compare(key, Qt::CaseInsensitive) == 0)
+			return item.second;
+	}
+	return {};
+}
+
+QString optionValue(const QString& text, const QString& key)
+{
+	const QRegularExpression expression(
+	        QStringLiteral("(?:^|,)%1=([^,]+)").arg(QRegularExpression::escape(key)),
+	        QRegularExpression::CaseInsensitiveOption);
+	const auto match = expression.match(text);
+	return match.hasMatch() ? QUrl::fromPercentEncoding(match.captured(1).toUtf8()) : QString{};
+}
+
+QString friendlyError(GdalOgcConnection::ServiceType type, const QString& raw)
+{
+	const QString service = gdalOgcServiceTypeName(type);
+	if (raw.isEmpty())
+		return trCatalog("%1 service could not be opened.").arg(service);
+	if (raw.contains(QStringLiteral("401")) || raw.contains(QStringLiteral("403"))
+	    || raw.contains(QStringLiteral("authentication"), Qt::CaseInsensitive))
+	{
+		return trCatalog("%1 authentication was rejected: %2").arg(service, raw);
+	}
+	if (raw.contains(QStringLiteral("timed out"), Qt::CaseInsensitive)
+	    || raw.contains(QStringLiteral("timeout"), Qt::CaseInsensitive))
+	{
+		return trCatalog("%1 server did not respond before the timeout: %2").arg(service, raw);
+	}
+	if (raw.contains(QStringLiteral("SSL"), Qt::CaseInsensitive)
+	    || raw.contains(QStringLiteral("certificate"), Qt::CaseInsensitive))
+	{
+		return trCatalog("%1 HTTPS/TLS connection failed: %2").arg(service, raw);
+	}
+	if (raw.contains(QStringLiteral("HTTP"), Qt::CaseInsensitive))
+		return trCatalog("%1 server returned an HTTP error: %2").arg(service, raw);
+	return trCatalog("%1 connection failed: %2").arg(service, raw);
+}
+
+QString sanitizedDescription(const GdalOgcConnection& connection, const char* description)
+{
+	QString result = description ? QString::fromUtf8(description) : QString{};
+	if (connection.authentication == GdalOgcConnection::Authentication::ApiKey
+	    && connection.api_key_placement == GdalOgcConnection::ApiKeyPlacement::Query)
+	{
+		const QString secret = connection.effectiveSecret();
+		if (!secret.isEmpty())
+			result.replace(secret, QStringLiteral("***"), Qt::CaseSensitive);
+	}
+	return result;
+}
+
+GdalOgcCatalogResult openCatalog(const GdalOgcConnection& connection,
+                                 GdalOgcConnection::ServiceType type)
+{
+	GdalOgcCatalogResult result;
+	result.detected_type = type;
+
+	if (connection.needsSecret() && connection.effectiveSecret().isEmpty())
+	{
+		result.error = trCatalog("Authentication credentials are missing.");
+		return result;
+	}
+
+	GdalManager();
+	GdalOgcHttpGuard http_guard(connection);
+	CPLErrorReset();
+	const char* driver_name = type == GdalOgcConnection::ServiceType::Wmts ? "WMTS" : "WMS";
+	if (!GDALGetDriverByName(driver_name))
+	{
+		result.error = trCatalog("The packaged GDAL %1 driver is unavailable.")
+		               .arg(QString::fromLatin1(driver_name));
+		return result;
+	}
+
+	const QString service_url = connection.serviceUrlForRequest();
+	const QString open_name = (type == GdalOgcConnection::ServiceType::Wmts)
+	                          ? QStringLiteral("WMTS:") + service_url
+	                          : QStringLiteral("WMS:") + service_url;
+	const QByteArray open_name_utf8 = open_name.toUtf8();
+	const char* allowed_wmts[] = { "WMTS", nullptr };
+	const char* allowed_wms[] = { "WMS", nullptr };
+	const char* const* allowed = (type == GdalOgcConnection::ServiceType::Wmts)
+	                             ? allowed_wmts : allowed_wms;
+
+	GDALDatasetH dataset = GDALOpenEx(open_name_utf8.constData(),
+	                                  GDAL_OF_RASTER | GDAL_OF_READONLY | GDAL_OF_VERBOSE_ERROR,
+	                                  allowed, nullptr, nullptr);
+	if (!dataset)
+	{
+		const QString raw = connection.sanitizeForDisplay(QString::fromUtf8(CPLGetLastErrorMsg()));
+		result.error = friendlyError(type, raw);
+		return result;
+	}
+
+	CSLConstList metadata = GDALGetMetadata(dataset, "SUBDATASETS");
+	for (int i = 1; ; ++i)
+	{
+		const QByteArray name_key = QByteArrayLiteral("SUBDATASET_")
+		                            + QByteArray::number(i)
+		                            + QByteArrayLiteral("_NAME");
+		const char* name = CSLFetchNameValue(metadata, name_key.constData());
+		if (!name)
+			break;
+
+		const QByteArray desc_key = QByteArrayLiteral("SUBDATASET_")
+		                            + QByteArray::number(i)
+		                            + QByteArrayLiteral("_DESC");
+		const char* desc = CSLFetchNameValue(metadata, desc_key.constData());
+
+		result.sources.push_back(GdalOgcCatalog::describeSource(
+		        connection,
+		        QString::fromUtf8(name),
+		        sanitizedDescription(connection, desc)));
+	}
+
+	if (result.sources.isEmpty() && GDALGetRasterCount(dataset) > 0)
+	{
+		const char* opened_driver_name = GDALGetDriverShortName(GDALGetDatasetDriver(dataset));
+		auto source = GdalOgcCatalog::describeSource(
+		        connection,
+		        open_name,
+		        QStringLiteral("%1 — %2")
+		        .arg(gdalOgcServiceTypeName(type),
+		             QString::fromLatin1(opened_driver_name ? opened_driver_name : "GDAL")));
+		result.sources.push_back(std::move(source));
+	}
+
+	GDALClose(dataset);
+
+	if (result.sources.isEmpty())
+		result.error = trCatalog("The service contains no raster layers that GDAL can open.");
+
+	return result;
+}
+
+}  // namespace
+
+GdalOgcSource GdalOgcCatalog::describeSource(
+	const GdalOgcConnection& connection,
+	const QString& dataset_name,
+	const QString& description)
+{
+	GdalOgcSource source;
+	source.dataset_name = connection.sanitizeDatasetName(dataset_name);
+	source.description = connection.sanitizeForDisplay(description);
+	source.title = source.description.isEmpty() ? source.dataset_name : source.description;
+
+	QString parameters = source.dataset_name;
+	if (parameters.startsWith(QStringLiteral("WMS:"), Qt::CaseInsensitive))
+		parameters.remove(0, 4);
+	else if (parameters.startsWith(QStringLiteral("WMTS:"), Qt::CaseInsensitive))
+		parameters.remove(0, 5);
+
+	const int option_start = parameters.indexOf(QLatin1Char(','));
+	const QString url_text = option_start >= 0 ? parameters.left(option_start) : parameters;
+	const QUrlQuery query{QUrl{url_text}};
+	source.layer_name = queryValueCaseInsensitive(query, QStringLiteral("LAYERS"));
+	if (source.layer_name.isEmpty())
+		source.layer_name = queryValueCaseInsensitive(query, QStringLiteral("LAYER"));
+	source.crs = queryValueCaseInsensitive(query, QStringLiteral("CRS"));
+	if (source.crs.isEmpty())
+		source.crs = queryValueCaseInsensitive(query, QStringLiteral("SRS"));
+	source.format = queryValueCaseInsensitive(query, QStringLiteral("FORMAT"));
+	source.style = queryValueCaseInsensitive(query, QStringLiteral("STYLES"));
+
+	if (source.layer_name.isEmpty())
+		source.layer_name = optionValue(parameters, QStringLiteral("layer"));
+	if (source.style.isEmpty())
+		source.style = optionValue(parameters, QStringLiteral("style"));
+	if (source.format.isEmpty())
+		source.format = optionValue(parameters, QStringLiteral("format"));
+	source.tile_matrix_set = optionValue(parameters, QStringLiteral("tilematrixset"));
+
+	if (source.crs.isEmpty())
+	{
+		const QRegularExpression epsg(QStringLiteral("EPSG[:/](\\d+)"),
+		                              QRegularExpression::CaseInsensitiveOption);
+		const auto match = epsg.match(source.description + QLatin1Char(' ') + source.dataset_name);
+		if (match.hasMatch())
+			source.crs = QStringLiteral("EPSG:") + match.captured(1);
+	}
+	if (source.format.isEmpty())
+		source.format = QStringLiteral("image/png");
+	return source;
+}
+
+GdalOgcCatalogResult GdalOgcCatalog::discover(const GdalOgcConnection& connection)
+{
+	if (!connection.isValid())
+	{
+		GdalOgcCatalogResult result;
+		result.error = trCatalog("Invalid WMS/WMTS service URL or authentication settings.");
+		return result;
+	}
+
+	if (connection.service_type == GdalOgcConnection::ServiceType::Wms)
+		return openCatalog(connection, GdalOgcConnection::ServiceType::Wms);
+	if (connection.service_type == GdalOgcConnection::ServiceType::Wmts)
+		return openCatalog(connection, GdalOgcConnection::ServiceType::Wmts);
+
+	const bool wmts_hint = connection.service_url.contains(QStringLiteral("wmts"), Qt::CaseInsensitive);
+	const auto first_type = wmts_hint ? GdalOgcConnection::ServiceType::Wmts
+	                                  : GdalOgcConnection::ServiceType::Wms;
+	const auto second_type = wmts_hint ? GdalOgcConnection::ServiceType::Wms
+	                                   : GdalOgcConnection::ServiceType::Wmts;
+
+	auto first = openCatalog(connection, first_type);
+	if (first.ok())
+		return first;
+
+	auto second = openCatalog(connection, second_type);
+	if (second.ok())
+		return second;
+
+	GdalOgcCatalogResult result;
+	const QString wms_error = first_type == GdalOgcConnection::ServiceType::Wms
+	                          ? first.error : second.error;
+	const QString wmts_error = first_type == GdalOgcConnection::ServiceType::Wmts
+	                           ? first.error : second.error;
+	result.error = trCatalog("WMS: %1\nWMTS: %2").arg(wms_error, wmts_error);
+	return result;
+}
+
+}  // namespace OpenOrienteering

--- a/src/gdal/gdal_ogc_catalog.h
+++ b/src/gdal/gdal_ogc_catalog.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 The OpenOrienteering developers
+ *
+ * This file is part of OpenOrienteering.
+ * OpenOrienteering is free software under GNU GPL version 3 or later.
+ */
+
+#ifndef OPENORIENTEERING_GDAL_OGC_CATALOG_H
+#define OPENORIENTEERING_GDAL_OGC_CATALOG_H
+
+#include <QString>
+#include <QVector>
+
+#include "gdal/gdal_ogc_connection.h"
+
+namespace OpenOrienteering {
+
+struct GdalOgcSource
+{
+	QString dataset_name;
+	QString description;
+	QString title;
+	QString layer_name;
+	QString crs;
+	QString format;
+	QString style;
+	QString tile_matrix_set;
+};
+
+struct GdalOgcCatalogResult
+{
+	GdalOgcConnection::ServiceType detected_type = GdalOgcConnection::ServiceType::Auto;
+	QVector<GdalOgcSource> sources;
+	QString error;
+
+	bool ok() const { return !sources.isEmpty(); }
+};
+
+class GdalOgcCatalog
+{
+public:
+	static GdalOgcCatalogResult discover(const GdalOgcConnection& connection);
+	static GdalOgcSource describeSource(const GdalOgcConnection& connection,
+	                                   const QString& dataset_name,
+	                                   const QString& description);
+};
+
+}  // namespace OpenOrienteering
+
+#endif

--- a/src/gdal/gdal_ogc_connection.cpp
+++ b/src/gdal/gdal_ogc_connection.cpp
@@ -1,0 +1,407 @@
+/*
+ * Copyright 2026 The OpenOrienteering developers
+ *
+ * This file is part of OpenOrienteering.
+ * OpenOrienteering is free software under GNU GPL version 3 or later.
+ */
+
+#include "gdal/gdal_ogc_connection.h"
+
+#include <string>
+
+#include <QtGlobal>
+#include <QCoreApplication>
+#include <QCryptographicHash>
+#include <QDir>
+#include <QFileInfo>
+#include <QStandardPaths>
+#include <QUrl>
+#include <QUrlQuery>
+
+#include <cpl_conv.h>
+#include <gdal.h>
+
+#ifdef Q_OS_WIN
+#  include <windows.h>
+#  include <wincred.h>
+#endif
+
+namespace OpenOrienteering {
+namespace {
+
+QString credentialTarget(const QString& credential_id)
+{
+	return QStringLiteral("OpenOrienteeringMapper/OGC/") + credential_id;
+}
+
+QString addOrRemoveQuerySecret(const QString& input,
+                               const QString& key,
+                               const QString& value,
+                               bool add)
+{
+	QUrl url(input);
+	if (!url.isValid() || key.isEmpty())
+		return input;
+
+	QUrlQuery query(url);
+	query.removeAllQueryItems(key);
+	if (add && !value.isEmpty())
+		query.addQueryItem(key, value);
+	url.setQuery(query);
+	return url.toString(QUrl::FullyEncoded);
+}
+
+int wmtsOptionStart(const QString& text)
+{
+	int first = -1;
+	for (const auto& marker : {
+	         QStringLiteral(",layer="),
+	         QStringLiteral(",tilematrixset="),
+	         QStringLiteral(",tilematrix="),
+	         QStringLiteral(",zoom_level="),
+	         QStringLiteral(",style="),
+	         QStringLiteral(",extendbeyonddateline=") })
+	{
+		const int pos = text.indexOf(marker, 0, Qt::CaseInsensitive);
+		if (pos >= 0 && (first < 0 || pos < first))
+			first = pos;
+	}
+	return first;
+}
+
+QString rewriteDatasetUrl(const QString& dataset_name,
+                          const QString& key,
+                          const QString& value,
+                          bool add)
+{
+	if (key.isEmpty())
+		return dataset_name;
+
+	QString prefix;
+	QString remainder = dataset_name;
+	bool is_wmts = false;
+	if (remainder.startsWith(QStringLiteral("WMTS:"), Qt::CaseInsensitive))
+	{
+		prefix = remainder.left(5);
+		remainder.remove(0, 5);
+		is_wmts = true;
+	}
+	else if (remainder.startsWith(QStringLiteral("WMS:"), Qt::CaseInsensitive))
+	{
+		prefix = remainder.left(4);
+		remainder.remove(0, 4);
+	}
+	else
+	{
+		return addOrRemoveQuerySecret(dataset_name, key, value, add);
+	}
+
+	QString suffix;
+	if (is_wmts)
+	{
+		const int option_pos = wmtsOptionStart(remainder);
+		if (option_pos >= 0)
+		{
+			suffix = remainder.mid(option_pos);
+			remainder = remainder.left(option_pos);
+		}
+	}
+
+	return prefix + addOrRemoveQuerySecret(remainder, key, value, add) + suffix;
+}
+
+QByteArray cacheNamespace(const GdalOgcConnection& connection)
+{
+	QByteArray material = connection.serviceUrlForStorage().toUtf8();
+	material += '|';
+	material += QByteArray::number(static_cast<int>(connection.service_type));
+	material += '|';
+	material += QByteArray::number(static_cast<int>(connection.authentication));
+	material += '|';
+	material += connection.username.toUtf8();
+	material += '|';
+	material += connection.api_key_name.toUtf8();
+	material += '|';
+	material += connection.credential_id.toUtf8();
+	if (connection.credential_id.isEmpty() && connection.needsSecret())
+	{
+		material += '|';
+		material += QCryptographicHash::hash(connection.effectiveSecret().toUtf8(),
+		                                   QCryptographicHash::Sha256).toHex();
+	}
+	return QCryptographicHash::hash(material, QCryptographicHash::Sha256).toHex();
+}
+
+}  // namespace
+
+bool GdalOgcConnection::isValid() const
+{
+	const QUrl url(service_url);
+	return url.isValid()
+	       && !url.host().isEmpty()
+	       && (url.scheme().compare(QStringLiteral("http"), Qt::CaseInsensitive) == 0
+	           || url.scheme().compare(QStringLiteral("https"), Qt::CaseInsensitive) == 0)
+	       && (authentication != Authentication::ApiKey || !api_key_name.trimmed().isEmpty());
+}
+
+bool GdalOgcConnection::needsSecret() const
+{
+	return authentication != Authentication::None;
+}
+
+QString GdalOgcConnection::effectiveSecret() const
+{
+	if (!secret.isEmpty())
+		return secret;
+	if (!credential_id.isEmpty())
+		return loadSecretSecurely(credential_id);
+	return {};
+}
+
+QString GdalOgcConnection::serviceUrlForStorage() const
+{
+	if (authentication == Authentication::ApiKey
+	    && api_key_placement == ApiKeyPlacement::Query)
+	{
+		return addOrRemoveQuerySecret(service_url, api_key_name, QString{}, false);
+	}
+	return service_url;
+}
+
+QString GdalOgcConnection::serviceUrlForRequest() const
+{
+	const QString stored_url = serviceUrlForStorage();
+	if (authentication == Authentication::ApiKey
+	    && api_key_placement == ApiKeyPlacement::Query)
+	{
+		return addOrRemoveQuerySecret(stored_url, api_key_name, effectiveSecret(), true);
+	}
+	return stored_url;
+}
+
+QString GdalOgcConnection::datasetNameForRequest(const QString& stored_dataset_name) const
+{
+	if (authentication == Authentication::ApiKey
+	    && api_key_placement == ApiKeyPlacement::Query)
+	{
+		return rewriteDatasetUrl(stored_dataset_name, api_key_name, effectiveSecret(), true);
+	}
+	return stored_dataset_name;
+}
+
+QString GdalOgcConnection::sanitizeDatasetName(const QString& request_dataset_name) const
+{
+	if (authentication == Authentication::ApiKey
+	    && api_key_placement == ApiKeyPlacement::Query)
+	{
+		return rewriteDatasetUrl(request_dataset_name, api_key_name, QString{}, false);
+	}
+	return request_dataset_name;
+}
+
+QString GdalOgcConnection::sanitizeForDisplay(QString text) const
+{
+	const QString value = effectiveSecret();
+	if (!value.isEmpty())
+	{
+		text.replace(value, QStringLiteral("***"), Qt::CaseSensitive);
+		const QString encoded = QString::fromLatin1(QUrl::toPercentEncoding(value));
+		if (encoded != value)
+			text.replace(encoded, QStringLiteral("***"), Qt::CaseSensitive);
+	}
+	return text;
+}
+
+QString GdalOgcConnection::ensureCredentialId()
+{
+	if (!credential_id.isEmpty())
+		return credential_id;
+
+	QByteArray material;
+	material += serviceUrlForStorage().toUtf8();
+	material += '|';
+	material += QByteArray::number(static_cast<int>(authentication));
+	material += '|';
+	material += username.toUtf8();
+	material += '|';
+	material += api_key_name.toUtf8();
+
+	credential_id = QString::fromLatin1(
+	        QCryptographicHash::hash(material, QCryptographicHash::Sha256).toHex());
+	return credential_id;
+}
+
+bool GdalOgcConnection::storeSecretSecurely()
+{
+	if (!needsSecret() || secret.isEmpty())
+		return true;
+
+#ifdef Q_OS_WIN
+	const QString target = credentialTarget(ensureCredentialId());
+	const std::wstring target_w = target.toStdWString();
+	const std::wstring username_w = username.toStdWString();
+	const QByteArray blob = secret.toUtf8();
+
+	CREDENTIALW credential {};
+	credential.Type = CRED_TYPE_GENERIC;
+	credential.TargetName = const_cast<LPWSTR>(target_w.c_str());
+	credential.CredentialBlobSize = static_cast<DWORD>(blob.size());
+	credential.CredentialBlob = reinterpret_cast<LPBYTE>(const_cast<char*>(blob.constData()));
+	credential.Persist = CRED_PERSIST_LOCAL_MACHINE;
+	credential.UserName = username_w.empty() ? nullptr : const_cast<LPWSTR>(username_w.c_str());
+	return CredWriteW(&credential, 0) == TRUE;
+#else
+	return false;
+#endif
+}
+
+bool GdalOgcConnection::secureCredentialStoreAvailable()
+{
+#ifdef Q_OS_WIN
+	return true;
+#else
+	return false;
+#endif
+}
+
+QString GdalOgcConnection::loadSecretSecurely(const QString& credential_id)
+{
+#ifdef Q_OS_WIN
+	if (credential_id.isEmpty())
+		return {};
+
+	const std::wstring target_w = credentialTarget(credential_id).toStdWString();
+	PCREDENTIALW credential = nullptr;
+	if (!CredReadW(target_w.c_str(), CRED_TYPE_GENERIC, 0, &credential))
+		return {};
+
+	const QByteArray blob(
+	        reinterpret_cast<const char*>(credential->CredentialBlob),
+	        static_cast<int>(credential->CredentialBlobSize));
+	CredFree(credential);
+	return QString::fromUtf8(blob);
+#else
+	Q_UNUSED(credential_id)
+	return {};
+#endif
+}
+
+GdalOgcHttpGuard::GdalOgcHttpGuard(const GdalOgcConnection& connection)
+: effective_secret(connection.effectiveSecret().toUtf8())
+{
+	const QString cache_root = QStandardPaths::writableLocation(QStandardPaths::CacheLocation)
+	                           + QStringLiteral("/gdal-ogc/")
+	                           + QString::fromLatin1(cacheNamespace(connection));
+	QDir().mkpath(cache_root);
+	cache_path = cache_root.toUtf8();
+
+	setOption("GDAL_DEFAULT_WMS_CACHE_PATH", cache_path);
+	setOption("GDAL_ENABLE_WMS_CACHE", QByteArrayLiteral("YES"));
+	setOption("GDAL_MAX_CONNECTIONS", QByteArrayLiteral("6"));
+	setOption("GDAL_HTTP_CONNECTTIMEOUT", QByteArrayLiteral("8"));
+	setOption("GDAL_HTTP_TIMEOUT", QByteArrayLiteral("25"));
+	setOption("GDAL_HTTP_MAX_RETRY", QByteArrayLiteral("1"));
+	setOption("GDAL_HTTP_RETRY_DELAY", QByteArrayLiteral("1"));
+	setOption("GDAL_HTTP_USERAGENT", QByteArrayLiteral("OpenOrienteering Mapper OGC client"));
+#ifdef Q_OS_WIN
+	const QString ca_bundle = gdalOgcBundledCaBundlePath();
+	if (!ca_bundle.isEmpty())
+	{
+		ca_bundle_path = ca_bundle.toLocal8Bit();
+		setOption("CURL_CA_BUNDLE", ca_bundle_path);
+		setOption("SSL_CERT_FILE", ca_bundle_path);
+	}
+	setOption("GDAL_HTTP_USE_CAPI_STORE", QByteArrayLiteral("YES"));
+#endif
+
+	switch (connection.authentication)
+	{
+	case GdalOgcConnection::Authentication::None:
+		break;
+	case GdalOgcConnection::Authentication::Basic:
+		auth_value = QByteArrayLiteral("BASIC");
+		userpwd_value = connection.username.toUtf8() + ':' + effective_secret;
+		setOption("GDAL_HTTP_AUTH", auth_value);
+		setOption("GDAL_HTTP_USERPWD", userpwd_value);
+		break;
+	case GdalOgcConnection::Authentication::Bearer:
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 9, 0)
+		auth_value = QByteArrayLiteral("BEARER");
+		bearer_value = effective_secret;
+		setOption("GDAL_HTTP_AUTH", auth_value);
+		setOption("GDAL_HTTP_BEARER", bearer_value);
+#else
+		headers_value = QByteArrayLiteral("Authorization: Bearer ") + effective_secret;
+		setOption("GDAL_HTTP_HEADERS", headers_value);
+#endif
+		break;
+	case GdalOgcConnection::Authentication::ApiKey:
+		if (connection.api_key_placement == GdalOgcConnection::ApiKeyPlacement::Header)
+		{
+			headers_value = connection.api_key_name.toUtf8()
+			                + QByteArrayLiteral(": ") + effective_secret;
+			setOption("GDAL_HTTP_HEADERS", headers_value);
+		}
+		break;
+	}
+}
+
+GdalOgcHttpGuard::~GdalOgcHttpGuard()
+{
+	clearOptions();
+}
+
+void GdalOgcHttpGuard::setOption(const char* key, const QByteArray& value)
+{
+	CPLSetThreadLocalConfigOption(key, value.constData());
+}
+
+void GdalOgcHttpGuard::clearOptions()
+{
+	for (const char* key : {
+	         "GDAL_DEFAULT_WMS_CACHE_PATH",
+	         "GDAL_ENABLE_WMS_CACHE",
+	         "GDAL_MAX_CONNECTIONS",
+	         "GDAL_HTTP_CONNECTTIMEOUT",
+	         "GDAL_HTTP_TIMEOUT",
+	         "GDAL_HTTP_MAX_RETRY",
+	         "GDAL_HTTP_RETRY_DELAY",
+	         "GDAL_HTTP_USERAGENT",
+	         "CURL_CA_BUNDLE",
+	         "SSL_CERT_FILE",
+	         "GDAL_HTTP_USE_CAPI_STORE",
+	         "GDAL_HTTP_AUTH",
+	         "GDAL_HTTP_USERPWD",
+	         "GDAL_HTTP_BEARER",
+	         "GDAL_HTTP_HEADERS" })
+	{
+		CPLSetThreadLocalConfigOption(key, nullptr);
+	}
+}
+
+QString gdalOgcBundledCaBundlePath()
+{
+#ifdef Q_OS_WIN
+	const QString candidate = QDir(QCoreApplication::applicationDirPath())
+	                          .filePath(QStringLiteral("certs/ca-bundle.crt"));
+	const QFileInfo bundle(candidate);
+	if (bundle.isFile() && bundle.isReadable())
+		return QDir::toNativeSeparators(bundle.absoluteFilePath());
+#endif
+	return {};
+}
+
+QString gdalOgcServiceTypeName(GdalOgcConnection::ServiceType type)
+{
+	switch (type)
+	{
+	case GdalOgcConnection::ServiceType::Wms:
+		return QStringLiteral("WMS");
+	case GdalOgcConnection::ServiceType::Wmts:
+		return QStringLiteral("WMTS");
+	default:
+		return QStringLiteral("Auto");
+	}
+}
+
+}  // namespace OpenOrienteering

--- a/src/gdal/gdal_ogc_connection.h
+++ b/src/gdal/gdal_ogc_connection.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 The OpenOrienteering developers
+ *
+ * This file is part of OpenOrienteering.
+ * OpenOrienteering is free software under GNU GPL version 3 or later.
+ */
+
+#ifndef OPENORIENTEERING_GDAL_OGC_CONNECTION_H
+#define OPENORIENTEERING_GDAL_OGC_CONNECTION_H
+
+#include <QByteArray>
+#include <QString>
+
+namespace OpenOrienteering {
+
+struct GdalOgcConnection
+{
+	enum class ServiceType
+	{
+		Auto = 0,
+		Wms,
+		Wmts
+	};
+
+	enum class Authentication
+	{
+		None = 0,
+		Basic,
+		Bearer,
+		ApiKey
+	};
+
+	enum class ApiKeyPlacement
+	{
+		Header = 0,
+		Query
+	};
+
+	ServiceType service_type = ServiceType::Auto;
+	QString name;
+	QString service_url;
+	Authentication authentication = Authentication::None;
+	QString username;
+	QString secret;
+	QString api_key_name;
+	ApiKeyPlacement api_key_placement = ApiKeyPlacement::Header;
+	QString credential_id;
+
+	bool isValid() const;
+	bool needsSecret() const;
+	QString effectiveSecret() const;
+
+	QString serviceUrlForStorage() const;
+	QString serviceUrlForRequest() const;
+	QString datasetNameForRequest(const QString& stored_dataset_name) const;
+	QString sanitizeDatasetName(const QString& request_dataset_name) const;
+	QString sanitizeForDisplay(QString text) const;
+
+	QString ensureCredentialId();
+	bool storeSecretSecurely();
+
+	static bool secureCredentialStoreAvailable();
+	static QString loadSecretSecurely(const QString& credential_id);
+};
+
+class GdalOgcHttpGuard
+{
+public:
+	explicit GdalOgcHttpGuard(const GdalOgcConnection& connection);
+	~GdalOgcHttpGuard();
+
+	GdalOgcHttpGuard(const GdalOgcHttpGuard&) = delete;
+	GdalOgcHttpGuard& operator=(const GdalOgcHttpGuard&) = delete;
+
+private:
+	void setOption(const char* key, const QByteArray& value);
+	void clearOptions();
+
+	QByteArray cache_path;
+	QByteArray ca_bundle_path;
+	QByteArray effective_secret;
+	QByteArray auth_value;
+	QByteArray userpwd_value;
+	QByteArray bearer_value;
+	QByteArray headers_value;
+};
+
+/** Returns the packaged TLS CA bundle used by GDAL/libcurl, if available. */
+QString gdalOgcBundledCaBundlePath();
+
+QString gdalOgcServiceTypeName(GdalOgcConnection::ServiceType type);
+
+}  // namespace OpenOrienteering
+
+#endif

--- a/src/gdal/gdal_ogc_dialog.cpp
+++ b/src/gdal/gdal_ogc_dialog.cpp
@@ -1,0 +1,623 @@
+/*
+ * Copyright 2026 The OpenOrienteering developers
+ *
+ * This file is part of OpenOrienteering.
+ * OpenOrienteering is free software under GNU GPL version 3 or later.
+ */
+
+#include "gdal/gdal_ogc_dialog.h"
+
+#include <functional>
+#include <algorithm>
+#include <utility>
+
+#include <QCheckBox>
+#include <QAbstractItemView>
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QFormLayout>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMessageBox>
+#include <QMetaObject>
+#include <QPointer>
+#include <QPushButton>
+#include <QRunnable>
+#include <QRegularExpression>
+#include <QSettings>
+#include <QSignalBlocker>
+#include <QStackedWidget>
+#include <QThreadPool>
+#include <QTreeWidget>
+#include <QTreeWidgetItem>
+#include <QUrl>
+#include <QVBoxLayout>
+#include <QWidget>
+
+namespace OpenOrienteering {
+namespace {
+
+class CatalogTask final : public QRunnable
+{
+public:
+	CatalogTask(GdalOgcConnection connection,
+	            std::function<void(GdalOgcCatalogResult)> completion)
+	: connection(std::move(connection))
+	, completion(std::move(completion))
+	{}
+
+	void run() override
+	{
+		completion(GdalOgcCatalog::discover(connection));
+	}
+
+private:
+	GdalOgcConnection connection;
+	std::function<void(GdalOgcCatalogResult)> completion;
+};
+
+class PrepareSelectionTask final : public QRunnable
+{
+public:
+	PrepareSelectionTask(GdalOgcConnection connection,
+	                     QString dataset_name,
+	                     QString map_crs_spec,
+	                     std::function<void(GdalOnlinePreparedDataPtr, QString)> completion)
+	: connection(std::move(connection))
+	, dataset_name(std::move(dataset_name))
+	, map_crs_spec(std::move(map_crs_spec))
+	, completion(std::move(completion))
+	{}
+
+	void run() override
+	{
+		QString error;
+		auto prepared = GdalOnlineRasterTemplate::prepareDataset(
+		        connection, dataset_name, map_crs_spec, error);
+		completion(std::move(prepared), std::move(error));
+	}
+
+private:
+	GdalOgcConnection connection;
+	QString dataset_name;
+	QString map_crs_spec;
+	std::function<void(GdalOnlinePreparedDataPtr, QString)> completion;
+};
+
+const auto connections_array = QStringLiteral("GDAL/online-raster-connections");
+
+void writeConnection(QSettings& settings, const GdalOgcConnection& connection)
+{
+	settings.setValue(QStringLiteral("name"), connection.name);
+	settings.setValue(QStringLiteral("url"), connection.serviceUrlForStorage());
+	settings.setValue(QStringLiteral("service-type"), static_cast<int>(connection.service_type));
+	settings.setValue(QStringLiteral("authentication"), static_cast<int>(connection.authentication));
+	settings.setValue(QStringLiteral("username"), connection.username);
+	settings.setValue(QStringLiteral("api-key-name"), connection.api_key_name);
+	settings.setValue(QStringLiteral("api-key-placement"), static_cast<int>(connection.api_key_placement));
+	settings.setValue(QStringLiteral("credential-id"), connection.credential_id);
+}
+
+GdalOgcConnection readConnection(QSettings& settings)
+{
+	GdalOgcConnection connection;
+	connection.name = settings.value(QStringLiteral("name")).toString();
+	connection.service_url = settings.value(QStringLiteral("url")).toString();
+	connection.service_type = static_cast<GdalOgcConnection::ServiceType>(
+	        settings.value(QStringLiteral("service-type")).toInt());
+	connection.authentication = static_cast<GdalOgcConnection::Authentication>(
+	        settings.value(QStringLiteral("authentication")).toInt());
+	connection.username = settings.value(QStringLiteral("username")).toString();
+	connection.api_key_name = settings.value(QStringLiteral("api-key-name")).toString();
+	connection.api_key_placement = static_cast<GdalOgcConnection::ApiKeyPlacement>(
+	        settings.value(QStringLiteral("api-key-placement")).toInt());
+	connection.credential_id = settings.value(QStringLiteral("credential-id")).toString();
+	return connection;
+}
+
+QWidget* noAuthenticationPage(QWidget* parent)
+{
+	auto* page = new QWidget(parent);
+	auto* layout = new QHBoxLayout(page);
+	layout->setContentsMargins(0, 0, 0, 0);
+	layout->addWidget(new QLabel(GdalOgcDialog::tr("No credentials required."), page));
+	layout->addStretch();
+	return page;
+}
+
+}  // namespace
+
+GdalOgcDialog::GdalOgcDialog(const QString& preferred_crs, QWidget* parent)
+: QDialog(parent)
+, preferred_crs(preferred_crs)
+{
+	setWindowTitle(tr("Add WMS/WMTS background map"));
+	resize(900, 600);
+
+	saved_connection_box = new QComboBox(this);
+	saved_connection_box->addItem(tr("New connection..."), -1);
+
+	name_edit = new QLineEdit(this);
+	name_edit->setPlaceholderText(tr("Example: Regional orthophoto service"));
+
+	service_type_box = new QComboBox(this);
+	service_type_box->addItem(tr("Auto detect"), static_cast<int>(GdalOgcConnection::ServiceType::Auto));
+	service_type_box->addItem(QStringLiteral("WMS"), static_cast<int>(GdalOgcConnection::ServiceType::Wms));
+	service_type_box->addItem(QStringLiteral("WMTS"), static_cast<int>(GdalOgcConnection::ServiceType::Wmts));
+
+	url_edit = new QLineEdit(this);
+	url_edit->setPlaceholderText(tr("https://server.example/ogc/service"));
+
+	authentication_box = new QComboBox(this);
+	authentication_box->addItem(tr("None"), static_cast<int>(GdalOgcConnection::Authentication::None));
+	authentication_box->addItem(tr("Username / password"), static_cast<int>(GdalOgcConnection::Authentication::Basic));
+	authentication_box->addItem(tr("Bearer token"), static_cast<int>(GdalOgcConnection::Authentication::Bearer));
+	authentication_box->addItem(tr("API key"), static_cast<int>(GdalOgcConnection::Authentication::ApiKey));
+
+	authentication_stack = new QStackedWidget(this);
+	authentication_stack->addWidget(noAuthenticationPage(authentication_stack));
+
+	{
+		auto* page = new QWidget(authentication_stack);
+		auto* form = new QFormLayout(page);
+		form->setContentsMargins(0, 0, 0, 0);
+		username_edit = new QLineEdit(page);
+		password_edit = new QLineEdit(page);
+		password_edit->setEchoMode(QLineEdit::Password);
+		form->addRow(tr("Username:"), username_edit);
+		form->addRow(tr("Password:"), password_edit);
+		authentication_stack->addWidget(page);
+	}
+
+	{
+		auto* page = new QWidget(authentication_stack);
+		auto* form = new QFormLayout(page);
+		form->setContentsMargins(0, 0, 0, 0);
+		bearer_edit = new QLineEdit(page);
+		bearer_edit->setEchoMode(QLineEdit::Password);
+		form->addRow(tr("Token:"), bearer_edit);
+		authentication_stack->addWidget(page);
+	}
+
+	{
+		auto* page = new QWidget(authentication_stack);
+		auto* form = new QFormLayout(page);
+		form->setContentsMargins(0, 0, 0, 0);
+		api_key_name_edit = new QLineEdit(page);
+		api_key_name_edit->setPlaceholderText(QStringLiteral("X-API-Key"));
+		api_key_value_edit = new QLineEdit(page);
+		api_key_value_edit->setEchoMode(QLineEdit::Password);
+		api_key_placement_box = new QComboBox(page);
+		api_key_placement_box->addItem(tr("HTTP header"), static_cast<int>(GdalOgcConnection::ApiKeyPlacement::Header));
+		api_key_placement_box->addItem(tr("URL query parameter"), static_cast<int>(GdalOgcConnection::ApiKeyPlacement::Query));
+		form->addRow(tr("Key name:"), api_key_name_edit);
+		form->addRow(tr("Key value:"), api_key_value_edit);
+		form->addRow(tr("Send as:"), api_key_placement_box);
+		authentication_stack->addWidget(page);
+	}
+
+	remember_credentials_box = new QCheckBox(tr("Remember credentials securely on this computer"), this);
+	remember_credentials_box->setChecked(GdalOgcConnection::secureCredentialStoreAvailable());
+	remember_credentials_box->setEnabled(GdalOgcConnection::secureCredentialStoreAvailable());
+
+	connect_button = new QPushButton(tr("Connect"), this);
+	status_label = new QLabel(tr("Not connected"), this);
+	status_label->setWordWrap(true);
+
+	source_tree = new QTreeWidget(this);
+	source_tree->setEnabled(false);
+	source_tree->setRootIsDecorated(false);
+	source_tree->setUniformRowHeights(true);
+	source_tree->setSelectionMode(QAbstractItemView::SingleSelection);
+	source_tree->setHeaderLabels({ tr("Title"), tr("Name"), tr("CRS / Tile matrix set"),
+	                               tr("Format"), tr("Style") });
+	source_tree->header()->setSectionResizeMode(0, QHeaderView::Stretch);
+	for (int column = 1; column < 5; ++column)
+		source_tree->header()->setSectionResizeMode(column, QHeaderView::ResizeToContents);
+	source_tree->setMinimumHeight(190);
+
+	auto* form = new QFormLayout();
+	form->addRow(tr("Saved connection:"), saved_connection_box);
+	form->addRow(tr("Name:"), name_edit);
+	form->addRow(tr("Service type:"), service_type_box);
+	form->addRow(tr("Service URL:"), url_edit);
+	form->addRow(tr("Authentication:"), authentication_box);
+	form->addRow(tr("Credentials:"), authentication_stack);
+	form->addRow(QString{}, remember_credentials_box);
+	form->addRow(QString{}, connect_button);
+	form->addRow(tr("Status:"), status_label);
+	form->addRow(tr("Layer:"), source_tree);
+
+	button_box = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+	button_box->button(QDialogButtonBox::Ok)->setText(tr("Add"));
+	button_box->button(QDialogButtonBox::Ok)->setEnabled(false);
+
+	auto* layout = new QVBoxLayout(this);
+	layout->addLayout(form);
+	layout->addStretch();
+	layout->addWidget(button_box);
+
+	connect(saved_connection_box, QOverload<int>::of(&QComboBox::currentIndexChanged),
+	        this, &GdalOgcDialog::savedConnectionChanged);
+	connect(authentication_box, QOverload<int>::of(&QComboBox::currentIndexChanged),
+	        this, &GdalOgcDialog::authenticationChanged);
+	connect(service_type_box, QOverload<int>::of(&QComboBox::currentIndexChanged),
+	        this, [this](int) { resetCredentialReference(); clearSources(); });
+	connect(name_edit, &QLineEdit::textEdited, this, [this](const QString&) { clearSources(); });
+	connect(url_edit, &QLineEdit::textEdited, this, [this](const QString&) {
+		resetCredentialReference();
+		clearSources();
+	});
+	for (auto* edit : { username_edit, password_edit, bearer_edit, api_key_name_edit, api_key_value_edit })
+		connect(edit, &QLineEdit::textEdited, this, [this](const QString&) {
+			resetCredentialReference();
+			clearSources();
+		});
+	connect(api_key_placement_box, QOverload<int>::of(&QComboBox::currentIndexChanged),
+	        this, [this](int) { resetCredentialReference(); clearSources(); });
+	connect(remember_credentials_box, &QCheckBox::toggled, this, [this](bool checked) {
+		if (checked || form_credential_id.isEmpty() || populating_form)
+			return;
+		const QString secret = GdalOgcConnection::loadSecretSecurely(form_credential_id);
+		const auto authentication = static_cast<GdalOgcConnection::Authentication>(
+		        authentication_box->currentData().toInt());
+		if (authentication == GdalOgcConnection::Authentication::Basic)
+			password_edit->setText(secret);
+		else if (authentication == GdalOgcConnection::Authentication::Bearer)
+			bearer_edit->setText(secret);
+		else if (authentication == GdalOgcConnection::Authentication::ApiKey)
+			api_key_value_edit->setText(secret);
+		resetCredentialReference();
+	});
+	connect(connect_button, &QPushButton::clicked, this, [this]() {
+		if (busy)
+			cancelRequest();
+		else
+			testConnection();
+	});
+	connect(button_box, &QDialogButtonBox::accepted, this, &GdalOgcDialog::acceptSelection);
+	connect(button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+	authenticationChanged(authentication_box->currentIndex());
+	loadSavedConnections();
+}
+
+void GdalOgcDialog::authenticationChanged(int index)
+{
+	authentication_stack->setCurrentIndex(index);
+	const auto auth = static_cast<GdalOgcConnection::Authentication>(authentication_box->currentData().toInt());
+	remember_credentials_box->setEnabled(auth != GdalOgcConnection::Authentication::None
+	                                      && GdalOgcConnection::secureCredentialStoreAvailable());
+	if (auth == GdalOgcConnection::Authentication::None)
+		remember_credentials_box->setChecked(false);
+	else if (GdalOgcConnection::secureCredentialStoreAvailable())
+		remember_credentials_box->setChecked(true);
+	resetCredentialReference();
+	clearSources();
+}
+
+GdalOgcConnection GdalOgcDialog::connectionFromForm() const
+{
+	GdalOgcConnection connection;
+	connection.name = name_edit->text().trimmed();
+	connection.service_type = static_cast<GdalOgcConnection::ServiceType>(service_type_box->currentData().toInt());
+	connection.service_url = QUrl::fromUserInput(url_edit->text().trimmed()).toString(QUrl::FullyEncoded);
+	connection.authentication = static_cast<GdalOgcConnection::Authentication>(authentication_box->currentData().toInt());
+	connection.credential_id = form_credential_id;
+
+	switch (connection.authentication)
+	{
+	case GdalOgcConnection::Authentication::None:
+		break;
+	case GdalOgcConnection::Authentication::Basic:
+		connection.username = username_edit->text();
+		connection.secret = password_edit->text();
+		break;
+	case GdalOgcConnection::Authentication::Bearer:
+		connection.secret = bearer_edit->text();
+		break;
+	case GdalOgcConnection::Authentication::ApiKey:
+		connection.api_key_name = api_key_name_edit->text().trimmed();
+		connection.secret = api_key_value_edit->text();
+		connection.api_key_placement = static_cast<GdalOgcConnection::ApiKeyPlacement>(api_key_placement_box->currentData().toInt());
+		break;
+	}
+	connection.service_url = connection.serviceUrlForStorage();
+	return connection;
+}
+
+void GdalOgcDialog::testConnection()
+{
+	const GdalOgcConnection connection = connectionFromForm();
+	clearSources();
+	if (connection.name.isEmpty())
+	{
+		status_label->setText(tr("Enter a connection name first."));
+		return;
+	}
+	if (!connection.isValid())
+	{
+		status_label->setText(tr("Invalid service URL or authentication settings."));
+		return;
+	}
+	if (connection.needsSecret() && connection.effectiveSecret().isEmpty())
+	{
+		status_label->setText(tr("Enter the authentication secret first."));
+		return;
+	}
+
+	setBusy(true);
+	status_label->setText(tr("Connecting and reading service capabilities..."));
+	const quint64 serial = ++request_serial;
+
+	QPointer<GdalOgcDialog> guard(this);
+	auto completion = [guard, connection, serial](GdalOgcCatalogResult result) mutable {
+		if (!guard)
+			return;
+		QMetaObject::invokeMethod(guard.data(), [guard, connection, serial, result = std::move(result)]() mutable {
+			if (guard)
+				guard->finishDiscovery(serial, connection, std::move(result));
+		}, Qt::QueuedConnection);
+	};
+
+	auto* task = new CatalogTask(connection, std::move(completion));
+	task->setAutoDelete(true);
+	QThreadPool::globalInstance()->start(task);
+}
+
+void GdalOgcDialog::cancelRequest()
+{
+	++request_serial;
+	preparing_layer = false;
+	setBusy(false);
+	status_label->setText(tr("Request cancelled."));
+}
+
+void GdalOgcDialog::finishDiscovery(quint64 serial,
+                                    const GdalOgcConnection& connection,
+                                    GdalOgcCatalogResult result)
+{
+	if (serial != request_serial)
+		return;
+	setBusy(false);
+	if (!result.ok())
+	{
+		status_label->setText(result.error.isEmpty()
+		                      ? tr("The service could not be opened.")
+		                      : result.error);
+		return;
+	}
+
+	active_connection = connection;
+	active_connection.service_type = result.detected_type;
+	active_sources = std::move(result.sources);
+
+	QString preferred_authority = preferred_crs;
+	const QRegularExpression epsg_expression(QStringLiteral("EPSG[:/](\\d+)"),
+	                                         QRegularExpression::CaseInsensitiveOption);
+	const auto preferred_match = epsg_expression.match(preferred_crs);
+	if (preferred_match.hasMatch())
+		preferred_authority = QStringLiteral("EPSG:") + preferred_match.captured(1);
+	auto preferred = [&preferred_authority](const GdalOgcSource& source) {
+		return !preferred_authority.isEmpty()
+		       && (source.crs.compare(preferred_authority, Qt::CaseInsensitive) == 0
+		           || source.dataset_name.contains(preferred_authority, Qt::CaseInsensitive));
+	};
+	std::stable_sort(active_sources.begin(), active_sources.end(),
+	                 [&preferred](const GdalOgcSource& a, const GdalOgcSource& b) {
+		return preferred(a) && !preferred(b);
+	});
+
+	for (int index = 0; index < active_sources.size(); ++index)
+	{
+		const auto& source = active_sources.at(index);
+		QString crs = source.crs;
+		if (!source.tile_matrix_set.isEmpty())
+			crs += (crs.isEmpty() ? QString{} : QStringLiteral(" / ")) + source.tile_matrix_set;
+		auto* item = new QTreeWidgetItem(source_tree,
+		        { source.title, source.layer_name, crs, source.format, source.style });
+		item->setData(0, Qt::UserRole, index);
+		item->setToolTip(0, source.description);
+	}
+	source_tree->setEnabled(true);
+	if (source_tree->topLevelItemCount() > 0)
+		source_tree->setCurrentItem(source_tree->topLevelItem(0));
+	button_box->button(QDialogButtonBox::Ok)->setEnabled(true);
+	connect_button->setText(tr("Refresh"));
+	status_label->setText(tr("Connected. %1 source(s) available via %2.")
+	                      .arg(active_sources.size())
+	                      .arg(gdalOgcServiceTypeName(active_connection.service_type)));
+}
+
+void GdalOgcDialog::acceptSelection()
+{
+	const auto* item = source_tree->currentItem();
+	const int index = item ? item->data(0, Qt::UserRole).toInt() : -1;
+	if (index < 0 || index >= active_sources.size())
+		return;
+
+	selected.connection = active_connection;
+	selected.source = active_sources.at(index);
+	selected.prepared_data.reset();
+	preparing_layer = true;
+	setBusy(true);
+	status_label->setText(tr("Opening the selected layer and verifying map imagery..."));
+	const quint64 serial = ++request_serial;
+
+	QPointer<GdalOgcDialog> guard(this);
+	auto completion = [guard, serial](GdalOnlinePreparedDataPtr prepared, QString error) mutable {
+		if (!guard)
+			return;
+		QMetaObject::invokeMethod(guard.data(),
+		                          [guard, serial, prepared = std::move(prepared),
+		                           error = std::move(error)]() mutable {
+			if (guard)
+				guard->finishPreparation(serial, std::move(prepared), error);
+		},
+		                          Qt::QueuedConnection);
+	};
+	auto* task = new PrepareSelectionTask(selected.connection,
+	                                      selected.source.dataset_name,
+	                                      preferred_crs,
+	                                      std::move(completion));
+	task->setAutoDelete(true);
+	QThreadPool::globalInstance()->start(task);
+}
+
+void GdalOgcDialog::finishPreparation(
+	quint64 serial,
+	GdalOnlinePreparedDataPtr prepared_data,
+	const QString& error)
+{
+	if (serial != request_serial)
+		return;
+	preparing_layer = false;
+	setBusy(false);
+	if (!prepared_data)
+	{
+		status_label->setText(error.isEmpty()
+		                      ? tr("The selected layer could not be opened.")
+		                      : selected.connection.sanitizeForDisplay(error));
+		return;
+	}
+	selected.prepared_data = std::move(prepared_data);
+
+	if (remember_credentials_box->isChecked() && selected.connection.needsSecret())
+	{
+		if (!selected.connection.storeSecretSecurely())
+		{
+			QMessageBox::warning(this,
+			                     tr("Credential storage"),
+			                     tr("Windows Credential Manager could not store these credentials. "
+			                        "They will be used only in the current Mapper session."));
+			selected.connection.credential_id.clear();
+		}
+		else
+		{
+			selected.connection.secret.clear();
+			form_credential_id = selected.connection.credential_id;
+		}
+	}
+
+	saveConnectionDefinition(selected.connection);
+	accept();
+}
+
+void GdalOgcDialog::setBusy(bool busy_value)
+{
+	busy = busy_value;
+	saved_connection_box->setEnabled(!busy);
+	name_edit->setEnabled(!busy);
+	service_type_box->setEnabled(!busy);
+	url_edit->setEnabled(!busy);
+	authentication_box->setEnabled(!busy);
+	authentication_stack->setEnabled(!busy);
+	connect_button->setEnabled(true);
+	connect_button->setText(busy ? tr("Cancel request")
+	                             : (active_sources.isEmpty() ? tr("Connect") : tr("Refresh")));
+	button_box->button(QDialogButtonBox::Ok)->setEnabled(!busy && !active_sources.isEmpty());
+}
+
+void GdalOgcDialog::clearSources()
+{
+	active_sources.clear();
+	active_connection = {};
+	source_tree->clear();
+	source_tree->setEnabled(false);
+	button_box->button(QDialogButtonBox::Ok)->setEnabled(false);
+	connect_button->setText(tr("Connect"));
+	if (!busy)
+		status_label->setText(tr("Not connected"));
+}
+
+void GdalOgcDialog::loadSavedConnections()
+{
+	QSettings settings;
+	const int count = settings.beginReadArray(connections_array);
+	for (int index = 0; index < count; ++index)
+	{
+		settings.setArrayIndex(index);
+		auto connection = readConnection(settings);
+		if (!connection.name.isEmpty() && connection.isValid())
+			saved_connections.push_back(std::move(connection));
+	}
+	settings.endArray();
+	std::sort(saved_connections.begin(), saved_connections.end(),
+	          [](const GdalOgcConnection& a, const GdalOgcConnection& b) {
+		return a.name.localeAwareCompare(b.name) < 0;
+	});
+	for (int index = 0; index < saved_connections.size(); ++index)
+		saved_connection_box->addItem(saved_connections.at(index).name, index);
+}
+
+void GdalOgcDialog::savedConnectionChanged(int)
+{
+	const int index = saved_connection_box->currentData().toInt();
+	if (index < 0 || index >= saved_connections.size())
+	{
+		form_credential_id.clear();
+		return;
+	}
+	populateSavedConnection(saved_connections.at(index));
+}
+
+void GdalOgcDialog::populateSavedConnection(const GdalOgcConnection& connection)
+{
+	populating_form = true;
+	name_edit->setText(connection.name);
+	url_edit->setText(connection.service_url);
+	service_type_box->setCurrentIndex(service_type_box->findData(static_cast<int>(connection.service_type)));
+	authentication_box->setCurrentIndex(authentication_box->findData(static_cast<int>(connection.authentication)));
+	username_edit->setText(connection.username);
+	password_edit->clear();
+	bearer_edit->clear();
+	api_key_name_edit->setText(connection.api_key_name);
+	api_key_value_edit->clear();
+	api_key_placement_box->setCurrentIndex(
+	        api_key_placement_box->findData(static_cast<int>(connection.api_key_placement)));
+	form_credential_id = connection.credential_id;
+	remember_credentials_box->setChecked(!form_credential_id.isEmpty());
+	populating_form = false;
+	clearSources();
+}
+
+void GdalOgcDialog::saveConnectionDefinition(const GdalOgcConnection& connection)
+{
+	if (connection.name.isEmpty())
+		return;
+
+	int replace_index = -1;
+	for (int index = 0; index < saved_connections.size(); ++index)
+	{
+		if (saved_connections.at(index).name.compare(connection.name, Qt::CaseInsensitive) == 0)
+		{
+			replace_index = index;
+			break;
+		}
+	}
+	if (replace_index >= 0)
+		saved_connections[replace_index] = connection;
+	else
+		saved_connections.push_back(connection);
+
+	QSettings settings;
+	settings.remove(connections_array);
+	settings.beginWriteArray(connections_array);
+	for (int index = 0; index < saved_connections.size(); ++index)
+	{
+		settings.setArrayIndex(index);
+		writeConnection(settings, saved_connections.at(index));
+	}
+	settings.endArray();
+	settings.sync();
+}
+
+void GdalOgcDialog::resetCredentialReference()
+{
+	if (!populating_form)
+		form_credential_id.clear();
+}
+
+}  // namespace OpenOrienteering

--- a/src/gdal/gdal_ogc_dialog.h
+++ b/src/gdal/gdal_ogc_dialog.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 The OpenOrienteering developers
+ *
+ * This file is part of OpenOrienteering.
+ * OpenOrienteering is free software under GNU GPL version 3 or later.
+ */
+
+#ifndef OPENORIENTEERING_GDAL_OGC_DIALOG_H
+#define OPENORIENTEERING_GDAL_OGC_DIALOG_H
+
+#include <QDialog>
+
+#include "gdal/gdal_ogc_catalog.h"
+#include "gdal/gdal_online_raster_template.h"
+
+class QCheckBox;
+class QComboBox;
+class QDialogButtonBox;
+class QLabel;
+class QLineEdit;
+class QPushButton;
+class QStackedWidget;
+class QTreeWidget;
+
+namespace OpenOrienteering {
+
+struct GdalOgcSelection
+{
+	GdalOgcConnection connection;
+	GdalOgcSource source;
+	GdalOnlinePreparedDataPtr prepared_data;
+};
+
+class GdalOgcDialog final : public QDialog
+{
+	Q_OBJECT
+
+public:
+	explicit GdalOgcDialog(const QString& preferred_crs = QString{},
+	                       QWidget* parent = nullptr);
+
+	GdalOgcSelection selection() const { return selected; }
+
+private slots:
+	void authenticationChanged(int index);
+	void testConnection();
+	void cancelRequest();
+	void acceptSelection();
+	void savedConnectionChanged(int index);
+
+private:
+	GdalOgcConnection connectionFromForm() const;
+	void setBusy(bool busy);
+	void finishDiscovery(quint64 serial,
+	                     const GdalOgcConnection& connection,
+	                     GdalOgcCatalogResult result);
+	void finishPreparation(quint64 serial,
+	                       GdalOnlinePreparedDataPtr prepared_data,
+	                       const QString& error);
+	void clearSources();
+	void loadSavedConnections();
+	void populateSavedConnection(const GdalOgcConnection& connection);
+	void saveConnectionDefinition(const GdalOgcConnection& connection);
+	void resetCredentialReference();
+
+	QComboBox* saved_connection_box = nullptr;
+	QLineEdit* name_edit = nullptr;
+	QComboBox* service_type_box = nullptr;
+	QLineEdit* url_edit = nullptr;
+	QComboBox* authentication_box = nullptr;
+	QStackedWidget* authentication_stack = nullptr;
+	QLineEdit* username_edit = nullptr;
+	QLineEdit* password_edit = nullptr;
+	QLineEdit* bearer_edit = nullptr;
+	QLineEdit* api_key_name_edit = nullptr;
+	QLineEdit* api_key_value_edit = nullptr;
+	QComboBox* api_key_placement_box = nullptr;
+	QCheckBox* remember_credentials_box = nullptr;
+	QPushButton* connect_button = nullptr;
+	QLabel* status_label = nullptr;
+	QTreeWidget* source_tree = nullptr;
+	QDialogButtonBox* button_box = nullptr;
+
+	GdalOgcConnection active_connection;
+	QVector<GdalOgcSource> active_sources;
+	QVector<GdalOgcConnection> saved_connections;
+	GdalOgcSelection selected;
+	QString preferred_crs;
+	QString form_credential_id;
+	quint64 request_serial = 0;
+	bool populating_form = false;
+	bool preparing_layer = false;
+	bool busy = false;
+};
+
+}  // namespace OpenOrienteering
+
+#endif

--- a/src/gdal/gdal_online_raster_template.cpp
+++ b/src/gdal/gdal_online_raster_template.cpp
@@ -1,0 +1,1234 @@
+/*
+ * Copyright 2026 The OpenOrienteering developers
+ *
+ * This file is part of OpenOrienteering.
+ * OpenOrienteering is free software under GNU GPL version 3 or later.
+ */
+
+#include "gdal/gdal_online_raster_template.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <memory>
+#include <limits>
+#include <utility>
+
+#include <Qt>
+#include <QtGlobal>
+#include <QByteArray>
+#include <QCoreApplication>
+#include <QDateTime>
+#include <QDebug>
+#include <QImage>
+#include <QMetaObject>
+#include <QMutex>
+#include <QMutexLocker>
+#include <QPainter>
+#include <QPaintDevice>
+#include <QPointer>
+#include <QRunnable>
+#include <QThreadPool>
+#include <QTimer>
+#include <QVector>
+#include <QXmlStreamAttributes>
+#include <QXmlStreamReader>
+#include <QXmlStreamWriter>
+
+#include <cpl_conv.h>
+#include <cpl_error.h>
+#include <gdal.h>
+#include <gdalwarper.h>
+#include <ogr_srs_api.h>
+
+#include "core/georeferencing.h"
+#include "core/map.h"
+#include "core/map_coord.h"
+#include "gdal/gdal_image_reader.h"
+#include "gdal/gdal_manager.h"
+#include "util/transformation.h"
+
+namespace OpenOrienteering {
+
+struct GdalOnlineDatasetHolder
+{
+	GdalOnlineDatasetHolder(GDALDatasetH source_dataset, GDALDatasetH render_dataset)
+	: source_dataset(source_dataset)
+	, render_dataset(render_dataset ? render_dataset : source_dataset)
+	{}
+
+	~GdalOnlineDatasetHolder()
+	{
+		if (render_dataset && render_dataset != source_dataset)
+			GDALClose(render_dataset);
+		if (source_dataset)
+			GDALClose(source_dataset);
+	}
+
+	GDALDatasetH source_dataset = nullptr;
+	GDALDatasetH render_dataset = nullptr;
+	QMutex mutex;
+};
+
+struct GdalOnlinePreparedData
+{
+	std::shared_ptr<GdalOnlineDatasetHolder> dataset;
+	int raster_width = 0;
+	int raster_height = 0;
+	QString source_crs_spec;
+	QString render_crs_spec;
+	QPointF projected_center;
+	bool has_projected_center = false;
+	QTransform pixel_to_world;
+	QTransform world_to_pixel;
+};
+
+namespace {
+
+struct RasterLayout
+{
+	QVector<int> bands;
+	QImage::Format format = QImage::Format_Invalid;
+	int pixel_space = 1;
+	int band_space = 1;
+	int band_offset = 0;
+	bool premultiply_argb = false;
+	bool expand_gray_alpha = false;
+	QVector<QRgb> color_table;
+};
+
+struct RenderResult
+{
+	quint64 serial = 0;
+	QRect source_window;
+	QSize requested_size;
+	QImage image;
+	QString error;
+};
+
+QString trOnline(const char* source_text)
+{
+	return QCoreApplication::translate("OpenOrienteering::GdalOnlineRasterTemplate", source_text);
+}
+
+QString toWkt(OGRSpatialReferenceH srs)
+{
+	QString wkt;
+	char* wkt_cstring = nullptr;
+	if (srs && OSRExportToWkt(srs, &wkt_cstring) == OGRERR_NONE)
+		wkt = QString::fromUtf8(wkt_cstring);
+	CPLFree(wkt_cstring);
+	return wkt;
+}
+
+QString datasetWkt(GDALDatasetH dataset)
+{
+	if (!dataset)
+		return {};
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 0, 0) && !defined(ACCEPT_USE_OF_DEPRECATED_PROJ_API_H)
+	return toWkt(GDALGetSpatialRef(dataset));
+#else
+	const char* projection = GDALGetProjectionRef(dataset);
+	return projection ? QString::fromUtf8(projection) : QString{};
+#endif
+}
+
+class SpatialReference final
+{
+public:
+	SpatialReference()
+	: handle(OSRNewSpatialReference(nullptr))
+	{}
+
+	~SpatialReference()
+	{
+		if (handle)
+			OSRDestroySpatialReference(handle);
+	}
+
+	SpatialReference(const SpatialReference&) = delete;
+	SpatialReference& operator=(const SpatialReference&) = delete;
+
+	OGRSpatialReferenceH get() const { return handle; }
+
+private:
+	OGRSpatialReferenceH handle = nullptr;
+};
+
+bool setFromUserInput(OGRSpatialReferenceH srs, const QString& specification)
+{
+	if (!srs || specification.trimmed().isEmpty())
+		return false;
+	const QByteArray utf8 = specification.toUtf8();
+	if (OSRSetFromUserInput(srs, utf8.constData()) != OGRERR_NONE)
+		return false;
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 0, 0)
+	OSRSetAxisMappingStrategy(srs, OAMS_TRADITIONAL_GIS_ORDER);
+#endif
+	return true;
+}
+
+int findBand(GDALDatasetH dataset, GDALColorInterp interpretation)
+{
+	const int count = GDALGetRasterCount(dataset);
+	for (int i = count; i > 0; --i)
+	{
+		GDALRasterBandH band = GDALGetRasterBand(dataset, i);
+		if (GDALGetRasterDataType(band) == GDT_Byte
+	    && GDALGetRasterColorInterpretation(band) == interpretation)
+			return i;
+	}
+	return 0;
+}
+
+RasterLayout rasterLayout(GDALDatasetH dataset)
+{
+	RasterLayout layout;
+	if (!dataset)
+		return layout;
+
+	const int count = GDALGetRasterCount(dataset);
+	const int alpha_band = findBand(dataset, GCI_AlphaBand);
+
+	if (count == 1)
+	{
+		GDALRasterBandH band = GDALGetRasterBand(dataset, 1);
+		if (GDALGetRasterDataType(band) != GDT_Byte)
+			return layout;
+
+		const auto interpretation = GDALGetRasterColorInterpretation(band);
+		if (interpretation == GCI_GrayIndex)
+		{
+			layout.format = QImage::Format_Grayscale8;
+			layout.pixel_space = 1;
+			layout.bands.push_back(1);
+		}
+		else if (interpretation == GCI_PaletteIndex)
+		{
+			layout.format = QImage::Format_Indexed8;
+			layout.pixel_space = 1;
+			layout.bands.push_back(1);
+			GDALColorTableH table = GDALGetRasterColorTable(band);
+			if (table)
+			{
+				const int colors = GDALGetColorEntryCount(table);
+				layout.color_table.reserve(colors);
+				for (int i = 0; i < colors; ++i)
+				{
+					GDALColorEntry entry {};
+					GDALGetColorEntryAsRGB(table, i, &entry);
+					layout.color_table.push_back(qRgba(entry.c1, entry.c2, entry.c3, entry.c4));
+				}
+			}
+		}
+		return layout;
+	}
+
+	if (count == 2 && alpha_band)
+	{
+		const int gray_band = 3 - alpha_band;
+		GDALRasterBandH band = GDALGetRasterBand(dataset, gray_band);
+		if (GDALGetRasterDataType(band) == GDT_Byte
+	    && GDALGetRasterColorInterpretation(band) == GCI_GrayIndex)
+		{
+			layout.format = QImage::Format_ARGB32_Premultiplied;
+			layout.pixel_space = 4;
+			layout.band_offset = 2;
+			layout.bands.push_back(gray_band);
+			layout.bands.push_back(alpha_band);
+			layout.expand_gray_alpha = true;
+		}
+		return layout;
+	}
+
+	if (count >= 3)
+	{
+		for (auto interpretation : { GCI_BlueBand, GCI_GreenBand, GCI_RedBand })
+		{
+			const int band = findBand(dataset, interpretation);
+			if (band)
+				layout.bands.push_back(band);
+		}
+
+		if (layout.bands.size() == 3)
+		{
+			layout.pixel_space = 4;
+			if (alpha_band)
+			{
+				layout.bands.push_back(alpha_band);
+				layout.format = QImage::Format_ARGB32_Premultiplied;
+				layout.premultiply_argb = true;
+			}
+			else
+			{
+				layout.format = QImage::Format_RGB32;
+			}
+		}
+	}
+	return layout;
+}
+
+void premultiplyArgb(QImage& image)
+{
+	if (image.depth() != 32)
+		return;
+	auto* first = reinterpret_cast<QRgb*>(image.bits());
+	auto* last = first + image.width() * image.height();
+	std::transform(first, last, first, [](QRgb pixel) { return qPremultiply(pixel); });
+}
+
+void expandGrayAlpha(QImage& image)
+{
+	if (image.depth() != 32)
+		return;
+	auto* first = reinterpret_cast<QRgb*>(image.bits());
+	auto* last = first + image.width() * image.height();
+	std::transform(first, last, first, [](QRgb pixel) {
+		const int gray = qRed(pixel);
+		return qPremultiply(qRgba(gray, gray, gray, qAlpha(pixel)));
+	});
+}
+
+bool readRasterWindow(GDALDatasetH dataset,
+                      const QRect& source_window,
+                      const QSize& output_size,
+                      QImage& image,
+                      QString& error)
+{
+	if (!dataset || source_window.isEmpty() || output_size.isEmpty())
+	{
+		error = trOnline("Invalid online raster render request.");
+		return false;
+	}
+
+	const RasterLayout layout = rasterLayout(dataset);
+	if (layout.format == QImage::Format_Invalid || layout.bands.isEmpty())
+	{
+		error = trOnline("Unsupported GDAL raster band layout.");
+		return false;
+	}
+
+	image = QImage(output_size, layout.format);
+	if (image.isNull())
+	{
+		error = trOnline("Not enough memory for the online raster image.");
+		return false;
+	}
+
+	image.fill(layout.bands.size() == 4 ? Qt::transparent : Qt::white);
+	if (!layout.color_table.isEmpty())
+		image.setColorTable(layout.color_table);
+
+	GDALRasterIOExtraArg extra;
+	INIT_RASTERIO_EXTRA_ARG(extra);
+	extra.eResampleAlg = GRIORA_Bilinear;
+
+	CPLErrorReset();
+	const CPLErr io_result = GDALDatasetRasterIOEx(
+	        dataset,
+	        GF_Read,
+	        source_window.x(), source_window.y(),
+	        source_window.width(), source_window.height(),
+	        image.bits() + layout.band_offset,
+	        output_size.width(), output_size.height(),
+	        GDT_Byte,
+	        layout.bands.size(), layout.bands.data(),
+	        layout.pixel_space, image.bytesPerLine(), layout.band_space,
+	        &extra);
+
+	if (io_result >= CE_Warning)
+	{
+		error = QString::fromUtf8(CPLGetLastErrorMsg());
+		if (error.isEmpty())
+			error = trOnline("GDAL RasterIO failed.");
+		image = {};
+		return false;
+	}
+
+	if (layout.expand_gray_alpha)
+		expandGrayAlpha(image);
+	else if (layout.premultiply_argb)
+		premultiplyArgb(image);
+	return true;
+}
+
+RenderResult renderWindow(const std::shared_ptr<GdalOnlineDatasetHolder>& holder,
+                          const GdalOgcConnection& connection,
+                          quint64 serial,
+                          const QRect& source_window,
+                          const QSize& requested_size)
+{
+	RenderResult result;
+	result.serial = serial;
+	result.source_window = source_window;
+	result.requested_size = requested_size;
+
+	if (!holder || !holder->render_dataset)
+	{
+		result.error = trOnline("Online raster dataset is not loaded.");
+		return result;
+	}
+	if (connection.needsSecret() && connection.effectiveSecret().isEmpty())
+	{
+		result.error = trOnline("Authentication credentials are unavailable.");
+		return result;
+	}
+
+	GdalOgcHttpGuard http_guard(connection);
+	QMutexLocker locker(&holder->mutex);
+	readRasterWindow(holder->render_dataset, source_window, requested_size, result.image, result.error);
+	return result;
+}
+
+class RenderTask final : public QRunnable
+{
+public:
+	RenderTask(QPointer<GdalOnlineRasterTemplate> target,
+	           std::shared_ptr<GdalOnlineDatasetHolder> dataset,
+	           GdalOgcConnection connection,
+	           quint64 serial,
+	           QRect source_window,
+	           QSize requested_size)
+	: target(std::move(target))
+	, dataset(std::move(dataset))
+	, connection(std::move(connection))
+	, serial(serial)
+	, source_window(std::move(source_window))
+	, requested_size(std::move(requested_size))
+	{}
+
+	void run() override
+	{
+		RenderResult result = renderWindow(dataset, connection, serial, source_window, requested_size);
+		if (!target)
+			return;
+
+		QPointer<GdalOnlineRasterTemplate> guard = target;
+		QMetaObject::invokeMethod(target.data(),
+		                          [guard, result = std::move(result)]() mutable {
+			if (guard)
+			{
+				guard->acceptRender(result.serial,
+				                    result.source_window,
+				                    result.requested_size,
+				                    std::move(result.image),
+				                    result.error);
+			}
+		},
+		                          Qt::QueuedConnection);
+	}
+
+private:
+	QPointer<GdalOnlineRasterTemplate> target;
+	std::shared_ptr<GdalOnlineDatasetHolder> dataset;
+	GdalOgcConnection connection;
+	quint64 serial;
+	QRect source_window;
+	QSize requested_size;
+};
+
+class PrepareTask final : public QRunnable
+{
+public:
+	PrepareTask(QPointer<GdalOnlineRasterTemplate> target,
+	            GdalOgcConnection connection,
+	            QString dataset_name,
+	            QString map_crs_spec,
+	            quint64 serial)
+	: target(std::move(target))
+	, connection(std::move(connection))
+	, dataset_name(std::move(dataset_name))
+	, map_crs_spec(std::move(map_crs_spec))
+	, serial(serial)
+	{}
+
+	void run() override
+	{
+		QString error;
+		auto prepared = GdalOnlineRasterTemplate::prepareDataset(
+		        connection, dataset_name, map_crs_spec, error);
+		if (!target)
+			return;
+
+		QPointer<GdalOnlineRasterTemplate> guard = target;
+		QMetaObject::invokeMethod(target.data(),
+		                          [guard, serial = serial,
+		                           prepared = std::move(prepared),
+		                           error = std::move(error)]() mutable {
+			if (guard)
+				guard->acceptPreparation(serial, std::move(prepared), error);
+		},
+		                          Qt::QueuedConnection);
+	}
+
+private:
+	QPointer<GdalOnlineRasterTemplate> target;
+	GdalOgcConnection connection;
+	QString dataset_name;
+	QString map_crs_spec;
+	quint64 serial;
+};
+
+QSize clampRenderSize(QSize size, bool on_screen)
+{
+	if (size.width() < 1 || size.height() < 1)
+		return {};
+
+	const double max_dimension = on_screen ? 4096.0 : 6144.0;
+	const double max_pixels = on_screen ? 12000000.0 : 24000000.0;
+	double factor = 1.0;
+	factor = std::min(factor, max_dimension / size.width());
+	factor = std::min(factor, max_dimension / size.height());
+	factor = std::min(factor, std::sqrt(max_pixels / (double(size.width()) * double(size.height()))));
+	if (factor < 1.0)
+	{
+		size.setWidth(std::max(1, int(std::floor(size.width() * factor))));
+		size.setHeight(std::max(1, int(std::floor(size.height() * factor))));
+	}
+	return size;
+}
+
+}  // namespace
+
+GdalOnlineRasterTemplate::GdalOnlineRasterTemplate(const QString& dataset_name, Map* map)
+: Template(dataset_name, map)
+, dataset_name(dataset_name)
+{
+	initializeTimers();
+	connect(&map->getGeoreferencing(), &Georeferencing::projectionChanged,
+	        this, &GdalOnlineRasterTemplate::mapGeoreferencingChanged);
+}
+
+GdalOnlineRasterTemplate::GdalOnlineRasterTemplate(const GdalOgcConnection& connection,
+                                                   const QString& dataset_name,
+                                                   const QString& display_name,
+                                                   GdalOnlinePreparedDataPtr prepared_data,
+                                                   Map* map)
+: Template(dataset_name, map)
+, connection(connection)
+, dataset_name(dataset_name)
+, display_name(display_name)
+, prepared_data(std::move(prepared_data))
+{
+	initializeTimers();
+	if (!display_name.isEmpty())
+		template_file = display_name;
+	connect(&map->getGeoreferencing(), &Georeferencing::projectionChanged,
+	        this, &GdalOnlineRasterTemplate::mapGeoreferencingChanged);
+}
+
+GdalOnlineRasterTemplate::GdalOnlineRasterTemplate(const GdalOnlineRasterTemplate& proto)
+: Template(proto)
+, connection(proto.connection)
+, dataset_name(proto.dataset_name)
+, display_name(proto.display_name)
+, prepared_data(proto.prepared_data)
+, dataset(proto.dataset)
+, raster_width(proto.raster_width)
+, raster_height(proto.raster_height)
+, crs_spec(proto.crs_spec)
+, pixel_to_world(proto.pixel_to_world)
+, world_to_pixel(proto.world_to_pixel)
+, map_extent(proto.map_extent)
+{
+	initializeTimers();
+	connect(&map->getGeoreferencing(), &Georeferencing::projectionChanged,
+	        this, &GdalOnlineRasterTemplate::mapGeoreferencingChanged);
+}
+
+GdalOnlineRasterTemplate::~GdalOnlineRasterTemplate() = default;
+
+GdalOnlineRasterTemplate* GdalOnlineRasterTemplate::duplicate() const
+{
+	return new GdalOnlineRasterTemplate(*this);
+}
+
+const char* GdalOnlineRasterTemplate::getTemplateType() const
+{
+	return "GdalOnlineRasterTemplate";
+}
+
+Template::LookupResult GdalOnlineRasterTemplate::tryToFindTemplateFile(const QString&)
+{
+	return FoundByAbsPath;
+}
+
+void GdalOnlineRasterTemplate::initializeTimers()
+{
+	render_timer = new QTimer(this);
+	render_timer->setSingleShot(true);
+	connect(render_timer, &QTimer::timeout,
+	        this, &GdalOnlineRasterTemplate::startPendingRender);
+}
+
+GdalOnlinePreparedDataPtr GdalOnlineRasterTemplate::prepareDataset(
+	const GdalOgcConnection& connection,
+	const QString& dataset_name,
+	const QString& map_crs_spec,
+	QString& error)
+{
+	error.clear();
+	if (connection.needsSecret() && connection.effectiveSecret().isEmpty())
+	{
+		error = tr("Authentication credentials for this WMS/WMTS service are unavailable.");
+		return {};
+	}
+
+	GdalManager();
+	GdalOgcHttpGuard http_guard(connection);
+	CPLErrorReset();
+	const QByteArray request_name = connection.datasetNameForRequest(dataset_name).toUtf8();
+	GDALDatasetH source_dataset = GDALOpenEx(request_name.constData(),
+	                                        GDAL_OF_RASTER | GDAL_OF_READONLY | GDAL_OF_VERBOSE_ERROR,
+	                                        nullptr, nullptr, nullptr);
+	if (!source_dataset || GDALGetRasterCount(source_dataset) <= 0)
+	{
+		if (source_dataset)
+			GDALClose(source_dataset);
+		error = tr("GDAL could not open the selected WMS/WMTS raster: %1")
+		        .arg(connection.sanitizeForDisplay(QString::fromUtf8(CPLGetLastErrorMsg())));
+		return {};
+	}
+
+	const QString source_wkt = datasetWkt(source_dataset);
+	if (source_wkt.isEmpty())
+	{
+		GDALClose(source_dataset);
+		error = tr("The selected WMS/WMTS raster does not declare a coordinate reference system.");
+		return {};
+	}
+
+	QString source_spec = source_wkt;
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 0, 0) && !defined(ACCEPT_USE_OF_DEPRECATED_PROJ_API_H)
+	if (OGRSpatialReferenceH source_srs = GDALGetSpatialRef(source_dataset))
+	{
+		const char* authority = OSRGetAuthorityName(source_srs, nullptr);
+		const char* code = OSRGetAuthorityCode(source_srs, nullptr);
+		if (authority && code)
+			source_spec = QString::fromLatin1(authority) + QLatin1Char(':') + QString::fromLatin1(code);
+	}
+#else
+	const QString proj_spec = GdalImageReader::toProjSpec(source_wkt.toUtf8());
+	if (!proj_spec.isEmpty())
+		source_spec = proj_spec;
+#endif
+
+	std::array<double, 6> source_gt {};
+	QPointF projected_center;
+	const bool has_projected_center = GDALGetGeoTransform(source_dataset, source_gt.data()) == CE_None;
+	if (has_projected_center)
+	{
+		const double cx = 0.5 * GDALGetRasterXSize(source_dataset);
+		const double cy = 0.5 * GDALGetRasterYSize(source_dataset);
+		projected_center = QPointF(source_gt[0] + cx * source_gt[1] + cy * source_gt[2],
+		                           source_gt[3] + cx * source_gt[4] + cy * source_gt[5]);
+	}
+
+	SpatialReference source_compare;
+	if (!setFromUserInput(source_compare.get(), source_wkt))
+	{
+		GDALClose(source_dataset);
+		error = tr("The WMS/WMTS coordinate reference system cannot be interpreted.");
+		return {};
+	}
+
+	GDALDatasetH render_dataset = source_dataset;
+	QString render_crs = source_wkt;
+
+	SpatialReference destination_srs;
+	if (!map_crs_spec.trimmed().isEmpty()
+	    && !setFromUserInput(destination_srs.get(), map_crs_spec))
+	{
+		GDALClose(source_dataset);
+		error = tr("The map coordinate reference system cannot be used by GDAL.");
+		return {};
+	}
+
+	if (!map_crs_spec.trimmed().isEmpty()
+	    && !OSRIsSame(source_compare.get(), destination_srs.get()))
+	{
+		char* source_wkt_c = nullptr;
+		char* destination_wkt_c = nullptr;
+		if (OSRExportToWkt(source_compare.get(), &source_wkt_c) != OGRERR_NONE
+		    || OSRExportToWkt(destination_srs.get(), &destination_wkt_c) != OGRERR_NONE)
+		{
+			CPLFree(source_wkt_c);
+			CPLFree(destination_wkt_c);
+			GDALClose(source_dataset);
+			error = tr("Failed to prepare WMS/WMTS CRS reprojection.");
+			return {};
+		}
+
+		CPLErrorReset();
+		render_dataset = GDALAutoCreateWarpedVRT(source_dataset,
+		                                         source_wkt_c,
+		                                         destination_wkt_c,
+		                                         GRA_Bilinear,
+		                                         0.125,
+		                                         nullptr);
+		CPLFree(source_wkt_c);
+		CPLFree(destination_wkt_c);
+		if (!render_dataset)
+		{
+			GDALClose(source_dataset);
+			error = tr("GDAL could not reproject the WMS/WMTS layer to the map CRS: %1")
+			        .arg(connection.sanitizeForDisplay(QString::fromUtf8(CPLGetLastErrorMsg())));
+			return {};
+		}
+		render_crs = toWkt(destination_srs.get());
+	}
+
+	auto new_dataset = std::make_shared<GdalOnlineDatasetHolder>(source_dataset, render_dataset);
+	if (rasterLayout(render_dataset).format == QImage::Format_Invalid)
+	{
+		error = tr("The WMS/WMTS layer uses a raster pixel format that Mapper cannot display.");
+		return {};
+	}
+
+	const int new_width = GDALGetRasterXSize(render_dataset);
+	const int new_height = GDALGetRasterYSize(render_dataset);
+	if (new_width <= 0 || new_height <= 0)
+	{
+		error = tr("The selected WMS/WMTS raster has invalid dimensions.");
+		return {};
+	}
+
+	std::array<double, 6> geo_transform {};
+	if (GDALGetGeoTransform(render_dataset, geo_transform.data()) != CE_None)
+	{
+		error = tr("The selected WMS/WMTS raster has no usable georeferencing.");
+		return {};
+	}
+
+	if (render_crs.isEmpty())
+		render_crs = datasetWkt(render_dataset);
+	if (render_crs.isEmpty())
+	{
+		error = tr("The selected WMS/WMTS raster has no usable CRS after reprojection.");
+		return {};
+	}
+
+	auto prepared = std::make_shared<GdalOnlinePreparedData>();
+	prepared->dataset = std::move(new_dataset);
+	prepared->raster_width = new_width;
+	prepared->raster_height = new_height;
+	prepared->source_crs_spec = source_spec;
+	prepared->render_crs_spec = render_crs;
+	prepared->projected_center = projected_center;
+	prepared->has_projected_center = has_projected_center;
+	prepared->pixel_to_world = QTransform(geo_transform[1], geo_transform[4],
+	                                      geo_transform[2], geo_transform[5],
+	                                      geo_transform[0], geo_transform[3]);
+	bool inverse_ok = false;
+	prepared->world_to_pixel = prepared->pixel_to_world.inverted(&inverse_ok);
+	if (!inverse_ok)
+	{
+		error = tr("The WMS/WMTS raster geotransform is not invertible.");
+		return {};
+	}
+
+	// Verify real imagery in the worker thread, not in Mapper's GUI thread.
+	const int probe_w = std::max(1, std::min(128, new_width));
+	const int probe_h = std::max(1, std::min(128, new_height));
+	const QRect probe_window(std::max(0, new_width / 2 - probe_w / 2),
+	                         std::max(0, new_height / 2 - probe_h / 2),
+	                         probe_w, probe_h);
+	QImage probe_image;
+	QString probe_error;
+	if (!readRasterWindow(prepared->dataset->render_dataset, probe_window,
+	                      QSize(std::min(128, probe_w), std::min(128, probe_h)),
+	                      probe_image, probe_error))
+	{
+		error = tr("The service opened, but GDAL could not read map imagery: %1")
+		        .arg(connection.sanitizeForDisplay(probe_error));
+		return {};
+	}
+	return prepared;
+}
+
+bool GdalOnlineRasterTemplate::applyPreparedData(GdalOnlinePreparedDataPtr prepared)
+{
+	if (!prepared || !prepared->dataset)
+	{
+		setErrorString(tr("The prepared WMS/WMTS dataset is unavailable."));
+		return false;
+	}
+
+	auto map_georef = map->getGeoreferencing();
+	if (map_georef.getState() != Georeferencing::Geospatial)
+	{
+		if (!map_georef.setProjectedCRS(QString{}, prepared->source_crs_spec))
+		{
+			setErrorString(tr("Mapper could not adopt the WMS/WMTS coordinate reference system."));
+			return false;
+		}
+		if (prepared->has_projected_center)
+			map_georef.setProjectedRefPoint(prepared->projected_center, false, false);
+		map->setGeoreferencing(map_georef);
+	}
+
+	dataset = prepared->dataset;
+	raster_width = prepared->raster_width;
+	raster_height = prepared->raster_height;
+	crs_spec = prepared->render_crs_spec;
+	pixel_to_world = prepared->pixel_to_world;
+	world_to_pixel = prepared->world_to_pixel;
+	prepared_data.reset();
+
+	cached_image = {};
+	cached_source_window = {};
+	cached_requested_size = {};
+	pending_source_window = {};
+	pending_output_size = {};
+	request_in_flight = false;
+	retry_after_ms = 0;
+	++request_serial;
+
+	if (!updateTemplateTransform())
+	{
+		clearDatasetState();
+		return false;
+	}
+
+	is_georeferenced = true;
+	return true;
+}
+
+void GdalOnlineRasterTemplate::scheduleDatasetPreparation()
+{
+	if (load_in_flight)
+		return;
+
+	QString map_crs_spec;
+	if (map->getGeoreferencing().getState() == Georeferencing::Geospatial)
+		map_crs_spec = map->getGeoreferencing().getProjectedCRSSpec();
+
+	load_in_flight = true;
+	const quint64 serial = ++preparation_serial;
+	auto* task = new PrepareTask(QPointer<GdalOnlineRasterTemplate>(this),
+	                             connection, dataset_name, map_crs_spec, serial);
+	task->setAutoDelete(true);
+	QThreadPool::globalInstance()->start(task);
+}
+
+void GdalOnlineRasterTemplate::acceptPreparation(
+	quint64 serial,
+	GdalOnlinePreparedDataPtr prepared,
+	const QString& error)
+{
+	if (serial != preparation_serial)
+		return;
+
+	load_in_flight = false;
+	if (!prepared || !applyPreparedData(std::move(prepared)))
+	{
+		if (!error.isEmpty())
+			setErrorString(error);
+		template_state = Invalid;
+		emit templateStateChanged();
+	}
+
+	setTemplateAreaDirty();
+	if (map)
+		map->updateAllMapWidgets();
+}
+
+void GdalOnlineRasterTemplate::clearDatasetState()
+{
+	++preparation_serial;
+	load_in_flight = false;
+	++request_serial;
+	request_in_flight = false;
+	if (render_timer)
+		render_timer->stop();
+	retry_after_ms = 0;
+	cached_image = {};
+	cached_source_window = {};
+	cached_requested_size = {};
+	pending_source_window = {};
+	pending_output_size = {};
+	dataset.reset();
+	raster_width = 0;
+	raster_height = 0;
+	crs_spec.clear();
+	pixel_to_world = {};
+	world_to_pixel = {};
+	map_extent = {};
+}
+
+bool GdalOnlineRasterTemplate::loadTemplateFileImpl()
+{
+	if (prepared_data)
+		return applyPreparedData(std::move(prepared_data));
+
+	// Project reopen and offline handling are asynchronous. The template is
+	// installed immediately and becomes Loaded or Invalid when preparation
+	// finishes, without blocking Mapper's event loop.
+	is_georeferenced = true;
+	scheduleDatasetPreparation();
+	return true;
+}
+
+bool GdalOnlineRasterTemplate::postLoadSetup(QWidget*, bool& out_center_in_view)
+{
+	if (!dataset || !is_georeferenced)
+		return false;
+	out_center_in_view = false;
+	return true;
+}
+
+void GdalOnlineRasterTemplate::unloadTemplateFileImpl()
+{
+	clearDatasetState();
+}
+
+bool GdalOnlineRasterTemplate::updateTemplateTransform()
+{
+	if (raster_width <= 0 || raster_height <= 0 || crs_spec.isEmpty())
+		return false;
+	if (map->getGeoreferencing().getState() != Georeferencing::Geospatial)
+		return false;
+
+	transform = TemplateTransform{};
+	updateTransformationMatrices();
+
+	map_extent = templateRect(QRect(0, 0, raster_width, raster_height));
+	if (!map_extent.isValid() || map_extent.isEmpty())
+	{
+		setErrorString(tr("Failed to calculate the WMS/WMTS extent in Mapper coordinates."));
+		return false;
+	}
+	return true;
+}
+
+QRectF GdalOnlineRasterTemplate::getTemplateExtent() const
+{
+	return map_extent;
+}
+
+QRect GdalOnlineRasterTemplate::sourceWindow(const QRectF& template_rect) const
+{
+	if (template_rect.isEmpty() || raster_width <= 0 || raster_height <= 0)
+		return {};
+
+	const auto& georef = map->getGeoreferencing();
+	const QPointF map_corners[] = {
+		template_rect.topLeft(),
+		template_rect.topRight(),
+		template_rect.bottomLeft(),
+		template_rect.bottomRight()
+	};
+
+	double min_x = std::numeric_limits<double>::infinity();
+	double min_y = std::numeric_limits<double>::infinity();
+	double max_x = -std::numeric_limits<double>::infinity();
+	double max_y = -std::numeric_limits<double>::infinity();
+
+	for (const QPointF& corner : map_corners)
+	{
+		const QPointF projected = georef.toProjectedCoords(MapCoordF(corner));
+		const QPointF pixel = world_to_pixel.map(projected);
+		min_x = std::min(min_x, pixel.x());
+		min_y = std::min(min_y, pixel.y());
+		max_x = std::max(max_x, pixel.x());
+		max_y = std::max(max_y, pixel.y());
+	}
+
+	const int left = int(std::floor(min_x));
+	const int top = int(std::floor(min_y));
+	const int right = int(std::ceil(max_x));
+	const int bottom = int(std::ceil(max_y));
+	return QRect(left, top, std::max(0, right - left), std::max(0, bottom - top))
+	        .intersected(QRect(0, 0, raster_width, raster_height));
+}
+
+QRectF GdalOnlineRasterTemplate::templateRect(const QRect& source_window) const
+{
+	if (source_window.isEmpty())
+		return {};
+
+	const QPointF pixel_corners[] = {
+		QPointF(source_window.x(), source_window.y()),
+		QPointF(source_window.x() + source_window.width(), source_window.y()),
+		QPointF(source_window.x(), source_window.y() + source_window.height()),
+		QPointF(source_window.x() + source_window.width(),
+		        source_window.y() + source_window.height())
+	};
+
+	const auto& georef = map->getGeoreferencing();
+	double min_x = std::numeric_limits<double>::infinity();
+	double min_y = std::numeric_limits<double>::infinity();
+	double max_x = -std::numeric_limits<double>::infinity();
+	double max_y = -std::numeric_limits<double>::infinity();
+
+	for (const QPointF& pixel : pixel_corners)
+	{
+		const QPointF projected = pixel_to_world.map(pixel);
+		const MapCoordF map_coord = georef.toMapCoordF(projected);
+		min_x = std::min(min_x, map_coord.x());
+		min_y = std::min(min_y, map_coord.y());
+		max_x = std::max(max_x, map_coord.x());
+		max_y = std::max(max_y, map_coord.y());
+	}
+
+	return QRectF(QPointF(min_x, min_y), QPointF(max_x, max_y)).normalized();
+}
+
+QRect GdalOnlineRasterTemplate::expandedWindow(const QRect& source_window) const
+{
+	const int margin_x = std::max(32, source_window.width() / 6);
+	const int margin_y = std::max(32, source_window.height() / 6);
+	return source_window.adjusted(-margin_x, -margin_y, margin_x, margin_y)
+	        .intersected(QRect(0, 0, raster_width, raster_height));
+}
+
+QSize GdalOnlineRasterTemplate::requiredOutputSize(QPainter* painter,
+                                                   const QRectF& target_rect,
+                                                   bool on_screen) const
+{
+	if (!painter || target_rect.isEmpty())
+		return {};
+
+	const QRectF logical_device_rect = painter->combinedTransform().mapRect(target_rect);
+	double pixel_ratio = 1.0;
+	if (on_screen && painter->device())
+		pixel_ratio = std::max(1.0, double(painter->device()->devicePixelRatioF()));
+
+	QSize result(std::max(1, int(std::ceil(std::abs(logical_device_rect.width()) * pixel_ratio))),
+	             std::max(1, int(std::ceil(std::abs(logical_device_rect.height()) * pixel_ratio))));
+	return clampRenderSize(result, on_screen);
+}
+
+bool GdalOnlineRasterTemplate::cachedImageIsAdequate(const QRect& source_window,
+                                                     const QSize& required_size) const
+{
+	if (cached_image.isNull()
+	    || cached_source_window.isEmpty()
+	    || !cached_source_window.contains(source_window)
+	    || required_size.isEmpty())
+	{
+		return false;
+	}
+
+	const double cached_x = double(cached_image.width()) / cached_source_window.width();
+	const double cached_y = double(cached_image.height()) / cached_source_window.height();
+	const double required_x = double(required_size.width()) / source_window.width();
+	const double required_y = double(required_size.height()) / source_window.height();
+	return cached_x >= required_x * 0.90 && cached_y >= required_y * 0.90;
+}
+
+void GdalOnlineRasterTemplate::drawCachedImage(QPainter* painter,
+                                               const QRect& source_window) const
+{
+	if (!painter || cached_image.isNull() || cached_source_window.isEmpty())
+		return;
+
+	const QRect intersection = source_window.intersected(cached_source_window);
+	if (intersection.isEmpty())
+		return;
+
+	const double sx = double(cached_image.width()) / cached_source_window.width();
+	const double sy = double(cached_image.height()) / cached_source_window.height();
+	const QRectF image_rect((intersection.left() - cached_source_window.left()) * sx,
+	                        (intersection.top() - cached_source_window.top()) * sy,
+	                        intersection.width() * sx,
+	                        intersection.height() * sy);
+	painter->drawImage(templateRect(intersection), cached_image, image_rect);
+}
+
+void GdalOnlineRasterTemplate::drawTemplate(QPainter* painter,
+                                            const QRectF& clip_rect,
+                                            double,
+                                            bool on_screen,
+                                            qreal opacity) const
+{
+	if (!painter || !dataset || raster_width <= 0 || raster_height <= 0)
+		return;
+
+	const QRectF visible_template = clip_rect.intersected(getTemplateExtent());
+	const QRect visible_source = sourceWindow(visible_template);
+	if (visible_source.isEmpty())
+		return;
+
+	painter->save();
+	painter->setOpacity(opacity);
+	painter->setRenderHint(QPainter::SmoothPixmapTransform, true);
+
+	const QRectF visible_target = templateRect(visible_source);
+	if (!on_screen)
+	{
+		const QSize output_size = requiredOutputSize(painter, visible_target, false);
+		drawCachedImage(painter, visible_source);
+		if (!cachedImageIsAdequate(visible_source, output_size))
+			scheduleRender(expandedWindow(visible_source), output_size);
+		painter->restore();
+		return;
+	}
+
+	const QSize visible_required = requiredOutputSize(painter, visible_target, true);
+	drawCachedImage(painter, visible_source);
+
+	if (!cachedImageIsAdequate(visible_source, visible_required)
+	    && QDateTime::currentMSecsSinceEpoch() >= retry_after_ms)
+	{
+		const QRect request_window = expandedWindow(visible_source);
+		const QSize request_size = requiredOutputSize(painter, templateRect(request_window), true);
+		scheduleRender(request_window, request_size);
+	}
+
+	painter->restore();
+}
+
+void GdalOnlineRasterTemplate::scheduleRender(const QRect& source_window,
+                                              const QSize& output_size) const
+{
+	if (!dataset || source_window.isEmpty() || output_size.isEmpty())
+		return;
+
+	pending_source_window = source_window;
+	pending_output_size = output_size;
+	if (request_in_flight)
+		return;
+
+	const qint64 now = QDateTime::currentMSecsSinceEpoch();
+	const int debounce_ms = cached_image.isNull() ? 0 : 180;
+	const int retry_delay = retry_after_ms > now
+	                        ? int(std::min<qint64>(30000, retry_after_ms - now))
+	                        : 0;
+	render_timer->start(std::max(debounce_ms, retry_delay));
+}
+
+void GdalOnlineRasterTemplate::startPendingRender()
+{
+	if (request_in_flight || !dataset
+	    || pending_source_window.isEmpty() || pending_output_size.isEmpty())
+	{
+		return;
+	}
+
+	const QRect source_window = pending_source_window;
+	const QSize output_size = pending_output_size;
+	pending_source_window = {};
+	pending_output_size = {};
+	request_in_flight = true;
+	const quint64 serial = ++request_serial;
+	QPointer<GdalOnlineRasterTemplate> target(this);
+	auto* task = new RenderTask(target, dataset, connection, serial, source_window, output_size);
+	task->setAutoDelete(true);
+	QThreadPool::globalInstance()->start(task);
+}
+
+void GdalOnlineRasterTemplate::acceptRender(quint64 serial,
+                                            const QRect& source_window,
+                                            const QSize& requested_size,
+                                            QImage image,
+                                            const QString& error)
+{
+	if (serial != request_serial)
+		return;
+
+	request_in_flight = false;
+	if (!image.isNull())
+	{
+		cached_image = std::move(image);
+		cached_source_window = source_window;
+		cached_requested_size = requested_size;
+		retry_after_ms = 0;
+	}
+	else
+	{
+		retry_after_ms = QDateTime::currentMSecsSinceEpoch() + 3000;
+		if (!error.isEmpty())
+			qWarning("WMS/WMTS render failed: %s",
+			         qUtf8Printable(connection.sanitizeForDisplay(error)));
+	}
+	if (!pending_source_window.isEmpty() && render_timer)
+		render_timer->start(0);
+
+	if (map)
+		map->updateAllMapWidgets();
+}
+
+void GdalOnlineRasterTemplate::mapGeoreferencingChanged()
+{
+	if (template_state != Loaded)
+		return;
+
+	setTemplateAreaDirty();
+	clearDatasetState();
+	is_georeferenced = true;
+
+	if (map->getGeoreferencing().getState() == Georeferencing::Geospatial)
+		scheduleDatasetPreparation();
+
+	setTemplateAreaDirty();
+	map->updateAllMapWidgets();
+}
+
+void GdalOnlineRasterTemplate::saveTypeSpecificTemplateConfiguration(QXmlStreamWriter& xml) const
+{
+	xml.writeStartElement(QStringLiteral("online-raster"));
+	xml.writeAttribute(QStringLiteral("dataset"), connection.sanitizeDatasetName(dataset_name));
+	xml.writeAttribute(QStringLiteral("display-name"), display_name);
+	xml.writeAttribute(QStringLiteral("connection-name"), connection.name);
+	xml.writeAttribute(QStringLiteral("service-url"), connection.serviceUrlForStorage());
+	xml.writeAttribute(QStringLiteral("service-type"), QString::number(static_cast<int>(connection.service_type)));
+	xml.writeAttribute(QStringLiteral("authentication"), QString::number(static_cast<int>(connection.authentication)));
+	xml.writeAttribute(QStringLiteral("username"), connection.username);
+	xml.writeAttribute(QStringLiteral("api-key-name"), connection.api_key_name);
+	xml.writeAttribute(QStringLiteral("api-key-placement"), QString::number(static_cast<int>(connection.api_key_placement)));
+	xml.writeAttribute(QStringLiteral("credential-id"), connection.credential_id);
+	if (map_extent.isValid() && !map_extent.isEmpty())
+	{
+		xml.writeAttribute(QStringLiteral("extent-x"), QString::number(map_extent.x(), 'g', 17));
+		xml.writeAttribute(QStringLiteral("extent-y"), QString::number(map_extent.y(), 'g', 17));
+		xml.writeAttribute(QStringLiteral("extent-width"), QString::number(map_extent.width(), 'g', 17));
+		xml.writeAttribute(QStringLiteral("extent-height"), QString::number(map_extent.height(), 'g', 17));
+	}
+	xml.writeEndElement();
+}
+
+bool GdalOnlineRasterTemplate::loadTypeSpecificTemplateConfiguration(QXmlStreamReader& xml)
+{
+	if (xml.name() != QLatin1String("online-raster"))
+	{
+		xml.skipCurrentElement();
+		return true;
+	}
+
+	const QXmlStreamAttributes attributes = xml.attributes();
+	dataset_name = attributes.value(QLatin1String("dataset")).toString();
+	display_name = attributes.value(QLatin1String("display-name")).toString();
+	connection.name = attributes.value(QLatin1String("connection-name")).toString();
+	connection.service_url = attributes.value(QLatin1String("service-url")).toString();
+	connection.service_type = static_cast<GdalOgcConnection::ServiceType>(
+	        attributes.value(QLatin1String("service-type")).toInt());
+	connection.authentication = static_cast<GdalOgcConnection::Authentication>(
+	        attributes.value(QLatin1String("authentication")).toInt());
+	connection.username = attributes.value(QLatin1String("username")).toString();
+	connection.api_key_name = attributes.value(QLatin1String("api-key-name")).toString();
+	connection.api_key_placement = static_cast<GdalOgcConnection::ApiKeyPlacement>(
+	        attributes.value(QLatin1String("api-key-placement")).toInt());
+	connection.credential_id = attributes.value(QLatin1String("credential-id")).toString();
+	if (attributes.hasAttribute(QLatin1String("extent-width")))
+	{
+		map_extent = QRectF(attributes.value(QLatin1String("extent-x")).toDouble(),
+		                    attributes.value(QLatin1String("extent-y")).toDouble(),
+		                    attributes.value(QLatin1String("extent-width")).toDouble(),
+		                    attributes.value(QLatin1String("extent-height")).toDouble());
+	}
+	connection.secret.clear();
+	xml.skipCurrentElement();
+	return true;
+}
+
+bool GdalOnlineRasterTemplate::finishTypeSpecificTemplateConfiguration()
+{
+	if (!dataset_name.isEmpty())
+		template_path = dataset_name;
+	if (!display_name.isEmpty())
+		template_file = display_name;
+	return true;
+}
+
+}  // namespace OpenOrienteering

--- a/src/gdal/gdal_online_raster_template.h
+++ b/src/gdal/gdal_online_raster_template.h
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2026 The OpenOrienteering developers
+ *
+ * This file is part of OpenOrienteering.
+ * OpenOrienteering is free software under GNU GPL version 3 or later.
+ */
+
+#ifndef OPENORIENTEERING_GDAL_ONLINE_RASTER_TEMPLATE_H
+#define OPENORIENTEERING_GDAL_ONLINE_RASTER_TEMPLATE_H
+
+#include <memory>
+
+#include <QtGlobal>
+#include <QImage>
+#include <QRect>
+#include <QRectF>
+#include <QSize>
+#include <QString>
+#include <QTransform>
+
+#include "gdal/gdal_ogc_connection.h"
+#include "templates/template.h"
+
+class QPainter;
+class QTimer;
+class QXmlStreamReader;
+class QXmlStreamWriter;
+
+namespace OpenOrienteering {
+
+struct GdalOnlineDatasetHolder;
+struct GdalOnlinePreparedData;
+using GdalOnlinePreparedDataPtr = std::shared_ptr<GdalOnlinePreparedData>;
+
+class GdalOnlineRasterTemplate final : public Template
+{
+	Q_OBJECT
+
+public:
+	GdalOnlineRasterTemplate(const QString& dataset_name, Map* map);
+	GdalOnlineRasterTemplate(const GdalOgcConnection& connection,
+	                         const QString& dataset_name,
+	                         const QString& display_name,
+	                         GdalOnlinePreparedDataPtr prepared_data,
+	                         Map* map);
+
+	/** Opens and validates an online dataset without touching GUI state.
+	 *
+	 * This function is intentionally safe to call from a worker thread. An
+	 * empty map CRS means that the service CRS will be adopted when the
+	 * prepared data is installed in a template.
+	 */
+	static GdalOnlinePreparedDataPtr prepareDataset(
+	        const GdalOgcConnection& connection,
+	        const QString& dataset_name,
+	        const QString& map_crs_spec,
+	        QString& error);
+
+protected:
+	GdalOnlineRasterTemplate(const GdalOnlineRasterTemplate& proto);
+
+public:
+	~GdalOnlineRasterTemplate() override;
+
+	GdalOnlineRasterTemplate* duplicate() const override;
+	const char* getTemplateType() const override;
+	bool isRasterGraphics() const override { return true; }
+	bool canBeDrawnOnto() const override { return false; }
+
+	bool fileExists() const override { return true; }
+	LookupResult tryToFindTemplateFile(const QString& map_path) override;
+
+	bool loadTemplateFileImpl() override;
+	bool postLoadSetup(QWidget* dialog_parent, bool& out_center_in_view) override;
+	void unloadTemplateFileImpl() override;
+
+	void drawTemplate(QPainter* painter,
+	                  const QRectF& clip_rect,
+	                  double scale,
+	                  bool on_screen,
+	                  qreal opacity) const override;
+	QRectF getTemplateExtent() const override;
+
+	void saveTypeSpecificTemplateConfiguration(QXmlStreamWriter& xml) const override;
+	bool loadTypeSpecificTemplateConfiguration(QXmlStreamReader& xml) override;
+	bool finishTypeSpecificTemplateConfiguration() override;
+
+public slots:
+	void acceptPreparation(quint64 serial,
+	                       GdalOnlinePreparedDataPtr prepared_data,
+	                       const QString& error);
+	void acceptRender(quint64 serial,
+	                  const QRect& source_window,
+	                  const QSize& requested_size,
+	                  QImage image,
+	                  const QString& error);
+
+private slots:
+	void mapGeoreferencingChanged();
+
+private:
+	void initializeTimers();
+	bool applyPreparedData(GdalOnlinePreparedDataPtr prepared_data);
+	void scheduleDatasetPreparation();
+	void clearDatasetState();
+	bool updateTemplateTransform();
+	QRect sourceWindow(const QRectF& template_rect) const;
+	QRectF templateRect(const QRect& source_window) const;
+	QRect expandedWindow(const QRect& source_window) const;
+	QSize requiredOutputSize(QPainter* painter,
+	                         const QRectF& template_rect,
+	                         bool on_screen) const;
+	bool cachedImageIsAdequate(const QRect& source_window,
+	                           const QSize& required_size) const;
+	void drawCachedImage(QPainter* painter, const QRect& source_window) const;
+	void scheduleRender(const QRect& source_window, const QSize& output_size) const;
+	void startPendingRender();
+
+	GdalOgcConnection connection;
+	QString dataset_name;
+	QString display_name;
+
+	GdalOnlinePreparedDataPtr prepared_data;
+	std::shared_ptr<GdalOnlineDatasetHolder> dataset;
+	int raster_width = 0;
+	int raster_height = 0;
+	QString crs_spec;
+	QTransform pixel_to_world;
+	QTransform world_to_pixel;
+	QRectF map_extent;
+
+	mutable QImage cached_image;
+	mutable QRect cached_source_window;
+	mutable QSize cached_requested_size;
+	mutable QRect pending_source_window;
+	mutable QSize pending_output_size;
+	QTimer* render_timer = nullptr;
+	bool load_in_flight = false;
+	quint64 preparation_serial = 0;
+	mutable bool request_in_flight = false;
+	mutable quint64 request_serial = 0;
+	mutable qint64 retry_after_ms = 0;
+};
+
+}  // namespace OpenOrienteering
+
+#endif

--- a/src/gui/map/map_editor.cpp
+++ b/src/gui/map/map_editor.cpp
@@ -170,6 +170,8 @@
 #include "util/backports.h" // IWYU pragma: keep
 
 #ifdef MAPPER_USE_GDAL
+#include "gdal/gdal_ogc_dialog.h"
+#include "gdal/gdal_online_raster_template.h"
 #include "gdal/ogr_template.h"
 #endif
 
@@ -1041,6 +1043,47 @@ void MapEditorController::createActions()
 	template_window_act = newCheckAction("templatewindow", tr("Template setup window"), this, SLOT(showTemplateWindow(bool)), "templates.png", tr("Show/Hide the template window"), "templates_menu.html");
 	//QAction* template_config_window_act = newCheckAction("templateconfigwindow", tr("Template configurations window"), this, SLOT(showTemplateConfigurationsWindow(bool)), "window-new", tr("Show/Hide the template configurations window"));
 	//QAction* template_visibilities_window_act = newCheckAction("templatevisibilitieswindow", tr("Template visibilities window"), this, SLOT(showTemplateVisbilitiesWindow(bool)), "window-new", tr("Show/Hide the template visibilities window"));
+#ifdef MAPPER_USE_GDAL
+	auto* ogc_template_act = newAction("openogctemplate", tr("Add WMS/WMTS background map..."), nullptr, nullptr, nullptr, QString{}, "templates_menu.html");
+	connect(ogc_template_act, &QAction::triggered, this, [this](bool) {
+		QString preferred_crs;
+		if (map->getGeoreferencing().getState() == Georeferencing::Geospatial)
+			preferred_crs = map->getGeoreferencing().getProjectedCRSSpec();
+		GdalOgcDialog dialog(preferred_crs, window);
+		if (dialog.exec() != QDialog::Accepted)
+			return;
+
+		const auto selection = dialog.selection();
+		const bool fit_service_extent = map->getNumObjects() == 0
+		  && map->getNumTemplates() == 0;
+		auto online_template = std::make_unique<GdalOnlineRasterTemplate>(
+		        selection.connection,
+		        selection.source.dataset_name,
+		        selection.source.description,
+		        selection.prepared_data,
+		        map);
+		if (!online_template->setupAndLoad(window, main_view))
+		{
+			QMessageBox::warning(window,
+			 tr("WMS/WMTS background map"),
+			 tr("Could not add the online background map: %1")
+			 .arg(online_template->errorString()));
+			return;
+		}
+
+		auto* online_template_ptr = online_template.get();
+		map->addTemplate(-1, std::move(online_template));
+		hideAllTemplates(false);
+		showTemplateWindow(true);
+		if (fit_service_extent)
+		{
+			const QRectF service_extent = online_template_ptr->calculateTemplateBoundingBox();
+			if (service_extent.isValid() && !service_extent.isEmpty())
+				map_widget->adjustViewToRect(service_extent, MapWidget::ContinuousZoom);
+		}
+		map->updateAllMapWidgets();
+	});
+#endif
 	open_template_act = newAction("opentemplate", tr("Open template..."), this, SLOT(openTemplateClicked()), nullptr, QString{}, "templates_menu.html");
 	reopen_template_act = newAction("reopentemplate", tr("Reopen template..."), this, SLOT(reopenTemplateClicked()), nullptr, QString{}, "templates_menu.html");
 	
@@ -1296,6 +1339,9 @@ void MapEditorController::createMenuAndToolbars()
 	/*template_menu->addAction(template_config_window_act);
 	template_menu->addAction(template_visibilities_window_act);*/
 	template_menu->addSeparator();
+#ifdef MAPPER_USE_GDAL
+	template_menu->addAction(findAction("openogctemplate"));
+#endif
 	template_menu->addAction(open_template_act);
 	template_menu->addAction(reopen_template_act);
 	

--- a/src/templates/template.cpp
+++ b/src/templates/template.cpp
@@ -56,6 +56,7 @@
 #include "core/objects/object.h"
 #include "fileformats/file_format.h"
 #include "gdal/gdal_template.h"
+#include "gdal/gdal_online_raster_template.h"
 #include "gdal/ogr_template.h"
 #include "gui/file_dialog.h"
 #include "templates/template_image.h"
@@ -1049,6 +1050,8 @@ std::unique_ptr<Template> Template::templateForType(const QStringRef& type, cons
 	else if (type_cstring == "TemplateTrack" && !track_with_gdal)
 		t = std::make_unique<TemplateTrack>(path, map);
 #ifdef MAPPER_USE_GDAL
+	else if (type_cstring == "GdalOnlineRasterTemplate")
+		t = std::make_unique<GdalOnlineRasterTemplate>(path, map);
 	else if (type_cstring == "GdalTemplate")
 		t = std::make_unique<GdalTemplate>(path, map);
 	else if (type_cstring == "OgrTemplate" || type_cstring == "TemplateTrack")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -174,6 +174,17 @@ if (Mapper_USE_GDAL)
 	target_compile_definitions(georeferencing_t PRIVATE MAPPER_TEST_GDAL)
 	target_include_directories(georeferencing_t SYSTEM PRIVATE ${GDAL_INCLUDE_DIRS})
 	target_link_libraries(georeferencing_t PRIVATE ${GDAL_LIBRARIES})
+	add_system_test(gdal_ogc_t)
+	target_link_libraries(gdal_ogc_t PRIVATE mapper-gdal)
+	if(WIN32 AND Mapper_CA_BUNDLE_FILE)
+		add_custom_command(TARGET gdal_ogc_t POST_BUILD
+		  COMMAND "${CMAKE_COMMAND}" -E make_directory
+		          "$<TARGET_FILE_DIR:gdal_ogc_t>/certs"
+		  COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+		          "${Mapper_CA_BUNDLE_FILE}"
+		          "$<TARGET_FILE_DIR:gdal_ogc_t>/certs/ca-bundle.crt"
+		  VERBATIM)
+	endif()
 endif()
 add_unit_test(grid_t ../src/util/util)
 add_unit_test(key_value_container_t ../src/util/key_value_container)

--- a/test/gdal_ogc_t.cpp
+++ b/test/gdal_ogc_t.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2026 The OpenOrienteering developers
+ *
+ * This file is part of OpenOrienteering.
+ * OpenOrienteering is free software under GNU GPL version 3 or later.
+ */
+
+#include "gdal_ogc_t.h"
+
+#include <QtTest>
+#include <QFileInfo>
+#include <QUrl>
+#include <QUrlQuery>
+#include <QXmlStreamReader>
+#include <QXmlStreamWriter>
+
+#include "core/map.h"
+#include "core/map_view.h"
+#include "gdal/gdal_ogc_catalog.h"
+#include "gdal/gdal_ogc_connection.h"
+#include "gdal/gdal_online_raster_template.h"
+
+#include <cpl_conv.h>
+
+namespace OpenOrienteering {
+
+void GdalOgcTest::validatesHttpUrls()
+{
+	GdalOgcConnection connection;
+	connection.service_url = QStringLiteral("https://example.test/wms?");
+	QVERIFY(connection.isValid());
+
+	connection.service_url = QStringLiteral("file:///tmp/service.xml");
+	QVERIFY(!connection.isValid());
+
+	connection.service_url = QStringLiteral("not a URL");
+	QVERIFY(!connection.isValid());
+}
+
+void GdalOgcTest::protectsQueryApiKeys()
+{
+	GdalOgcConnection connection;
+	connection.service_url = QStringLiteral(
+	        "https://example.test/wms?token=old-secret&foo=1");
+	connection.authentication = GdalOgcConnection::Authentication::ApiKey;
+	connection.api_key_placement = GdalOgcConnection::ApiKeyPlacement::Query;
+	connection.api_key_name = QStringLiteral("token");
+	connection.secret = QStringLiteral("new secret/+token");
+
+	const QString stored_url = connection.serviceUrlForStorage();
+	QVERIFY(!stored_url.contains(QStringLiteral("old-secret")));
+	QVERIFY(!stored_url.contains(QStringLiteral("new secret/+token")));
+	QVERIFY(stored_url.contains(QStringLiteral("foo=1")));
+
+	const QString request_url = connection.serviceUrlForRequest();
+	QCOMPARE(QUrlQuery(QUrl(request_url)).queryItemValue(
+	                 QStringLiteral("token"), QUrl::FullyDecoded),
+	         QStringLiteral("new secret/+token"));
+
+	const QString stored_dataset = QStringLiteral(
+	        "WMTS:https://example.test/wmts?foo=1&token=new%20secret%2F%2Btoken,layer=test,tilematrixset=web");
+	const QString sanitized = connection.sanitizeDatasetName(stored_dataset);
+	QVERIFY(!sanitized.contains(QStringLiteral("new%20secret%2F%2Btoken")));
+	QVERIFY(sanitized.contains(QStringLiteral(",layer=test,tilematrixset=web")));
+	QCOMPARE(connection.sanitizeForDisplay(QStringLiteral("failed: new%20secret%2F%2Btoken")),
+	         QStringLiteral("failed: ***"));
+}
+
+void GdalOgcTest::describesWmsSources()
+{
+	GdalOgcConnection connection;
+	const auto source = GdalOgcCatalog::describeSource(
+	        connection,
+	        QStringLiteral("WMS:https://example.test/wms?LAYERS=roads&CRS=EPSG%3A3059&FORMAT=image%2Fpng&STYLES=default"),
+	        QStringLiteral("Road network"));
+
+	QCOMPARE(source.title, QStringLiteral("Road network"));
+	QCOMPARE(source.layer_name, QStringLiteral("roads"));
+	QCOMPARE(source.crs, QStringLiteral("EPSG:3059"));
+	QCOMPARE(source.format, QStringLiteral("image/png"));
+	QCOMPARE(source.style, QStringLiteral("default"));
+}
+
+void GdalOgcTest::describesWmtsSources()
+{
+	GdalOgcConnection connection;
+	const auto source = GdalOgcCatalog::describeSource(
+	        connection,
+	        QStringLiteral("WMTS:https://example.test/WMTSCapabilities.xml,layer=BlueMarble,"
+	                       "tilematrixset=GoogleMapsCompatible_Level9,style=default"),
+	        QStringLiteral("Blue Marble EPSG:3857"));
+
+	QCOMPARE(source.layer_name, QStringLiteral("BlueMarble"));
+	QCOMPARE(source.crs, QStringLiteral("EPSG:3857"));
+	QCOMPARE(source.style, QStringLiteral("default"));
+	QCOMPARE(source.tile_matrix_set, QStringLiteral("GoogleMapsCompatible_Level9"));
+	QCOMPARE(source.format, QStringLiteral("image/png"));
+}
+
+void GdalOgcTest::usesPackagedCaBundleOnWindows()
+{
+#ifdef Q_OS_WIN
+	const QString ca_bundle = gdalOgcBundledCaBundlePath();
+	if (ca_bundle.isEmpty())
+		QSKIP("No packaged TLS CA bundle in this build-tree test runtime");
+	QVERIFY(QFileInfo(ca_bundle).isReadable());
+
+	GdalOgcConnection connection;
+	{
+		GdalOgcHttpGuard guard(connection);
+		QCOMPARE(QString::fromLocal8Bit(
+		                 CPLGetThreadLocalConfigOption("CURL_CA_BUNDLE", "")),
+		         ca_bundle);
+		QCOMPARE(QString::fromLocal8Bit(
+		                 CPLGetThreadLocalConfigOption("SSL_CERT_FILE", "")),
+		         ca_bundle);
+		QCOMPARE(QString::fromLatin1(
+		                 CPLGetThreadLocalConfigOption("GDAL_HTTP_USE_CAPI_STORE", "")),
+		         QStringLiteral("YES"));
+	}
+#else
+	QSKIP("The packaged CA-bundle lookup is specific to standalone Windows builds");
+#endif
+}
+
+void GdalOgcTest::supportsRegionalOverviewZoom()
+{
+	QVERIFY(MapView::zoom_out_limit <= 1.0 / 4096.0);
+	Map map;
+	MapView view(&map);
+	view.setZoom(1.0 / 2048.0);
+	QVERIFY(qFuzzyCompare(view.getZoom(), 1.0 / 2048.0));
+}
+
+void GdalOgcTest::preservesProjectConfigurationWithoutSecrets()
+{
+	Map map;
+	GdalOnlineRasterTemplate online_template(QStringLiteral("unused"), &map);
+	QXmlStreamReader reader(QStringLiteral(
+	        "<online-raster "
+	        "dataset=\"WMTS:https://example.test/capabilities.xml,layer=BlueMarble,"
+	        "tilematrixset=WebMercatorQuad,style=default\" "
+	        "display-name=\"Blue Marble\" connection-name=\"Example WMTS\" "
+	        "service-url=\"https://example.test/capabilities.xml\" "
+	        "service-type=\"2\" authentication=\"3\" username=\"\" "
+	        "api-key-name=\"token\" api-key-placement=\"1\" "
+	        "credential-id=\"opaque-credential-id\"/>"));
+	QVERIFY(reader.readNextStartElement());
+	QVERIFY(online_template.loadTypeSpecificTemplateConfiguration(reader));
+	QVERIFY(online_template.finishTypeSpecificTemplateConfiguration());
+
+	QString saved;
+	QXmlStreamWriter writer(&saved);
+	online_template.saveTypeSpecificTemplateConfiguration(writer);
+	QVERIFY(saved.contains(QStringLiteral("connection-name=\"Example WMTS\"")));
+	QVERIFY(saved.contains(QStringLiteral("layer=BlueMarble")));
+	QVERIFY(saved.contains(QStringLiteral("tilematrixset=WebMercatorQuad")));
+	QVERIFY(saved.contains(QStringLiteral("credential-id=\"opaque-credential-id\"")));
+	QVERIFY(!saved.contains(QStringLiteral("secret"), Qt::CaseInsensitive));
+	QVERIFY(!saved.contains(QStringLiteral("password"), Qt::CaseInsensitive));
+}
+
+}  // namespace OpenOrienteering
+
+#ifndef Q_OS_MACOS
+namespace {
+auto Q_DECL_UNUSED qpa_selected = qputenv("QT_QPA_PLATFORM", "offscreen");
+}
+#endif
+
+QTEST_MAIN(OpenOrienteering::GdalOgcTest)

--- a/test/gdal_ogc_t.h
+++ b/test/gdal_ogc_t.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 The OpenOrienteering developers
+ *
+ * This file is part of OpenOrienteering.
+ * OpenOrienteering is free software under GNU GPL version 3 or later.
+ */
+
+#ifndef OPENORIENTEERING_GDAL_OGC_T_H
+#define OPENORIENTEERING_GDAL_OGC_T_H
+
+#include <QObject>
+
+namespace OpenOrienteering {
+
+class GdalOgcTest final : public QObject
+{
+	Q_OBJECT
+
+private slots:
+	void validatesHttpUrls();
+	void protectsQueryApiKeys();
+	void describesWmsSources();
+	void describesWmtsSources();
+	void usesPackagedCaBundleOnWindows();
+	void supportsRegionalOverviewZoom();
+	void preservesProjectConfigurationWithoutSecrets();
+};
+
+}  // namespace OpenOrienteering
+
+#endif


### PR DESCRIPTION
Add saved OGC connections, service/layer discovery, asynchronous viewport-based raster rendering, reprojection, caching, credential handling, standalone Windows TLS support, and regression tests for generic WMS/WMTS services.